### PR TITLE
QLC+: Add null pixelKeys as empty heads

### DIFF
--- a/plugins/qlcplus/export.js
+++ b/plugins/qlcplus/export.js
@@ -218,15 +218,18 @@ function addHeads(xmlMode, mode) {
   );
 
   if (hasMatrixChannels) {
-    const pixelKeys = mode.fixture.matrix.getPixelKeysByOrder(`X`, `Y`, `Z`);
-    for (const pixelKey of pixelKeys) {
-      const channels = mode.channels.filter(channel => controlsPixelKey(channel, pixelKey));
-      const xmlHead = xmlMode.element(`Head`);
+    for (const zLevel of mode.fixture.matrix.pixelKeyStructure) {
+      for (const row of zLevel) {
+        for (const pixelKey of row) {
+          const channels = mode.channels.filter(channel => controlsPixelKey(channel, pixelKey));
+          const xmlHead = xmlMode.element(`Head`);
 
-      for (const ch of channels) {
-        xmlHead.element({
-          Channel: mode.getChannelIndex(ch.key)
-        });
+          for (const ch of channels) {
+            xmlHead.element({
+              Channel: mode.getChannelIndex(ch.key)
+            });
+          }
+        }
       }
     }
   }

--- a/plugins/qlcplus/export.js
+++ b/plugins/qlcplus/export.js
@@ -23,7 +23,7 @@ const {
 /* eslint-enable no-unused-vars */
 
 module.exports.name = `QLC+`;
-module.exports.version = `0.5.0`;
+module.exports.version = `0.6.0`;
 
 module.exports.export = function exportQLCplus(fixtures, options) {
   return fixtures.map(fixture => {


### PR DESCRIPTION
For example, the Robe Robin LEDWash 600 now has the correct pixel order (the arrangement is still wrong, but will be fixed with #417).

Unfortunately, QLC+ renders empty heads as white pixels. I think this is still a better compromise than leaving the pixels out, which leads to completely weird pixel arrangement. I already requested in the QLC+ forum to hide empty heads.