### PR TITLE
Fix schema $id

### DIFF
--- a/schemas/capability.json
+++ b/schemas/capability.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/channel.json",
+  "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/capability.json",
 
   "$comment": "This file is used by another schema file and should not be used directly as a JSON schema.",
 

--- a/schemas/fixture-redirect.json
+++ b/schemas/fixture-redirect.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture-redirect.json",
 
-  "version": "7.1.0",
+  "version": "7.1.1",
 
   "type": "object",
   "properties": {

--- a/schemas/fixture.json
+++ b/schemas/fixture.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
 
-  "version": "7.1.0",
+  "version": "7.1.1",
 
   "type": "object",
   "properties": {

--- a/schemas/manufacturers.json
+++ b/schemas/manufacturers.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/manufacturers.json",
 
-  "version": "7.1.0",
+  "version": "7.1.1",
 
   "type": "object",
   "propertyNames": {


### PR DESCRIPTION
The `$id` property in JSON Schemas was not used in our code yet, so we didn't notice this mistake yet.