### PR TITLE
Millumin supports schema version 7.3.0

### DIFF
--- a/fixtures/american-dj/xs-400.json
+++ b/fixtures/american-dj/xs-400.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Flo Edelmann"],
     "createDate": "2017-09-04",
-    "lastModifyDate": "2017-10-16"
+    "lastModifyDate": "2018-06-18"
   },
   "manualURL": "http://adjmedia.s3-website-eu-west-1.amazonaws.com/manuals/XS%20400.pdf",
   "helpWanted": "What is tiltMax?",

--- a/fixtures/elation/acl-360-roller.json
+++ b/fixtures/elation/acl-360-roller.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Felix Edelmann"],
     "createDate": "2018-06-14",
-    "lastModifyDate": "2018-06-14"
+    "lastModifyDate": "2018-06-18"
   },
   "manualURL": "https://cdb.s3.amazonaws.com/ItemRelatedFiles/9806/elation_ACL_360_ROLLER_user_manual_ver_1.pdf",
   "physical": {

--- a/fixtures/elation/platinum-hfx.json
+++ b/fixtures/elation/platinum-hfx.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Flo Edelmann"],
     "createDate": "2017-05-26",
-    "lastModifyDate": "2017-10-16"
+    "lastModifyDate": "2018-06-18"
   },
   "manualURL": "https://cdb.s3.amazonaws.com/ItemRelatedFiles/9814/elation_platinum_HFX_user_manual_012717.pdf",
   "physical": {

--- a/fixtures/elation/platinum-hfx.json
+++ b/fixtures/elation/platinum-hfx.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Flo Edelmann"],
     "createDate": "2017-05-26",
-    "lastModifyDate": "2018-06-18"
+    "lastModifyDate": "2017-10-16"
   },
   "manualURL": "https://cdb.s3.amazonaws.com/ItemRelatedFiles/9814/elation_platinum_HFX_user_manual_012717.pdf",
   "physical": {

--- a/fixtures/eliminator/stealth-beam.json
+++ b/fixtures/eliminator/stealth-beam.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["George Qualley IV"],
     "createDate": "2017-09-19",
-    "lastModifyDate": "2017-10-16",
+    "lastModifyDate": "2018-06-18",
     "importPlugin": {
       "plugin": "qlcplus",
       "date": "2017-09-19",

--- a/fixtures/futurelight/dmh-75-i-led-moving-head.json
+++ b/fixtures/futurelight/dmh-75-i-led-moving-head.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Flo Edelmann"],
     "createDate": "2017-12-12",
-    "lastModifyDate": "2017-12-12"
+    "lastModifyDate": "2018-06-18"
   },
   "manualURL": "http://media.steinigke.de/download_t/51841840-MANUAL-1.10-de-en_00087817.pdf",
   "physical": {

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -72,7 +72,7 @@
     },
     "american-dj/xs-400": {
       "name": "XS 400",
-      "lastModifyDate": "2017-10-16",
+      "lastModifyDate": "2018-06-18",
       "lastAction": "modified"
     },
     "ayra/tdc-triple-burst": {
@@ -237,7 +237,7 @@
     },
     "elation/platinum-hfx": {
       "name": "Platinum HFX",
-      "lastModifyDate": "2017-10-16",
+      "lastModifyDate": "2018-06-18",
       "lastAction": "modified"
     },
     "elation/platinum-seven": {
@@ -252,7 +252,7 @@
     },
     "eliminator/stealth-beam": {
       "name": "Stealth Beam",
-      "lastModifyDate": "2017-10-16",
+      "lastModifyDate": "2018-06-18",
       "lastAction": "modified"
     },
     "equinox/gigabar": {
@@ -312,8 +312,8 @@
     },
     "futurelight/dmh-75-i-led-moving-head": {
       "name": "DMH-75.i LED Moving Head",
-      "lastModifyDate": "2017-12-12",
-      "lastAction": "created"
+      "lastModifyDate": "2018-06-18",
+      "lastAction": "modified"
     },
     "futurelight/pro-slim-par-7-hcl": {
       "name": "PRO Slim PAR-7 HCL",
@@ -1432,6 +1432,10 @@
     }
   },
   "lastUpdated": [
+    "american-dj/xs-400",
+    "elation/platinum-hfx",
+    "eliminator/stealth-beam",
+    "futurelight/dmh-75-i-led-moving-head",
     "boomtonedj/xtrem-led",
     "elation/acl-360-roller",
     "glp/jdc1",
@@ -1498,7 +1502,6 @@
     "cameo/flat-pro-flood-ip65-tri",
     "futurelight/sc-250-scanner",
     "ayra/tdc-triple-burst",
-    "futurelight/dmh-75-i-led-moving-head",
     "generic/cmy-fader",
     "generic/rgba-fader",
     "martin/mac-aura",
@@ -1514,14 +1517,11 @@
     "stairville/mh-100",
     "5star-systems/spica-250m",
     "abstract/twister-4",
-    "american-dj/xs-400",
     "cameo/hydrabeam-100",
     "cameo/nanospot-120",
     "coemar/prospot-250-lx",
     "dts/xr1200-wash",
-    "elation/platinum-hfx",
     "elation/platinum-spot-15r-pro",
-    "eliminator/stealth-beam",
     "eurolite/led-sls-6-uv-floor",
     "eurolite/led-svf-1",
     "eurolite/led-tmh-7",

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -232,12 +232,12 @@
     },
     "elation/acl-360-roller": {
       "name": "ACL 360 Roller",
-      "lastModifyDate": "2018-06-14",
-      "lastAction": "created"
+      "lastModifyDate": "2018-06-18",
+      "lastAction": "modified"
     },
     "elation/platinum-hfx": {
       "name": "Platinum HFX",
-      "lastModifyDate": "2018-06-18",
+      "lastModifyDate": "2017-10-16",
       "lastAction": "modified"
     },
     "elation/platinum-seven": {
@@ -1433,11 +1433,10 @@
   },
   "lastUpdated": [
     "american-dj/xs-400",
-    "elation/platinum-hfx",
+    "elation/acl-360-roller",
     "eliminator/stealth-beam",
     "futurelight/dmh-75-i-led-moving-head",
     "boomtonedj/xtrem-led",
-    "elation/acl-360-roller",
     "glp/jdc1",
     "magicfx/stage-flame",
     "showven/sparkular",
@@ -1521,6 +1520,7 @@
     "cameo/nanospot-120",
     "coemar/prospot-250-lx",
     "dts/xr1200-wash",
+    "elation/platinum-hfx",
     "elation/platinum-spot-15r-pro",
     "eurolite/led-sls-6-uv-floor",
     "eurolite/led-svf-1",

--- a/plugins/millumin/export.js
+++ b/plugins/millumin/export.js
@@ -1,10 +1,10 @@
 const fixtureJsonStringify = require(`../../lib/fixture-json-stringify.js`);
 
 module.exports.name = `Millumin`;
-module.exports.version = `0.1.0`;
+module.exports.version = `0.2.0`;
 
 // needed for export test
-module.exports.supportedOflVersion = `7.2.0`;
+module.exports.supportedOflVersion = `7.3.0`;
 
 module.exports.export = function exportMillumin(fixtures, options) {
   // one JSON file for each fixture
@@ -16,9 +16,6 @@ module.exports.export = function exportMillumin(fixtures, options) {
     jsonData.manufacturerKey = fixture.manufacturer.key;
     jsonData.oflURL = `https://open-fixture-library.org/${fixture.manufacturer.key}/${fixture.key}`;
 
-    downgradePhysical(jsonData.physical);
-    jsonData.modes.forEach(mode => downgradePhysical(mode.physical));
-
     return {
       name: `${fixture.manufacturer.key}/${fixture.key}.json`,
       content: fixtureJsonStringify(jsonData),
@@ -26,18 +23,3 @@ module.exports.export = function exportMillumin(fixtures, options) {
     };
   });
 };
-
-/**
- * Downgrades the given physical JSON object by replacing infinite pan/tilt maximum with 9999 degrees.
- * @param {!Physical} physical The physical data to downgrade.
- */
-function downgradePhysical(physical) {
-  if (physical && physical.focus) {
-    if (physical.focus.panMax === `infinite`) {
-      physical.focus.panMax = 9999;
-    }
-    if (physical.focus.tiltMax === `infinite`) {
-      physical.focus.tiltMax = 9999;
-    }
-  }
-}


### PR DESCRIPTION
They don't use the physical data yet and will support `"infinite"` as a value for `panMax`/`tiltMax`, so we can disable downgrading.

CC @anome @ameanomes @ameisso