### PR TITLE
Add no-nuxt make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ dereferenced-schema-files := $(schema-files:schemas/%=schemas/dereferenced/%)
 
 ### PHONY rules, see https://stackoverflow.com/a/2145605/451391
 
-.PHONY: all register plugin-data test-fixtures schemas nuxt-build clean
+.PHONY: all no-nuxt register plugin-data test-fixtures schemas nuxt-build clean
 
 all: register plugin-data test-fixtures schemas nuxt-build
+
+no-nuxt: register plugin-data test-fixtures schemas
 
 register: fixtures/register.json
 


### PR DESCRIPTION
`make no-nuxt` is identical to `make` except that it's missing the nuxt-build target.

Actually, this could also be achieved by `make -W nuxt-build`, but that command is missing autocomplete and therefore is not as convenient as the `no-nuxt` target.