### PR TITLE
Add color-hex format in schemas

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -36,7 +36,8 @@
   },
   "colorString": {
     "type": "string",
-    "pattern": "^#[0-9a-f]{6}$"
+    "pattern": "^#[0-9a-f]{6}$",
+    "format": "color-hex"
   },
   "dmxValue": {
     "type": "integer",

--- a/tests/fixture-valid.js
+++ b/tests/fixture-valid.js
@@ -14,6 +14,7 @@ const {
 } = require(`../lib/model.js`);
 
 const ajv = new Ajv();
+ajv.addFormat(`color-hex`, ``); // do not crash when `format: color-hex` is used; actual validation is done with an additional pattern, the format is only added for VSCode's color preview
 const schemaValidate = ajv.compile(fixtureSchema);
 const redirectSchemaValidate = ajv.compile(fixtureRedirectSchema);
 


### PR DESCRIPTION
Add `color-hex` format for schema's `colorString` to enable color previews in VS Code.