### PR TITLE
Bump schema version to 7.3.2

### DIFF
--- a/schemas/fixture.json
+++ b/schemas/fixture.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
 
-  "version": "7.3.0",
+  "version": "7.3.2",
 
   "type": "object",
   "properties": {

--- a/schemas/manufacturers.json
+++ b/schemas/manufacturers.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/manufacturers.json",
 
-  "version": "7.3.0",
+  "version": "7.3.2",
 
   "type": "object",
   "propertyNames": {


### PR DESCRIPTION
As I forgot to update the schema version to 7.3.1 in #535, but still published a new release. Thus, we jump directly to 7.3.2. Sorry!