### PR TITLE
Call export tests with file object instead of file content

### DIFF
--- a/cli/run-export-test.js
+++ b/cli/run-export-test.js
@@ -58,14 +58,14 @@ const files = plugin.export(fixtures, {});
 for (const testKey of plugins.data[args.plugin].exportTests) {
   const test = require(path.join(__dirname, `../plugins`, args.plugin, `exportTests/${testKey}.js`));
   const filePromises = files.map(file =>
-    test(file.content)
+    test(file)
       .then(() => colors.green(`[PASS] `) + file.name)
-      .catch(err => {
-        const lines = [colors.red(`[FAIL] `) + file.name];
-        const errors = Array.isArray(err) ? err : [err];
-        for (const error of errors) {
-          lines.push(`- ${error}`);
-        }
+      .catch(errors => {
+        let lines = [colors.red(`[FAIL] `) + file.name];
+        lines = lines.concat(
+          errors.map(error => `- ${error}`)
+        );
+
         return lines.join(`\n`);
       })
   );

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -25,17 +25,19 @@ If exporting is supported, create a `plugins/<plugin-key>/export.js` module that
 
 ```js
 {
-  name: 'filename.ext',
-  content: 'file content',
-  mimetype: 'text/plain'
+  name: `filename.ext`, // Required, may include forward slashes to generate a folder structure
+  content: `file content`, // Required
+  mimetype: `text/plain`, // Required
+  fixtures: [fixA, fixB], // Optional, list of Fixture objects that are described in this file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information)
+  mode: `8ch` // Optional, mode's shortName if this file only describes a single mode
 }
 ```
 
 A very simple export plugin looks like this:
 
 ```js
-module.exports.name = 'Plugin Name';
-module.exports.version = '0.1.0';  // semantic versioning of export plugin
+module.exports.name = `Plugin Name`;
+module.exports.version = `0.1.0`;  // semantic versioning of export plugin
 
 /**
  * @param {!Array.<Fixture>} fixtures An array of Fixture objects, see our fixture model
@@ -53,7 +55,7 @@ module.exports.export = function exportPluginName(fixtures, options) {
         name: `${fixture.manufacturer.key}-${fixture.key}-${mode.shortName}.xml`,
         // that's just an example, normally, the (way larger) file contents are computated using several helper functions
         content: `<title>${fixture.name}: ${mode.channels.length}ch</title>`,
-        mimetype: 'application/xml'
+        mimetype: `application/xml`
       });
     }
   }
@@ -88,8 +90,8 @@ The `reject` function should be called with an error string if it's not possible
 Example:
 
 ```js
-module.exports.name = 'Plugin Name';
-module.exports.version = '0.1.0';  // semantic versioning of import plugin
+module.exports.name = `Plugin Name`;
+module.exports.version = `0.1.0`;  // semantic versioning of import plugin
 
 /**
  * @param {!string} fileContent The imported file's content
@@ -105,22 +107,22 @@ module.exports.import = function importPluginName(fileContent, fileName, resolve
   };
 
   // just an example
-  const manKey = 'cameo';
-  const fixKey = 'thunder-wash-600-rgb'; // use a sanitized key as it's used as filename!
+  const manKey = `cameo`;
+  const fixKey = `thunder-wash-600-rgb`; // use a sanitized key as it's used as filename!
 
   const fixtureObject = {};
   out.warnings[`${manKey}/${fixKey}`] = [];
 
-  const couldNotParse = fileContent.includes('Error');
+  const couldNotParse = fileContent.includes(`Error`);
   if (couldNotParse) {
     reject(`Could not parse '${fileName}'.`);
     return;
   }
 
-  fixtureObject.name = 'Thunder Wash 600 RGB';
+  fixtureObject.name = `Thunder Wash 600 RGB`;
 
   // Add warning if a necessary property is not included in parsed file
-  out.warnings[`${manKey}/${fixKey}`].push('Could not parse categories, please specify them manually.');
+  out.warnings[`${manKey}/${fixKey}`].push(`Could not parse categories, please specify them manually.`);
 
   // That's the imported fixture
   out.fixtures[`${manKey}/${fixKey}`] = fixtureObject;
@@ -133,31 +135,43 @@ module.exports.import = function importPluginName(fileContent, fileName, resolve
 
 We want to run unit tests whereever possible (see [Testing](testing.md)), that's why it's possible to write plugin specific tests for exported fixtures, so called export tests. Of course they're only possible if the plugin provides an export module.
 
-A plugin's export test takes an exported fixture as argument and evaluates it against plugin-specific requirements. For example, there is a [QLC+ export test](../plugins/qlcplus/exportTests/xsd-schema-conformity.js) that compares the generated xml file with the given QLC+ xsd fixture schema (if an official xml schema is available, it should definitely be used in an export test). We run these export tests automatically using the Travis CI.
+A plugin's export test takes an exported file object as argument and evaluates it against plugin-specific requirements. For example, there is a [QLC+ export test](../plugins/qlcplus/exportTests/xsd-schema-conformity.js) that compares the generated xml file with the given QLC+ xsd fixture schema (if an official xml schema is available, it should definitely be used in an export test). We run these export tests automatically using the Travis CI.
 
 Each test module should be located at `plugins/<plugin-key>/exportTests/<export-test-key>.js`. Here's a dummy test illustrating the structure:
 
 ```js
-const xml2js = require('xml2js');
+const xml2js = require(`xml2js`);
 
 /**
- * @param {string} exportFileData The content of a file returned by the plugins' export module.
- * @returns {Promise} Resolve when the test passes or reject with an error if the test fails.
+ * @param {object} exportFile The file returned by the plugins' export module.
+ * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
+ * @param {!string} exportFile.content File content.
+ * @param {!string} exportFile.mimetype File mime type.
+ * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @param {?string} exportFile.mode Mode's shortName if given file only describes a single mode.
+ * @returns {!Promise} Resolve when the test passes or reject with an array of errors if the test fails.
 **/
-module.exports = function testValueCorrectness(exportFileData) {
+module.exports = function testValueCorrectness(exportFile) {
   return new Promise((resolve, reject) => {
     const parser = new xml2js.Parser();
 
-    parser.parseString(exportFileData, (parseError, xml) => {
+    parser.parseString(exportFile.content, (parseError, xml) => {
       if (parseError) {
-        reject(`Error parsing XML: ${parseError}`);
+        reject([`Error parsing XML: ${parseError}`]);
         return;
       }
 
-      // the plugin crashes if the name is empty, so we must ensure that this won't happen
+      const errors = [];
+
+      // the lighting software crashes if the name is empty, so we must ensure that this won't happen
       // (just an example)
       if (xml.Fixture.Name[0].length === 0) {
-        reject('Name missing');
+        errors.push(`Name missing`);
+        return;
+      }
+
+      if (errors.length > 0) {
+        reject(errors)
         return;
       }
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -143,7 +143,7 @@ Each test module should be located at `plugins/<plugin-key>/exportTests/<export-
 const xml2js = require(`xml2js`);
 
 /**
- * @param {object} exportFile The file returned by the plugins' export module.
+ * @param {!object} exportFile The file returned by the plugins' export module.
  * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
  * @param {!string} exportFile.content File content.
  * @param {!string} exportFile.mimetype File mime type.

--- a/plugins/d-light/export.js
+++ b/plugins/d-light/export.js
@@ -47,7 +47,9 @@ module.exports.export = function exportDLight(fixtures, options) {
           pretty: true,
           indent: `  `
         }),
-        mimetype: `application/xml`
+        mimetype: `application/xml`,
+        fixtures: [fixture],
+        mode: mode.shortName
       });
     }
   }

--- a/plugins/d-light/exportTests/attributes-correctness.js
+++ b/plugins/d-light/exportTests/attributes-correctness.js
@@ -1,7 +1,7 @@
 const xml2js = require(`xml2js`);
 
 /**
- * @param {object} exportFile The file returned by the plugins' export module.
+ * @param {!object} exportFile The file returned by the plugins' export module.
  * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
  * @param {!string} exportFile.content File content.
  * @param {!string} exportFile.mimetype File mime type.

--- a/plugins/d-light/exportTests/attributes-correctness.js
+++ b/plugins/d-light/exportTests/attributes-correctness.js
@@ -1,12 +1,21 @@
 const xml2js = require(`xml2js`);
 
-module.exports = function testAttributesCorrectness(exportFileData) {
+/**
+ * @param {object} exportFile The file returned by the plugins' export module.
+ * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
+ * @param {!string} exportFile.content File content.
+ * @param {!string} exportFile.mimetype File mime type.
+ * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @param {?string} exportFile.mode Mode's shortName if given file only describes a single mode.
+ * @returns {!Promise} Resolve when the test passes or reject with an array of errors if the test fails.
+**/
+module.exports = function testAttributesCorrectness(exportFile) {
   return new Promise((resolve, reject) => {
     const parser = new xml2js.Parser();
 
-    parser.parseString(exportFileData, (parseError, xml) => {
+    parser.parseString(exportFile.content, (parseError, xml) => {
       if (parseError) {
-        return reject(`Error parsing XML: ${parseError.toString()}`);
+        return reject([`Error parsing XML: ${parseError.toString()}`]);
       }
 
       const errors = [];

--- a/plugins/ecue/README.md
+++ b/plugins/ecue/README.md
@@ -6,6 +6,7 @@ The [e:cue Lighting Application Suite](http://www.ecue.com/index.php?id=502) out
 
 A large (but a bit outdated) library is included. Some fixtures are available from their [Support Forum](http://www.ecue.com/no_cache/forum.html?tx_mmforum_pi1%5Baction%5D=list_topic&tx_mmforum_pi1%5Bfid%5D=11). New fixtures can be created in the *Library Editor* program, from which other fixtures can also be imported.
 
-**File locations:**
+### File locations
+
 *User Library:* `C:\Documents and Settings\[Your User]\AppData\Local\ecue\Library V7.0\UserLibrary.xml`  
 *Main Library:* `C:\ProgramData\ecue\Library V7.0\MainLibrary.xml`

--- a/plugins/ecue/export.js
+++ b/plugins/ecue/export.js
@@ -76,7 +76,8 @@ module.exports.export = function exportEcue(fixtures, options) {
       pretty: true,
       indent: `    `
     }),
-    mimetype: `application/xml`
+    mimetype: `application/xml`,
+    fixtures: fixtures
   }];
 };
 

--- a/plugins/millumin/README.md
+++ b/plugins/millumin/README.md
@@ -4,7 +4,7 @@
 
 Output fixtures for the Mac OS software *Millumin 2*. The format is essentially [the OFL format at schema version 7.0.0](https://github.com/OpenLightingProject/open-fixture-library/blob/schema-7.0.0/docs/fixture-format.md), with a few additional properties: Fixture and manufacturer keys and a link to the OFL fixture page.
 
-**File locations:**
+### File locations
 
 Fixtures should be copied into the `~/Library/Millumin/` folder (`~` is the user's home directory). You can keep them inside their manufacturer subfolder.
 

--- a/plugins/millumin/export.js
+++ b/plugins/millumin/export.js
@@ -51,7 +51,8 @@ module.exports.export = function exportMillumin(fixtures, options) {
     return {
       name: `${fixture.manufacturer.key}/${fixture.key}.json`,
       content: fixtureJsonStringify(jsonData),
-      mimetype: `application/ofl-fixture`
+      mimetype: `application/ofl-fixture`,
+      fixtures: [fixture]
     };
   });
 };

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -7,7 +7,16 @@ const SCHEMA_FILES = [`capability.json`, `channel.json`, `definitions.json`, `fi
 
 const schemaPromises = SCHEMA_FILES.map(filename => getSchema(SCHEMA_BASE_URL + filename));
 
-module.exports = function testSchemaConformity(exportFileData) {
+/**
+ * @param {object} exportFile The file returned by the plugins' export module.
+ * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
+ * @param {!string} exportFile.content File content.
+ * @param {!string} exportFile.mimetype File mime type.
+ * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @param {?string} exportFile.mode Mode's shortName if given file only describes a single mode.
+ * @returns {!Promise} Resolve when the test passes or reject with an error or an array of errors if the test fails.
+**/
+module.exports = function testSchemaConformity(exportFile) {
   return Promise.all(schemaPromises).then(schemas => {
     const fixtureSchema = schemas[SCHEMA_FILES.indexOf(`fixture.json`)];
 
@@ -22,7 +31,7 @@ module.exports = function testSchemaConformity(exportFileData) {
     const ajv = new Ajv({ schemas });
     const schemaValidate = ajv.getSchema(`https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json`);
 
-    const schemaValid = schemaValidate(JSON.parse(exportFileData));
+    const schemaValid = schemaValidate(JSON.parse(exportFile.content));
     if (!schemaValid) {
       return Promise.reject(JSON.stringify(schemaValidate.errors, null, 2));
     }

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -8,7 +8,7 @@ const SCHEMA_FILES = [`capability.json`, `channel.json`, `definitions.json`, `fi
 const schemaPromises = SCHEMA_FILES.map(filename => getSchema(SCHEMA_BASE_URL + filename));
 
 /**
- * @param {object} exportFile The file returned by the plugins' export module.
+ * @param {!object} exportFile The file returned by the plugins' export module.
  * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
  * @param {!string} exportFile.content File content.
  * @param {!string} exportFile.mimetype File mime type.

--- a/plugins/ofl/export.js
+++ b/plugins/ofl/export.js
@@ -23,7 +23,8 @@ module.exports.export = function exportOFL(fixtures, options) {
     return {
       name: `${fixture.manufacturer.key}/${fixture.key}.json`,
       content: fixtureJsonStringify(jsonData),
-      mimetype: `application/ofl-fixture`
+      mimetype: `application/ofl-fixture`,
+      fixtures: [fixture]
     };
   });
 

--- a/plugins/qlcplus_4.11.2/README.md
+++ b/plugins/qlcplus_4.11.2/README.md
@@ -8,7 +8,7 @@ The main library is available in their [GitHub repository](https://github.com/mc
 
 To import a fixture into *QLC+*, copy the `.qxf` file into the right directory (see below).
 
-**File locations:**
+### File locations
 
 Fixtures are always located in the `fixture` subdirectory in one of the following paths. Fixtures in subdirectories of `fixture` (e.g. grouped by manufacturer) aren't recognized!
 

--- a/plugins/qlcplus_4.11.2/export.js
+++ b/plugins/qlcplus_4.11.2/export.js
@@ -58,7 +58,8 @@ module.exports.export = function exportQLCplus(fixtures, options) {
         pretty: true,
         indent: ` `
       }),
-      mimetype: `application/x-qlc-fixture`
+      mimetype: `application/x-qlc-fixture`,
+      fixtures: [fixture]
     };
   });
 };

--- a/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
+++ b/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
@@ -3,7 +3,16 @@ const xsd = require(`libxml-xsd`);
 
 const SCHEMA_URL = `https://raw.githubusercontent.com/mcallegari/qlcplus/QLC+_4.11.2/resources/schemas/fixture.xsd`;
 
-module.exports = function testSchemaConformity(exportFileData) {
+/**
+ * @param {object} exportFile The file returned by the plugins' export module.
+ * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
+ * @param {!string} exportFile.content File content.
+ * @param {!string} exportFile.mimetype File mime type.
+ * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @param {?string} exportFile.mode Mode's shortName if given file only describes a single mode.
+ * @returns {!Promise} Resolve when the test passes or reject with an array of errors if the test fails.
+**/
+module.exports = function testSchemaConformity(exportFile) {
   return new Promise((resolve, reject) => {
     https.get(SCHEMA_URL, res => {
       let data = ``;
@@ -18,12 +27,12 @@ module.exports = function testSchemaConformity(exportFileData) {
     .then(schemaData => new Promise((resolve, reject) => {
       xsd.parse(schemaData, (err, schema) => {
         if (err) {
-          reject(err);
+          reject([err]);
         }
         else {
-          schema.validate(exportFileData, (err, validationErrors) => {
+          schema.validate(exportFile.content, (err, validationErrors) => {
             if (err) {
-              reject(err);
+              reject([err]);
             }
             else if (validationErrors) {
               reject(validationErrors.map(err => err.message));

--- a/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
+++ b/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
@@ -4,7 +4,7 @@ const xsd = require(`libxml-xsd`);
 const SCHEMA_URL = `https://raw.githubusercontent.com/mcallegari/qlcplus/QLC+_4.11.2/resources/schemas/fixture.xsd`;
 
 /**
- * @param {object} exportFile The file returned by the plugins' export module.
+ * @param {!object} exportFile The file returned by the plugins' export module.
  * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
  * @param {!string} exportFile.content File content.
  * @param {!string} exportFile.mimetype File mime type.

--- a/tests/github/exports-valid.js
+++ b/tests/github/exports-valid.js
@@ -206,7 +206,7 @@ function getTaskPromise(task) {
 
   let failed = false;
   return Promise.all(files.map(
-    file => test(file.content)
+    file => test(file)
       .then(() => {
         return `    <li>:heavy_check_mark: ${file.name}</li>`;
       })


### PR DESCRIPTION
Also include fixture(s) and mode (both optional) in file object to give
export tests more opportunities.
Documentation has been improved as well.

Extracted from #359.