### PR TITLE
Fix tests and register generation

### DIFF
--- a/cli/make-register.js
+++ b/cli/make-register.js
@@ -21,7 +21,7 @@ try {
   const manufacturers = JSON.parse(fs.readFileSync(path.join(fixturePath, `manufacturers.json`), `utf8`));
 
   // add all fixture.json files to the register
-  for (const manKey of fs.readdirSync(fixturePath).sort()) {
+  for (const manKey of fs.readdirSync(fixturePath).sort(localeSort)) {
     const manDir = path.join(fixturePath, manKey);
 
     // only directories
@@ -35,7 +35,7 @@ try {
         };
       }
 
-      for (const filename of fs.readdirSync(manDir).sort()) {
+      for (const filename of fs.readdirSync(manDir).sort(localeSort)) {
         if (path.extname(filename) !== `.json`) {
           continue;
         }
@@ -110,7 +110,7 @@ catch (readError) {
 }
 
 // copy sorted categories into register
-for (const cat of Object.keys(categories).sort()) {
+for (const cat of Object.keys(categories).sort(localeSort)) {
   register.categories[cat] = categories[cat];
 }
 
@@ -144,13 +144,13 @@ register.lastUpdated = Object.keys(register.filesystem).filter(
 });
 
 // copy sorted RDM data into register
-for (const manId of Object.keys(rdm).sort()) {
+for (const manId of Object.keys(rdm).sort(localeSort)) {
   register.rdm[manId] = {
     key: rdm[manId].key,
     models: {}
   };
 
-  for (const fixId of Object.keys(rdm[manId].models).sort()) {
+  for (const fixId of Object.keys(rdm[manId].models).sort(localeSort)) {
     register.rdm[manId].models[fixId] = rdm[manId].models[fixId];
   }
 }
@@ -165,3 +165,16 @@ fs.writeFile(filename, `${JSON.stringify(register, null, 2)}\n`, `utf8`, error =
   console.log(`${colors.green(`[Success]`)} Updated register file ${filename}`);
   process.exit(0);
 });
+
+
+/**
+ * Function to pass into Array.sort().
+ * @param {!string} a The first string.
+ * @param {!string} b The second string.
+ * @returns {!number} A number indicating the order of the two strings.
+ */
+function localeSort(a, b) {
+  return a.localeCompare(b, `en`, {
+    numeric: true
+  });
+}

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -325,11 +325,6 @@
       "lastModifyDate": "2018-08-09",
       "lastAction": "modified"
     },
-    "eurolite/led-tmh-18": {
-      "name": "LED TMH-18",
-      "lastModifyDate": "2018-08-09",
-      "lastAction": "modified"
-    },
     "eurolite/led-tmh-7": {
       "name": "LED TMH-7",
       "lastModifyDate": "2018-08-09",
@@ -337,6 +332,11 @@
     },
     "eurolite/led-tmh-9": {
       "name": "LED TMH-9",
+      "lastModifyDate": "2018-08-09",
+      "lastAction": "modified"
+    },
+    "eurolite/led-tmh-18": {
+      "name": "LED TMH-18",
       "lastModifyDate": "2018-08-09",
       "lastAction": "modified"
     },
@@ -645,13 +645,13 @@
       "lastModifyDate": "2018-07-21",
       "lastAction": "modified"
     },
-    "showtec/phantom-140-led-spot": {
-      "name": "Phantom 140 LED Beam",
+    "showtec/phantom-50-led-spot": {
+      "name": "Phantom 50 LED Spot",
       "lastModifyDate": "2018-08-09",
       "lastAction": "modified"
     },
-    "showtec/phantom-50-led-spot": {
-      "name": "Phantom 50 LED Spot",
+    "showtec/phantom-140-led-spot": {
+      "name": "Phantom 140 LED Beam",
       "lastModifyDate": "2018-08-09",
       "lastAction": "modified"
     },
@@ -817,9 +817,9 @@
       "led-ps-4-hcl",
       "led-sls-6-uv-floor",
       "led-svf-1",
-      "led-tmh-18",
       "led-tmh-7",
       "led-tmh-9",
+      "led-tmh-18",
       "led-tmh-x25"
     ],
     "futurelight": [
@@ -924,8 +924,8 @@
       "kanjo-spot-60",
       "kanjo-wash-rgb",
       "led-light-bar-rgb-v3",
-      "phantom-140-led-spot",
       "phantom-50-led-spot",
+      "phantom-140-led-spot",
       "pixel-bar-12-mkii",
       "sunraise-led",
       "xs-1-rgbw"
@@ -1018,9 +1018,9 @@
       "eurolite/led-kls-801",
       "eurolite/led-par-56-tcl",
       "eurolite/led-ps-4-hcl",
-      "eurolite/led-tmh-18",
       "eurolite/led-tmh-7",
       "eurolite/led-tmh-9",
+      "eurolite/led-tmh-18",
       "eurolite/led-tmh-x25",
       "futurelight/dmh-75-i-led-moving-head",
       "futurelight/pro-slim-par-7-hcl",
@@ -1072,8 +1072,8 @@
       "showtec/kanjo-spot-60",
       "showtec/kanjo-wash-rgb",
       "showtec/led-light-bar-rgb-v3",
-      "showtec/phantom-140-led-spot",
       "showtec/phantom-50-led-spot",
+      "showtec/phantom-140-led-spot",
       "showtec/pixel-bar-12-mkii",
       "showtec/sunraise-led",
       "showtec/xs-1-rgbw",
@@ -1163,9 +1163,9 @@
       "elation/platinum-spot-15r-pro",
       "eliminator/stealth-beam",
       "eurolite/led-svf-1",
-      "eurolite/led-tmh-18",
       "eurolite/led-tmh-7",
       "eurolite/led-tmh-9",
+      "eurolite/led-tmh-18",
       "eurolite/led-tmh-x25",
       "futurelight/dmh-75-i-led-moving-head",
       "generic/pan-tilt",
@@ -1193,8 +1193,8 @@
       "robe/robin-ledwash-600",
       "showtec/kanjo-spot-60",
       "showtec/kanjo-wash-rgb",
-      "showtec/phantom-140-led-spot",
       "showtec/phantom-50-led-spot",
+      "showtec/phantom-140-led-spot",
       "showtec/xs-1-rgbw",
       "stairville/mh-100",
       "stairville/mh-x25"
@@ -1261,9 +1261,9 @@
       "eurolite/led-par-56-tcl",
       "eurolite/led-ps-4-hcl",
       "eurolite/led-sls-6-uv-floor",
-      "eurolite/led-tmh-18",
       "eurolite/led-tmh-7",
       "eurolite/led-tmh-9",
+      "eurolite/led-tmh-18",
       "futurelight/dmh-75-i-led-moving-head",
       "futurelight/pro-slim-par-7-hcl",
       "generic/cmy-fader",
@@ -1290,8 +1290,8 @@
       "showtec/kanjo-spot-60",
       "showtec/kanjo-wash-rgb",
       "showtec/led-light-bar-rgb-v3",
-      "showtec/phantom-140-led-spot",
       "showtec/phantom-50-led-spot",
+      "showtec/phantom-140-led-spot",
       "stairville/mh-x25",
       "stairville/stage-tri-led",
       "tmb/solaris-flare",
@@ -1353,8 +1353,8 @@
       "showtec/dominator",
       "showtec/kanjo-wash-rgb",
       "showtec/led-light-bar-rgb-v3",
-      "showtec/phantom-140-led-spot",
       "showtec/phantom-50-led-spot",
+      "showtec/phantom-140-led-spot",
       "showtec/pixel-bar-12-mkii",
       "showtec/sunraise-led",
       "stairville/led-flood-panel-150",

--- a/lib/create-github-pr.js
+++ b/lib/create-github-pr.js
@@ -350,18 +350,18 @@ module.exports = function createPullRequest(out, callback) {
     };
 
     // copy sorted filesystem into register
-    for (const fixKey of Object.keys(register.filesystem).sort()) {
+    for (const fixKey of Object.keys(register.filesystem).sort(localeSort)) {
       newRegister.filesystem[fixKey] = register.filesystem[fixKey];
     }
 
     // copy sorted manufacturers into register
-    for (const man of Object.keys(register.manufacturers).sort()) {
-      newRegister.manufacturers[man] = register.manufacturers[man].sort();
+    for (const man of Object.keys(register.manufacturers).sort(localeSort)) {
+      newRegister.manufacturers[man] = register.manufacturers[man].sort(localeSort);
     }
 
     // copy sorted categories into register
-    for (const cat of Object.keys(register.categories).sort()) {
-      newRegister.categories[cat] = register.categories[cat].sort();
+    for (const cat of Object.keys(register.categories).sort(localeSort)) {
+      newRegister.categories[cat] = register.categories[cat].sort(localeSort);
     }
 
     // copy sorted contributors into register
@@ -371,7 +371,7 @@ module.exports = function createPullRequest(out, callback) {
       return fixturesDelta !== 0 ? fixturesDelta : nameDelta;
     });
     for (const contributor of sortedContributors) {
-      newRegister.contributors[contributor] = register.contributors[contributor].sort();
+      newRegister.contributors[contributor] = register.contributors[contributor].sort(localeSort);
     }
 
     // the higher the value, the higher the rank if the dates are the same
@@ -394,13 +394,13 @@ module.exports = function createPullRequest(out, callback) {
     });
 
     // copy sorted RDM data into register
-    for (const manId of Object.keys(register.rdm).sort()) {
+    for (const manId of Object.keys(register.rdm).sort(localeSort)) {
       newRegister.rdm[manId] = {
         key: register.rdm[manId].key,
         models: {}
       };
 
-      for (const fixId of Object.keys(register.rdm[manId].models).sort()) {
+      for (const fixId of Object.keys(register.rdm[manId].models).sort(localeSort)) {
         newRegister.rdm[manId].models[fixId] = register.rdm[manId].models[fixId];
       }
     }
@@ -427,4 +427,17 @@ function prettyJsonStringify(obj) {
   const str = JSON.stringify(obj, null, 2);
 
   return `${str}\n`;
+}
+
+
+/**
+ * Function to pass into Array.sort().
+ * @param {!string} a The first string.
+ * @param {!string} b The second string.
+ * @returns {!number} A number indicating the order of the two strings.
+ */
+function localeSort(a, b) {
+  return a.localeCompare(b, `en`, {
+    numeric: true
+  });
 }

--- a/tests/fixture-valid.js
+++ b/tests/fixture-valid.js
@@ -121,7 +121,7 @@ function checkFixture(manKey, fixKey, fixtureJson, uniqueValues = null) {
    * Checks that fixture key, name and shortName are unique.
    * @param {?UniqueValues} [uniqueValues=null] Values that have to be unique are checked and all new occurences are appended.
    */
-  function checkFixIdentifierUniqueness(uniqueValues) {
+  function checkFixIdentifierUniqueness(uniqueValues = null) {
     // test is called for a single fixture, e.g. when importing
     if (uniqueValues === null) {
       return;
@@ -956,8 +956,8 @@ function checkFixture(manKey, fixKey, fixtureJson, uniqueValues = null) {
    * @param {!string} manKey The manufacturer key.
    * @param {?UniqueValues} [uniqueValues=null] Values that have to be unique are checked and all new occurences are appended.
    */
-  function checkRdm(manKey, uniqueValues) {
-    if (fixture.rdm === null) {
+  function checkRdm(manKey, uniqueValues = null) {
+    if (fixture.rdm === null || uniqueValues === null) {
       return;
     }
 


### PR DESCRIPTION
* Fix RDM uniqueness check in fixture-valid test
* Sort register entries with `localeCompare`. This way, *LED TMH 18* comes after *LED TMH 5*, like it should. Hopefully, it also fixes the *sparkular* / *sparkular-fall* sorting differences on different systems.