### PR TITLE
Add QLC+ forum link to ADJ Inno Pocket Fusion

### DIFF
--- a/fixtures/american-dj/inno-pocket-fusion.json
+++ b/fixtures/american-dj/inno-pocket-fusion.json
@@ -14,7 +14,8 @@
       "https://www.youtube.com/watch?v=hLYHfn-D5aY",
       "https://www.youtube.com/watch?v=Zdd0t-rlqck",
       "https://www.youtube.com/watch?v=uy0yZrFI4zg"
-    ]
+    ],
+    "other": ["https://www.qlcplus.org/forum/viewtopic.php?f=6&t=12415"]
   },
   "physical": {
     "dimensions": [340, 177, 132],


### PR DESCRIPTION
Seems like I always forgot to add it. I think the `lastModifyDate` doesn't have to be changed though.