### PR TITLE
Promisify all the things!

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,11 +8,13 @@
   },
   "plugins": [
     "json",
+    "promise",
     "security",
     "vue"
   ],
   "extends": [
     "eslint:recommended",
+    "plugin:promise/recommended",
     "plugin:security/recommended",
     "plugin:vue/recommended"
   ],
@@ -119,6 +121,10 @@
         "String": "string"
       }
     }],
+    "promise/always-return": "off",
+    "promise/no-nesting": "off",
+    "promise/no-return-in-finally": "error",
+    "promise/valid-params": "error",
     "vue/max-attributes-per-line": ["error", { "singleline": 3 }],
     "vue/html-closing-bracket-newline": "error",
     "vue/html-closing-bracket-spacing": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -123,6 +123,7 @@
     }],
     "promise/always-return": "off",
     "promise/no-nesting": "off",
+    "promise/no-promise-in-callback": "off",
     "promise/no-return-in-finally": "error",
     "promise/valid-params": "error",
     "vue/max-attributes-per-line": ["error", { "singleline": 3 }],

--- a/cli/export-fixture.js
+++ b/cli/export-fixture.js
@@ -3,6 +3,7 @@ const fs = require(`fs`);
 const path = require(`path`);
 const minimist = require(`minimist`);
 const colors = require(`colors`);
+const mkdirp = require(`mkdirp`);
 
 const plugins = require(`../plugins/plugins.json`);
 const { fixtureFromRepository } = require(`../lib/model.js`);
@@ -59,13 +60,7 @@ else {
   });
 }
 
-let outDir;
-if (args.o) {
-  outDir = path.join(process.cwd(), args.o);
-  if (!fs.existsSync(outDir)) {
-    fs.mkdirSync(outDir);
-  }
-}
+const outDir = args.o ? path.join(process.cwd(), args.o) : null;
 
 const plugin = require(path.join(__dirname, `../plugins`, args.plugin, `export.js`));
 plugin.export(
@@ -76,11 +71,7 @@ plugin.export(
 ).forEach(file => {
   if (args.o) {
     const filePath = path.join(outDir, file.name);
-
-    if (!fs.existsSync(path.dirname(filePath))) {
-      fs.mkdirSync(path.dirname(filePath));
-    }
-
+    mkdirp.sync(path.dirname(filePath));
     fs.writeFileSync(filePath, file.content);
     console.log(`Created file ${filePath}`);
   }

--- a/cli/export-fixture.js
+++ b/cli/export-fixture.js
@@ -68,15 +68,17 @@ plugin.export(
   {
     baseDir: path.join(__dirname, `..`)
   }
-).forEach(file => {
-  if (args.o) {
-    const filePath = path.join(outDir, file.name);
-    mkdirp.sync(path.dirname(filePath));
-    fs.writeFileSync(filePath, file.content);
-    console.log(`Created file ${filePath}`);
-  }
-  else {
-    console.log(`\n${colors.yellow(`File name: '${file.name}'`)}`);
-    console.log(file.content);
-  }
+).then(files => {
+  files.forEach(file => {
+    if (args.o) {
+      const filePath = path.join(outDir, file.name);
+      mkdirp.sync(path.dirname(filePath));
+      fs.writeFileSync(filePath, file.content);
+      console.log(`Created file ${filePath}`);
+    }
+    else {
+      console.log(`\n${colors.yellow(`File name: '${file.name}'`)}`);
+      console.log(file.content);
+    }
+  });
 });

--- a/cli/export-fixture.js
+++ b/cli/export-fixture.js
@@ -69,17 +69,22 @@ plugin.export(
     baseDir: path.join(__dirname, `..`),
     date: new Date()
   }
-).then(files => {
-  files.forEach(file => {
-    if (args.o) {
-      const filePath = path.join(outDir, file.name);
-      mkdirp.sync(path.dirname(filePath));
-      fs.writeFileSync(filePath, file.content);
-      console.log(`Created file ${filePath}`);
-    }
-    else {
-      console.log(`\n${colors.yellow(`File name: '${file.name}'`)}`);
-      console.log(file.content);
-    }
+)
+  .then(files => {
+    files.forEach(file => {
+      if (args.o) {
+        const filePath = path.join(outDir, file.name);
+        mkdirp.sync(path.dirname(filePath));
+        fs.writeFileSync(filePath, file.content);
+        console.log(`Created file ${filePath}`);
+      }
+      else {
+        console.log(`\n${colors.yellow(`File name: '${file.name}'`)}`);
+        console.log(file.content);
+      }
+    });
+  })
+  .catch(error => {
+    console.error(`${colors.red(`[Error]`)} Exporting failed:`, error);
+    process.exit(1);
   });
-});

--- a/cli/export-fixture.js
+++ b/cli/export-fixture.js
@@ -66,7 +66,8 @@ const plugin = require(path.join(__dirname, `../plugins`, args.plugin, `export.j
 plugin.export(
   fixtures.map(([man, fix]) => fixtureFromRepository(man, fix)),
   {
-    baseDir: path.join(__dirname, `..`)
+    baseDir: path.join(__dirname, `..`),
+    date: new Date()
   }
 ).then(files => {
   files.forEach(file => {

--- a/cli/import-fixture.js
+++ b/cli/import-fixture.js
@@ -48,15 +48,12 @@ fs.readFile(filename, `utf8`, (error, data) => {
     }
 
     if (args[`create-pull-request`]) {
-      createPullRequest(result, (error, pullRequestUrl) => {
-        if (error) {
+      createPullRequest(result)
+        .then(pullRequestUrl => console.log(`URL: ${pullRequestUrl}`))
+        .catch(error => {
           console.log(fixtureJsonStringify(result));
-          console.error(`Error: ${error}`);
-          return;
-        }
-
-        console.log(`URL: ${pullRequestUrl}`);
-      });
+          console.error(`Error creating pull request: ${error.message}`);
+        });
     }
     else {
       console.log(fixtureJsonStringify(result));

--- a/cli/import-fixture.js
+++ b/cli/import-fixture.js
@@ -29,9 +29,7 @@ if (args._.length !== 1 || !plugins.importPlugins.includes(args.plugin)) {
 readFile(filename, `utf8`)
   .then(data => {
     const plugin = require(path.join(__dirname, `../plugins`, args.plugin, `import.js`));
-    return new Promise((resolve, reject) => {
-      plugin.import(data, filename, resolve, reject);
-    });
+    return plugin.import(data, filename);
   })
   .then(result => {
     result.errors = {};
@@ -58,6 +56,6 @@ readFile(filename, `utf8`)
     }
   })
   .catch(error => {
-    console.error(error);
+    console.error(`Error parsing '${filename}'.\n${error.toString()}`);
     process.exit(1);
   });

--- a/cli/import-fixture.js
+++ b/cli/import-fixture.js
@@ -26,10 +26,10 @@ if (args._.length !== 1 || !plugins.importPlugins.includes(args.plugin)) {
   process.exit(1);
 }
 
-readFile(filename, `utf8`)
-  .then(data => {
+readFile(filename)
+  .then(buffer => {
     const plugin = require(path.join(__dirname, `../plugins`, args.plugin, `import.js`));
-    return plugin.import(data, filename);
+    return plugin.import(buffer, filename);
   })
   .then(result => {
     result.errors = {};

--- a/cli/import-fixture.js
+++ b/cli/import-fixture.js
@@ -1,8 +1,9 @@
 #!/usr/bin/node
 
-const fs = require(`fs`);
 const path = require(`path`);
 const minimist = require(`minimist`);
+const promisify = require(`util`).promisify;
+const readFile = promisify(require(`fs`).readFile);
 
 const { checkFixture } = require(`../tests/fixture-valid.js`);
 const plugins = require(`../plugins/plugins.json`);
@@ -25,17 +26,14 @@ if (args._.length !== 1 || !plugins.importPlugins.includes(args.plugin)) {
   process.exit(1);
 }
 
-fs.readFile(filename, `utf8`, (error, data) => {
-  if (error) {
-    console.error(`read error`, error);
-    process.exit(1);
-    return;
-  }
-
-  const plugin = require(path.join(__dirname, `../plugins`, args.plugin, `import.js`));
-  new Promise((resolve, reject) => {
-    plugin.import(data, filename, resolve, reject);
-  }).then(result => {
+readFile(filename, `utf8`)
+  .then(data => {
+    const plugin = require(path.join(__dirname, `../plugins`, args.plugin, `import.js`));
+    return new Promise((resolve, reject) => {
+      plugin.import(data, filename, resolve, reject);
+    });
+  })
+  .then(result => {
     result.errors = {};
 
     for (const key of Object.keys(result.fixtures)) {
@@ -58,7 +56,8 @@ fs.readFile(filename, `utf8`, (error, data) => {
     else {
       console.log(fixtureJsonStringify(result));
     }
-  }).catch(error => {
+  })
+  .catch(error => {
     console.error(error);
+    process.exit(1);
   });
-});

--- a/cli/make-test-fixtures.js
+++ b/cli/make-test-fixtures.js
@@ -35,9 +35,9 @@ for (const featureFile of fs.readdirSync(fixFeaturesDir)) {
         }
       }
 
-      // check uniquness of id
+      // check uniqueness of id
       if (fixFeature.id in featuresUsed) {
-        console.error(`${colors.red(`[Error]`)} Fix feature id ${fixFeature.id} used multiple times.`);
+        console.error(`${colors.red(`[Error]`)} Fixture feature id '${fixFeature.id}' is used multiple times.`);
         process.exit(1);
       }
 

--- a/cli/run-export-test.js
+++ b/cli/run-export-test.js
@@ -60,8 +60,7 @@ plugin.export(fixtures, {
         .catch(err => {
           const errors = Array.isArray(err) ? err : [err];
 
-          return [].concat(
-            `${colors.red(`[FAIL]`)} ${file.name}`,
+          return [`${colors.red(`[FAIL]`)} ${file.name}`].concat(
             errors.map(error => `- ${error}`)
           ).join(`\n`);
         })

--- a/cli/run-export-test.js
+++ b/cli/run-export-test.js
@@ -50,25 +50,30 @@ const plugin = require(path.join(__dirname, `../plugins`, args.plugin, `export.j
 plugin.export(fixtures, {
   baseDir: path.join(__dirname, `..`),
   date: new Date()
-}).then(files => {
-  for (const testKey of plugins.data[args.plugin].exportTests) {
-    const exportTest = require(path.join(__dirname, `../plugins`, args.plugin, `exportTests/${testKey}.js`));
+})
+  .then(files => Promise.all(
+    plugins.data[args.plugin].exportTests.map(testKey => {
+      const exportTest = require(path.join(__dirname, `../plugins`, args.plugin, `exportTests/${testKey}.js`));
 
-    const filePromises = files.map(file =>
-      exportTest(file)
-        .then(() => `${colors.green(`[PASS]`)} ${file.name}`)
-        .catch(err => {
-          const errors = Array.isArray(err) ? err : [err];
+      const filePromises = files.map(file =>
+        exportTest(file)
+          .then(() => `${colors.green(`[PASS]`)} ${file.name}`)
+          .catch(err => {
+            const errors = Array.isArray(err) ? err : [err];
 
-          return [`${colors.red(`[FAIL]`)} ${file.name}`].concat(
-            errors.map(error => `- ${error}`)
-          ).join(`\n`);
-        })
-    );
+            return [`${colors.red(`[FAIL]`)} ${file.name}`].concat(
+              errors.map(error => `- ${error}`)
+            ).join(`\n`);
+          })
+      );
 
-    Promise.all(filePromises).then(outputPerFile => {
-      console.log(`\n${colors.yellow(`Test ${testKey}`)}`);
-      console.log(outputPerFile.join(`\n`));
-    });
-  }
-});
+      return Promise.all(filePromises).then(outputPerFile => {
+        console.log(`\n${colors.yellow(`Test ${testKey}`)}`);
+        console.log(outputPerFile.join(`\n`));
+      });
+    })
+  ))
+  .catch(error => {
+    console.error(`${colors.red(`[Error]`)} Exporting failed:`, error);
+    process.exit(1);
+  });

--- a/cli/run-export-test.js
+++ b/cli/run-export-test.js
@@ -47,7 +47,10 @@ else {
 }
 
 const plugin = require(path.join(__dirname, `../plugins`, args.plugin, `export.js`));
-plugin.export(fixtures, {}).then(files => {
+plugin.export(fixtures, {
+  baseDir: path.join(__dirname, `..`),
+  date: new Date()
+}).then(files => {
   for (const testKey of plugins.data[args.plugin].exportTests) {
     const exportTest = require(path.join(__dirname, `../plugins`, args.plugin, `exportTests/${testKey}.js`));
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -21,14 +21,14 @@ node cli/export-fixture.js -p <plugin> <fixture> [<more fixtures>]
 
 ## Exporting
 
-If exporting is supported, create a `plugins/<plugin-key>/export.js` module that provides the plugin name, version and a method that generates the needed third-party files out of an given array of fixtures. This method should return an array of objects for each file that should be exported / downloadable; the files are zipped together automatically if neccessary. A file object looks like this:
+If exporting is supported, create a `plugins/<plugin-key>/export.js` module that provides the plugin name, version and a method that generates the needed third-party files out of an given array of fixtures. This method should return an array of objects for each file that should be exported / downloadable; the files are zipped together automatically if necessary. A file object looks like this:
 
 ```js
 {
   name: `filename.ext`, // Required, may include forward slashes to generate a folder structure
   content: `file content`, // Required
   mimetype: `text/plain`, // Required
-  fixtures: [fixA, fixB], // Optional, list of Fixture objects that are described in this file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information)
+  fixtures: [fixA, fixB], // Optional, list of Fixture objects that are described in this file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information)
   mode: `8ch` // Optional, mode's shortName if this file only describes a single mode
 }
 ```
@@ -68,7 +68,7 @@ module.exports.export = function exportPluginName(fixtures, options) {
 
 If importing is supported, create a `plugins/<plugin-key>/import.js` module that exports the plugin name, version and a method that creates OFL fixture definitions out of a given third-party file.
 
-As file parsing (like xml processing) can be asynchronous, the import method returns its results asynchronously using a [Promise](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to an object that looks like this:
+As file parsing (like XML processing) can be asynchronous, the import method returns its results asynchronously using a [Promise](https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Promise) that resolves to an object that looks like this:
 
 ```js
 {
@@ -134,9 +134,9 @@ Note that this example did not use asynchronous functions, so `Promise.resolve` 
 
 ## Export tests
 
-We want to run unit tests whereever possible (see [Testing](testing.md)), that's why it's possible to write plugin specific tests for exported fixtures, so called export tests. Of course they're only possible if the plugin provides an export module.
+We want to run unit tests wherever possible (see [Testing](testing.md)), that's why it's possible to write plugin specific tests for exported fixtures, so called export tests. Of course they're only possible if the plugin provides an export module.
 
-A plugin's export test takes an exported file object as argument and evaluates it against plugin-specific requirements. For example, there is a [QLC+ export test](../plugins/qlcplus/exportTests/xsd-schema-conformity.js) that compares the generated xml file with the given QLC+ xsd fixture schema (if an official xml schema is available, it should definitely be used in an export test). We run these export tests automatically using the Travis CI.
+A plugin's export test takes an exported file object as argument and evaluates it against plugin-specific requirements. For example, there is a [QLC+ export test](../plugins/qlcplus/exportTests/xsd-schema-conformity.js) that compares the generated XML file with the given QLC+ XSD fixture schema (if an official XML schema is available, it should definitely be used in an export test). We run these export tests automatically using the Travis CI.
 
 Each test module should be located at `plugins/<plugin-key>/exportTests/<export-test-key>.js`. Here's a dummy test illustrating the structure:
 
@@ -148,7 +148,7 @@ const xml2js = require(`xml2js`);
  * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
  * @param {!string} exportFile.content File content.
  * @param {!string} exportFile.mimetype File mime type.
- * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {?string} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {!Promise} Resolve when the test passes or reject with an array of errors if the test fails.
 **/

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -98,8 +98,8 @@ module.exports.version = `0.1.0`;  // semantic versioning of import plugin
 /**
  * @param {!Buffer} buffer The imported file.
  * @param {!string} fileName The imported file's name.
- * @returns {!Promise.<!object, !Error} A Promise resolving to an out object
- *                                      (see above) or rejects with an error.
+ * @returns {!Promise.<!object, !Error>} A Promise resolving to an out object
+ *                                       (see above) or rejects with an error.
 **/
 module.exports.import = function importPluginName(buffer, fileName) {
   const out = {

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -21,7 +21,7 @@ node cli/export-fixture.js -p <plugin> <fixture> [<more fixtures>]
 
 ## Exporting
 
-If exporting is supported, create a `plugins/<plugin-key>/export.js` module that provides the plugin name, version and a method that generates the needed third-party files out of an given array of fixtures. This method should return an array of objects for each file that should be exported / downloadable; the files are zipped together automatically if necessary. A file object looks like this:
+If exporting is supported, create a `plugins/<plugin-key>/export.js` module that provides the plugin name, version and a method that generates the needed third-party files out of an given array of fixtures. This method should return a Promise of an array of objects for each file that should be exported / downloadable; the files are zipped together automatically if necessary. A file object looks like this:
 
 ```js
 {
@@ -44,7 +44,7 @@ module.exports.version = `0.1.0`;  // semantic versioning of export plugin
  * @param {!object} options Some global options, for example:
  * @param {!string} options.baseDir Absolute path to OFL's root directory
  * @param {?Date} options.date The current time (prefer this over new Date())
- * @returns {!Array.<object>} All generated files (see file schema above)
+ * @returns {!Promise.<!Array.<object>, !Error>} All generated files (see file schema above)
 */
 module.exports.export = function exportPluginName(fixtures, options) {
   const outfiles = [];
@@ -53,14 +53,16 @@ module.exports.export = function exportPluginName(fixtures, options) {
     for (const mode of fixture.modes) {
       outfiles.push({
         name: `${fixture.manufacturer.key}-${fixture.key}-${mode.shortName}.xml`,
-        // that's just an example, normally, the (way larger) file contents are computated using several helper functions
+
+        // That's just an example! Usually, the (way larger) file contents are
+        // computed using several (possibly asynchronous) helper functions
         content: `<title>${fixture.name}: ${mode.channels.length}ch</title>`,
         mimetype: `application/xml`
       });
     }
   }
 
-  return outfiles;
+  return Promise.resolve(outfiles);
 };
 ```
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -96,12 +96,12 @@ module.exports.name = `Plugin Name`;
 module.exports.version = `0.1.0`;  // semantic versioning of import plugin
 
 /**
- * @param {!string} fileContent The imported file's content
- * @param {!string} fileName The imported file's name
+ * @param {!Buffer} buffer The imported file.
+ * @param {!string} fileName The imported file's name.
  * @returns {!Promise.<!object, !Error} A Promise resolving to an out object
  *                                      (see above) or rejects with an error.
 **/
-module.exports.import = function importPluginName(fileContent, fileName) {
+module.exports.import = function importPluginName(buffer, fileName) {
   const out = {
     manufacturers: {},
     fixtures: {},
@@ -115,6 +115,7 @@ module.exports.import = function importPluginName(fileContent, fileName) {
   const fixtureObject = {};
   out.warnings[`${manKey}/${fixKey}`] = [];
 
+  const fileContent = buffer.toString();
   const couldNotParse = fileContent.includes(`Error`);
   if (couldNotParse) {
     return Promise.reject(new Error(`Could not parse '${fileName}'.`));

--- a/lib/create-github-pr.js
+++ b/lib/create-github-pr.js
@@ -71,9 +71,10 @@ module.exports = function createPullRequest(out) {
       let chain = Promise.resolve();
 
       for (const fixtureKey of Object.keys(out.fixtures)) {
-        chain = chain.then(() => addOrUpdateFile(`fixtures/${fixtureKey}.json`, `fixture '${fixtureKey}'`, oldFileContent => {
-          return fixtureJsonStringify(out.fixtures[fixtureKey]);
-        }));
+        chain = chain.then(() => addOrUpdateFile(
+          `fixtures/${fixtureKey}.json`, `fixture '${fixtureKey}'`,
+          oldFileContent => fixtureJsonStringify(out.fixtures[fixtureKey])
+        ));
       }
 
       return chain;

--- a/lib/create-github-pr.js
+++ b/lib/create-github-pr.js
@@ -1,22 +1,12 @@
-const GitHubApi = require(`@octokit/rest`);
+const octokit = require(`@octokit/rest`);
 const fixtureJsonStringify = require(`./fixture-json-stringify.js`);
 
 require(`./load-env-file.js`);
 
-const github = new GitHubApi({
-  debug: false,
-  protocol: `https`,
-  host: `api.github.com`,
-  headers: {
-    'user-agent': `Open Fixture Library`
-  },
-  timeout: 5000
-});
-
 /**
  * @callback pullRequestCreated
- * @param {?any} errorObj If no error occured, this is null. Otherwise it can be any error object or message.
- * @param {?string} pullRequestUrl If an error occured, this is null. Otherwise it is the URL of the created pull request.
+ * @param {?any} errorObj If no error occurred, this is null. Otherwise it can be any error object or message.
+ * @param {?string} pullRequestUrl If an error occurred, this is null. Otherwise it is the URL of the created pull request.
  */
 
 /**
@@ -49,14 +39,14 @@ module.exports = function createPullRequest(out, callback) {
   const changedFiles = [];
   const warnings = [];
 
-  github.authenticate({
+  octokit.authenticate({
     type: `token`,
     token: userToken
   });
 
 
   console.log(`get latest commit hash ...`);
-  github.gitdata.getReference({
+  octokit.gitdata.getReference({
     owner: `OpenLightingProject`,
     repo: repository,
     ref: `heads/master`
@@ -66,7 +56,7 @@ module.exports = function createPullRequest(out, callback) {
       console.log(latestCommitHash);
 
       console.log(`create new branch '${branchName}' ...`);
-      return github.gitdata.createReference({
+      octokit.gitdata.createReference({
         owner: `OpenLightingProject`,
         repo: repository,
         ref: `refs/heads/${branchName}`,
@@ -187,7 +177,7 @@ module.exports = function createPullRequest(out, callback) {
 
       body += `\n\nThank you ${getSubmitterNameMarkdown()}!`;
 
-      return github.pullRequests.create({
+      octokit.pullRequests.create({
         owner: `OpenLightingProject`,
         repo: repository,
         title: title,
@@ -201,7 +191,7 @@ module.exports = function createPullRequest(out, callback) {
       pullRequestUrl = result.data.html_url;
 
       console.log(`add labels to pull request ...`);
-      return github.issues.addLabels({
+      octokit.issues.addLabels({
         owner: `OpenLightingProject`,
         repo: repository,
         number: result.data.number,
@@ -280,7 +270,7 @@ module.exports = function createPullRequest(out, callback) {
   function addOrUpdateFile(filename, displayName, newContentFunction) {
     console.log(`does ${displayName} exist?`);
 
-    return github.repos.getContent({
+    octokit.repos.getContent({
       owner: `OpenLightingProject`,
       repo: repository,
       path: filename
@@ -296,7 +286,7 @@ module.exports = function createPullRequest(out, callback) {
           return Promise.resolve();
         }
 
-        return github.repos.updateFile({
+        octokit.repos.updateFile({
           owner: `OpenLightingProject`,
           repo: repository,
           path: filename,
@@ -316,7 +306,7 @@ module.exports = function createPullRequest(out, callback) {
       })
       .catch(error => {
         console.log(`no -> create it ...`);
-        return github.repos.createFile({
+        octokit.repos.createFile({
           owner: `OpenLightingProject`,
           repo: repository,
           path: filename,

--- a/lib/create-github-pr.js
+++ b/lib/create-github-pr.js
@@ -4,12 +4,6 @@ const fixtureJsonStringify = require(`./fixture-json-stringify.js`);
 require(`./load-env-file.js`);
 
 /**
- * @callback pullRequestCreated
- * @param {?any} errorObj If no error occurred, this is null. Otherwise it can be any error object or message.
- * @param {?string} pullRequestUrl If an error occurred, this is null. Otherwise it is the URL of the created pull request.
- */
-
-/**
  * @typedef importPluginReturn
  * @type {!object}
  * @property {!object} manufacturers like in manufacturers.json
@@ -19,16 +13,15 @@ require(`./load-env-file.js`);
 
 /**
  * @param {!importPluginReturn} out The object like returned by an import plugin.
- * @param {!pullRequestCreated} callback A function to call when finished (in either error or success case).
+ * @returns {!Promise<!string, !Error>} A promise that resolves to the pull request URL, or rejects with an error.
  */
-module.exports = function createPullRequest(out, callback) {
+module.exports = function createPullRequest(out) {
   const repository = process.env.NODE_ENV === `production` ? `open-fixture-library` : `ofl-test`;
 
   const userToken = process.env.GITHUB_USER_TOKEN;
   if (userToken === undefined) {
     console.error(`.env file does not contain GITHUB_USER_TOKEN variable`);
-    callback(`GitHub user token was not set`, null);
-    return;
+    return Promise.reject(new Error(`GitHub user token was not set`));
   }
 
   let pullRequestUrl;
@@ -46,7 +39,7 @@ module.exports = function createPullRequest(out, callback) {
 
 
   console.log(`get latest commit hash ...`);
-  octokit.gitdata.getReference({
+  return octokit.gitdata.getReference({
     owner: `OpenLightingProject`,
     repo: repository,
     ref: `heads/master`
@@ -56,7 +49,7 @@ module.exports = function createPullRequest(out, callback) {
       console.log(latestCommitHash);
 
       console.log(`create new branch '${branchName}' ...`);
-      octokit.gitdata.createReference({
+      return octokit.gitdata.createReference({
         owner: `OpenLightingProject`,
         repo: repository,
         ref: `refs/heads/${branchName}`,
@@ -177,7 +170,7 @@ module.exports = function createPullRequest(out, callback) {
 
       body += `\n\nThank you ${getSubmitterNameMarkdown()}!`;
 
-      octokit.pullRequests.create({
+      return octokit.pullRequests.create({
         owner: `OpenLightingProject`,
         repo: repository,
         title: title,
@@ -191,7 +184,7 @@ module.exports = function createPullRequest(out, callback) {
       pullRequestUrl = result.data.html_url;
 
       console.log(`add labels to pull request ...`);
-      octokit.issues.addLabels({
+      return octokit.issues.addLabels({
         owner: `OpenLightingProject`,
         repo: repository,
         number: result.data.number,
@@ -201,11 +194,11 @@ module.exports = function createPullRequest(out, callback) {
     .then(() => {
       console.log(`done`);
       console.log(`View the pull request at ${pullRequestUrl}`);
-      callback(null, pullRequestUrl);
+      return pullRequestUrl;
     })
     .catch(error => {
       console.error(`Error: ${error.message}`);
-      callback(error.message, null);
+      return Promise.reject(error);
     });
 
 
@@ -270,7 +263,7 @@ module.exports = function createPullRequest(out, callback) {
   function addOrUpdateFile(filename, displayName, newContentFunction) {
     console.log(`does ${displayName} exist?`);
 
-    octokit.repos.getContent({
+    return octokit.repos.getContent({
       owner: `OpenLightingProject`,
       repo: repository,
       path: filename
@@ -286,7 +279,7 @@ module.exports = function createPullRequest(out, callback) {
           return Promise.resolve();
         }
 
-        octokit.repos.updateFile({
+        return octokit.repos.updateFile({
           owner: `OpenLightingProject`,
           repo: repository,
           path: filename,
@@ -306,7 +299,7 @@ module.exports = function createPullRequest(out, callback) {
       })
       .catch(error => {
         console.log(`no -> create it ...`);
-        octokit.repos.createFile({
+        return octokit.repos.createFile({
           owner: `OpenLightingProject`,
           repo: repository,
           path: filename,

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -38,7 +38,7 @@ module.exports = function(plugin, ref, fixtures) {
   const scriptName = path.join(`plugins`, plugin, `export.js`);
 
   // delete old temp folder and recreate it
-  del([tempDir], { force: true })
+  return del([tempDir], { force: true })
     .then(() => mkdirp(tempDir))
 
     // export with current plugin script
@@ -153,6 +153,7 @@ module.exports = function(plugin, ref, fixtures) {
       console.log(`Done.`);
       return outputData;
     });
+
 
   /**
    *

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -172,16 +172,17 @@ module.exports = function(plugin, ref, fixtures) {
 
     const { fixtureFromRepository } = require(path.join(baseDir, `lib`, `model.js`));
 
-    const outFiles = plugin.export(fixtures.map(([man, fix]) => fixtureFromRepository(man, fix)), {
+    return plugin.export(fixtures.map(([man, fix]) => fixtureFromRepository(man, fix)), {
       baseDir: baseDir,
       date: date
-    });
-
-    return Promise.all(outFiles.map(outFile => {
-      const outFilePath = path.join(outputPath, outFile.name);
-      return mkdirp(path.dirname(outFilePath))
-        .then(() => promisify(fs.writeFile)(outFilePath, outFile.content));
-    }));
+    })
+      .then(outFiles => Promise.all(
+        outFiles.map(outFile => {
+          const outFilePath = path.join(outputPath, outFile.name);
+          return mkdirp(path.dirname(outFilePath))
+            .then(() => promisify(fs.writeFile)(outFilePath, outFile.content));
+        })
+      ));
   }
 };
 

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -84,18 +84,14 @@ module.exports = function(plugin, ref, fixtures) {
         })
 
         // delete compare archive
-        .then(() => {
-          return del(compareArchivePath, { force: true });
-        })
+        .then(() => del(compareArchivePath, { force: true }))
 
         // export with compare plugin script
-        .then(() => {
-          return exportFixtures(
-            compareOut,
-            path.join(unzipDir, scriptName),
-            unzipDir
-          );
-        })
+        .then(() => exportFixtures(
+          compareOut,
+          path.join(unzipDir, scriptName),
+          unzipDir
+        ))
         .catch(error => {
           console.error(`${colors.red(`[Error]`)} Exporting with compare plugin script failed:`, error);
           process.exit(1);

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -173,17 +173,21 @@ module.exports = function(plugin, ref, fixtures) {
 
     const { fixtureFromRepository } = require(path.join(baseDir, `lib`, `model.js`));
 
-    return plugin.export(fixtures.map(([man, fix]) => fixtureFromRepository(man, fix)), {
+    const exportResult = plugin.export(fixtures.map(([man, fix]) => fixtureFromRepository(man, fix)), {
       baseDir: baseDir,
       date: date
-    })
-      .then(outFiles => Promise.all(
-        outFiles.map(outFile => {
-          const outFilePath = path.join(outputPath, outFile.name);
-          return mkdirp(path.dirname(outFilePath))
-            .then(() => promisify(fs.writeFile)(outFilePath, outFile.content));
-        })
-      ));
+    });
+
+    // backwards compatibility
+    const promise = exportResult instanceof Promise ? exportResult : Promise.resolve(exportResult);
+
+    return promise.then(outFiles => Promise.all(
+      outFiles.map(outFile => {
+        const outFilePath = path.join(outputPath, outFile.name);
+        return mkdirp(path.dirname(outFilePath))
+          .then(() => promisify(fs.writeFile)(outFilePath, outFile.content));
+      })
+    ));
   }
 };
 

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -1,20 +1,16 @@
 const fs = require(`fs`);
 const path = require(`path`);
 const childProcess = require(`child_process`);
-const del = require(`node-delete`);
 const Zip = require(`node-zip`);
 const colors = require(`colors`);
 const disparity = require(`disparity`);
 const dirCompare = require(`dir-compare`);
+const promisify = require(`util`).promisify;
+const mkdirp = promisify(require(`mkdirp`));
+const del = promisify(require(`node-delete`));
 
 module.exports = function(plugin, ref, fixtures) {
   const date = new Date();
-
-  const outputData = {
-    removedFiles: [],
-    addedFiles: [],
-    changedFiles: {}
-  };
 
   // get manufacturer and fixture data later used by export plugins
   fixtures = fixtures.map(relativePath => {
@@ -25,141 +21,167 @@ module.exports = function(plugin, ref, fixtures) {
     ];
   });
 
-  console.log();
   console.log(`## Diffing plugin output`);
   console.log(`# plugin:`, plugin);
   console.log(`# ref:`, ref);
   console.log(`# fixtures:`, fixtures.map(([man, fix]) => `${man}/${fix}`).join(`, `));
   console.log();
 
-  // delete old temp folder and recreate it
   const tempDir = path.join(__dirname, `..`, `tmp`);
   if (process.cwd().match(tempDir)) {
     console.error(`${colors.red(`[Error]`)} This script can't be run from inside the tmp directory.`);
     process.exit(1);
   }
-  del.sync([tempDir], {force: true});
-  fs.mkdirSync(tempDir);
+
   const currentOut = path.join(tempDir, `current_output`);
   const compareOut = path.join(tempDir, `compare_output`);
-
   const scriptName = path.join(`plugins`, plugin, `export.js`);
 
-  // export with current plugin script
-  exportFixtures(
-    currentOut,
-    path.join(__dirname, `..`, scriptName),
-    path.join(__dirname, `..`)
-  );
+  // delete old temp folder and recreate it
+  del([tempDir], { force: true })
+    .then(() => mkdirp(tempDir))
 
-  // get compare script and fixture files as archive
-  const compareArchive = path.join(tempDir, `compare.zip`);
-  try {
-    childProcess.execSync(`git archive ${ref} -o ${compareArchive}`, {
-      cwd: path.join(__dirname, `..`),
-      encoding: `utf-8`
-    });
-  }
-  catch (e) {
-    console.error(`${colors.red(`[Error]`)} Failed to download compare plugin script: ${e.message}`);
-    process.exit(1);
-  }
+    // export with current plugin script
+    .then(() => exportFixtures(
+      currentOut,
+      path.join(__dirname, `..`, scriptName),
+      path.join(__dirname, `..`)
+    ))
+    .catch(error => {
+      console.error(`${colors.red(`[Error]`)} Exporting with current plugin script failed:`, error);
+      process.exit(1);
+    })
 
-  // unzip archive
-  const unzip = new Zip(fs.readFileSync(compareArchive));
-  const unzipDir = path.join(tempDir, `compareFiles`);
-  fs.mkdirSync(unzipDir);
-  for (let file of Object.keys(unzip.files)) {
-    file = unzip.files[file];
-    const filePath = path.join(unzipDir, file.name);
+    // get compare script and fixture files as archive
+    .then(() => {
+      const compareArchivePath = path.join(tempDir, `compare.zip`);
+      const unzipDir = path.join(tempDir, `compareFiles`);
 
-    if (file.dir) {
-      fs.mkdirSync(filePath);
-    }
-    else {
-      fs.writeFileSync(filePath, file.asNodeBuffer());
-    }
-  }
-  del.sync(compareArchive, {force: true});
+      return promisify(childProcess.exec)(`git archive ${ref} -o ${compareArchivePath}`, {
+        cwd: path.join(__dirname, `..`),
+        encoding: `utf-8`
+      })
+        .catch(error => {
+          console.error(`${colors.red(`[Error]`)} Failed to download compare plugin script: ${error.message}`);
+          process.exit(1);
+        })
 
-  // export with compare plugin script
-  exportFixtures(
-    compareOut,
-    path.join(unzipDir, scriptName),
-    unzipDir
-  );
+        // unzip compare archive
+        .then(() => mkdirp(unzipDir))
+        .then(() => promisify(fs.readFile)(compareArchivePath))
+        .then(compareArchive => {
+          const unzip = new Zip(compareArchive);
 
-  // find the differences
-  const differences = dirCompare.compareSync(compareOut, currentOut, {
-    compareContent: true
-  }).diffSet;
-  for (const difference of differences) {
-    let name;
+          Object.keys(unzip.files).forEach(fileName => {
+            const file = unzip.files[fileName];
+            const filePath = path.join(unzipDir, file.name);
 
-    switch (difference.state) {
-      case `equal`:
-        continue;
+            if (!file.dir) {
+              mkdirp.sync(path.dirname(filePath));
+              fs.writeFileSync(filePath, file.asNodeBuffer());
+            }
+          });
+        })
 
-      case `left`:
-        name = getRelativePath(difference.relativePath, difference.name1, difference.type1);
+        // delete compare archive
+        .then(() => {
+          return del(compareArchivePath, { force: true });
+        })
 
-        console.log(colors.red(`File or directory ${name} was removed.`));
+        // export with compare plugin script
+        .then(() => {
+          return exportFixtures(
+            compareOut,
+            path.join(unzipDir, scriptName),
+            unzipDir
+          );
+        })
+        .catch(error => {
+          console.error(`${colors.red(`[Error]`)} Exporting with compare plugin script failed:`, error);
+          process.exit(1);
+        });
+    })
 
-        outputData.removedFiles.push(name);
-        continue;
+    // find the differences
+    .then(() => dirCompare.compare(compareOut, currentOut, {
+      compareContent: true
+    }))
+    .then(diffResult => {
+      const outputData = {
+        removedFiles: [],
+        addedFiles: [],
+        changedFiles: {}
+      };
 
-      case `right`:
-        name = getRelativePath(difference.relativePath, difference.name2, difference.type2);
+      for (const difference of diffResult.diffSet) {
+        let name;
 
-        console.log(colors.green(`File or directory ${name} was added.`));
+        switch (difference.state) {
+          case `equal`:
+            continue;
 
-        outputData.addedFiles.push(name);
-        continue;
+          case `left`:
+            name = getRelativePath(difference.relativePath, difference.name1, difference.type1);
 
-      case `distinct`: {
-        name = getRelativePath(difference.relativePath, difference.name2, difference.type2);
-        const file1 = fs.readFileSync(path.join(difference.path1, difference.name1), `utf8`);
-        const file2 = fs.readFileSync(path.join(difference.path2, difference.name2), `utf8`);
+            console.log(colors.red(`File or directory ${name} was removed.`));
 
-        console.log(colors.yellow(`Diff for ${name}`));
-        console.log(disparity.unified(file1, file2));
+            outputData.removedFiles.push(name);
+            continue;
 
-        outputData.changedFiles[name] = disparity.unifiedNoColor(file1, file2);
-        continue;
+          case `right`:
+            name = getRelativePath(difference.relativePath, difference.name2, difference.type2);
+
+            console.log(colors.green(`File or directory ${name} was added.`));
+
+            outputData.addedFiles.push(name);
+            continue;
+
+          case `distinct`: {
+            name = getRelativePath(difference.relativePath, difference.name2, difference.type2);
+            const file1 = fs.readFileSync(path.join(difference.path1, difference.name1), `utf8`);
+            const file2 = fs.readFileSync(path.join(difference.path2, difference.name2), `utf8`);
+
+            console.log(colors.yellow(`Diff for ${name}`));
+            console.log(disparity.unified(file1, file2));
+
+            outputData.changedFiles[name] = disparity.unifiedNoColor(file1, file2);
+            continue;
+          }
+        }
       }
-    }
-  }
 
-  console.log(`Done.`);
-  return outputData;
+      console.log(`Done.`);
+      return outputData;
+    });
 
+  /**
+   *
+   * @param {!string} outputPath The path where to output the exported fixtures.
+   * @param {!string} pluginScript The path of the plugin export script.
+   * @param {!string} baseDir The OFL root directory.
+   * @returns {!Promise.<null, !Error>} A Promise that resolves when all exported fixtures are saved to the filesystem.
+   */
   function exportFixtures(outputPath, pluginScript, baseDir) {
-    if (!fs.existsSync(outputPath)) {
-      fs.mkdirSync(outputPath);
-    }
-
     let plugin;
     try {
       plugin = require(pluginScript);
     }
-    catch (e) {
-      console.error(e.message);
-      return;
+    catch (error) {
+      return Promise.reject(error);
     }
 
     const { fixtureFromRepository } = require(path.join(baseDir, `lib`, `model.js`));
+
     const outFiles = plugin.export(fixtures.map(([man, fix]) => fixtureFromRepository(man, fix)), {
       baseDir: baseDir,
       date: date
     });
 
-    for (const outFile of outFiles) {
+    return Promise.all(outFiles.map(outFile => {
       const outFilePath = path.join(outputPath, outFile.name);
-      if (!fs.existsSync(path.dirname(outFilePath))) {
-        fs.mkdirSync(path.dirname(outFilePath));
-      }
-      fs.writeFileSync(outFilePath, outFile.content);
-    }
+      return mkdirp(path.dirname(outFilePath))
+        .then(() => promisify(fs.writeFile)(outFilePath, outFile.content));
+    }));
   }
 };
 
@@ -171,7 +193,7 @@ module.exports = function(plugin, ref, fixtures) {
  */
 function getRelativePath(relativePath, name, type) {
   if (type === `directory`) {
-    return path.join(`.`, relativePath, name, `/`); // the '.' removes a '/' in the beggining of the relative path
+    return path.join(`.`, relativePath, name, `/`); // the '.' removes a '/' in the beginning of the relative path
   }
   return path.join(`.`, relativePath, name);
 }

--- a/main.js
+++ b/main.js
@@ -56,7 +56,8 @@ app.get(`/download.:format([a-z0-9_.-]+)`, (request, response, next) => {
 
   const plugin = require(path.join(__dirname, `plugins`, format, `export.js`));
   plugin.export(fixtures, {
-    baseDir: __dirname
+    baseDir: __dirname,
+    date: new Date()
   }).then(outfiles => downloadFiles(response, outfiles, format));
 });
 
@@ -80,7 +81,8 @@ app.get(`/:manKey/:fixKey.:format([a-z0-9_.-]+)`, (request, response, next) => {
 
   const plugin = require(path.join(__dirname, `plugins`, format, `export.js`));
   plugin.export([fixtureFromRepository(manKey, fixKey)], {
-    baseDir: __dirname
+    baseDir: __dirname,
+    date: new Date()
   }).then(outfiles => downloadFiles(response, outfiles, `${manKey}_${fixKey}_${format}`));
 });
 

--- a/main.js
+++ b/main.js
@@ -58,7 +58,13 @@ app.get(`/download.:format([a-z0-9_.-]+)`, (request, response, next) => {
   plugin.export(fixtures, {
     baseDir: __dirname,
     date: new Date()
-  }).then(outfiles => downloadFiles(response, outfiles, format));
+  })
+    .then(outfiles => downloadFiles(response, outfiles, format))
+    .catch(error => {
+      response
+        .status(500)
+        .send(`Exporting all fixtures with ${format} failed: ${error.toString()}`);
+    });
 });
 
 app.get(`/:manKey/:fixKey.:format([a-z0-9_.-]+)`, (request, response, next) => {
@@ -83,7 +89,13 @@ app.get(`/:manKey/:fixKey.:format([a-z0-9_.-]+)`, (request, response, next) => {
   plugin.export([fixtureFromRepository(manKey, fixKey)], {
     baseDir: __dirname,
     date: new Date()
-  }).then(outfiles => downloadFiles(response, outfiles, `${manKey}_${fixKey}_${format}`));
+  })
+    .then(outfiles => downloadFiles(response, outfiles, `${manKey}_${fixKey}_${format}`))
+    .catch(error => {
+      response
+        .status(500)
+        .send(`Exporting fixture ${manKey}/${fixKey} with ${format} failed: ${error.toString()}`);
+    });
 });
 
 app.get(`/sitemap.xml`, (request, response) => {

--- a/main.js
+++ b/main.js
@@ -55,11 +55,9 @@ app.get(`/download.:format([a-z0-9_.-]+)`, (request, response, next) => {
   });
 
   const plugin = require(path.join(__dirname, `plugins`, format, `export.js`));
-  const outfiles = plugin.export(fixtures, {
+  plugin.export(fixtures, {
     baseDir: __dirname
-  });
-
-  downloadFiles(response, outfiles, format);
+  }).then(outfiles => downloadFiles(response, outfiles, format));
 });
 
 app.get(`/:manKey/:fixKey.:format([a-z0-9_.-]+)`, (request, response, next) => {
@@ -81,11 +79,9 @@ app.get(`/:manKey/:fixKey.:format([a-z0-9_.-]+)`, (request, response, next) => {
   }
 
   const plugin = require(path.join(__dirname, `plugins`, format, `export.js`));
-  const outfiles = plugin.export([fixtureFromRepository(manKey, fixKey)], {
+  plugin.export([fixtureFromRepository(manKey, fixKey)], {
     baseDir: __dirname
-  });
-
-  downloadFiles(response, outfiles, `${manKey}_${fixKey}_${format}`);
+  }).then(outfiles => downloadFiles(response, outfiles, `${manKey}_${fixKey}_${format}`));
 });
 
 app.get(`/sitemap.xml`, (request, response) => {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "disparity": "^2.0.0",
     "eslint": "^5.0.0",
     "eslint-plugin-json": "^1.2.0",
+    "eslint-plugin-promise": "^4.0.0",
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-vue": "^4.3.0",
     "libxml-xsd": "^0.5.2",

--- a/plugins/d-light/export.js
+++ b/plugins/d-light/export.js
@@ -54,7 +54,7 @@ module.exports.export = function exportDLight(fixtures, options) {
     }
   }
 
-  return deviceFiles;
+  return Promise.resolve(deviceFiles);
 };
 
 /**

--- a/plugins/d-light/export.js
+++ b/plugins/d-light/export.js
@@ -11,6 +11,13 @@ const {
 module.exports.name = `D::Light`;
 module.exports.version = `0.1.0`;
 
+/**
+ * @param {!Array.<Fixture>} fixtures An array of Fixture objects.
+ * @param {!object} options Global options, including:
+ * @param {!string} options.baseDir Absolute path to OFL's root directory.
+ * @param {?Date} options.date The current time.
+ * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
+*/
 module.exports.export = function exportDLight(fixtures, options) {
   const deviceFiles = [];
 

--- a/plugins/d-light/exportTests/attributes-correctness.js
+++ b/plugins/d-light/exportTests/attributes-correctness.js
@@ -1,23 +1,20 @@
 const xml2js = require(`xml2js`);
+const promisify = require(`util`).promisify;
 
 /**
  * @param {!object} exportFile The file returned by the plugins' export module.
  * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
  * @param {!string} exportFile.content File content.
  * @param {!string} exportFile.mimetype File mime type.
- * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @param {?Array.<!Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {?string} exportFile.mode Mode's shortName if given file only describes a single mode.
- * @returns {!Promise} Resolve when the test passes or reject with an array of errors if the test fails.
+ * @returns {!Promise.<undefined, !Array.<!string>|!string>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
 **/
 module.exports = function testAttributesCorrectness(exportFile) {
-  return new Promise((resolve, reject) => {
-    const parser = new xml2js.Parser();
+  const parser = new xml2js.Parser();
 
-    parser.parseString(exportFile.content, (parseError, xml) => {
-      if (parseError) {
-        return reject([`Error parsing XML: ${parseError.toString()}`]);
-      }
-
+  return promisify(parser.parseString)(exportFile.content)
+    .then(xml => {
       const errors = [];
 
       const attrDefs = xml.Device.Attributes[0].AttributesDefinition;
@@ -37,9 +34,10 @@ module.exports = function testAttributesCorrectness(exportFile) {
       }
 
       if (errors.length > 0) {
-        return reject(errors);
+        return Promise.reject(errors);
       }
-      return resolve();
-    });
-  });
+
+      return Promise.resolve();
+    })
+    .catch(parseError => Promise.reject(`Error parsing XML: ${parseError.toString()}`));
 };

--- a/plugins/ecue/export.js
+++ b/plugins/ecue/export.js
@@ -70,7 +70,7 @@ module.exports.export = function exportEcue(fixtures, options) {
     }
   }
 
-  return [{
+  return Promise.resolve([{
     name: `UserLibrary.xml`,
     content: xml.end({
       pretty: true,
@@ -78,7 +78,7 @@ module.exports.export = function exportEcue(fixtures, options) {
     }),
     mimetype: `application/xml`,
     fixtures: fixtures
-  }];
+  }]);
 };
 
 /**

--- a/plugins/ecue/export.js
+++ b/plugins/ecue/export.js
@@ -19,9 +19,6 @@ module.exports.version = `0.3.0`;
  * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
 */
 module.exports.export = function exportECue(fixtures, options) {
-  if (!(`date` in options)) {
-    options.date = new Date();
-  }
   const timestamp = dateToString(options.date);
 
   const manufacturers = {};

--- a/plugins/ecue/export.js
+++ b/plugins/ecue/export.js
@@ -11,6 +11,13 @@ const {
 module.exports.name = `e:cue`;
 module.exports.version = `0.3.0`;
 
+/**
+ * @param {!Array.<Fixture>} fixtures An array of Fixture objects.
+ * @param {!object} options Global options, including:
+ * @param {!string} options.baseDir Absolute path to OFL's root directory.
+ * @param {?Date} options.date The current time.
+ * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
+*/
 module.exports.export = function exportEcue(fixtures, options) {
   if (!(`date` in options)) {
     options.date = new Date();

--- a/plugins/ecue/export.js
+++ b/plugins/ecue/export.js
@@ -18,7 +18,7 @@ module.exports.version = `0.3.0`;
  * @param {?Date} options.date The current time.
  * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
 */
-module.exports.export = function exportEcue(fixtures, options) {
+module.exports.export = function exportECue(fixtures, options) {
   if (!(`date` in options)) {
     options.date = new Date();
   }

--- a/plugins/ecue/import.js
+++ b/plugins/ecue/import.js
@@ -10,7 +10,7 @@ for (const hex of Object.keys(colorNames)) {
   colors[colorNames[hex].toLowerCase().replace(/\s/g, ``)] = hex;
 }
 
-module.exports.import = function importEcue(str, filename) {
+module.exports.import = function importEcue(buffer, filename) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);
 
@@ -20,7 +20,7 @@ module.exports.import = function importEcue(str, filename) {
     warnings: {}
   };
 
-  return promisify(parser.parseString)(str)
+  return promisify(parser.parseString)(buffer.toString())
     .then(xml => {
       if (!(`Library` in xml.Document) || !(`Fixtures` in xml.Document.Library[0]) || !(`Manufacturer` in xml.Document.Library[0].Fixtures[0])) {
         throw new Error(`Nothing to import.`);

--- a/plugins/ecue/import.js
+++ b/plugins/ecue/import.js
@@ -15,7 +15,7 @@ for (const hex of Object.keys(colorNames)) {
  * @param {!string} filename The imported file's name.
  * @returns {!Promise.<!object, !Error>} A Promise resolving to an out object
 **/
-module.exports.import = function importEcue(buffer, filename) {
+module.exports.import = function importECue(buffer, filename) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);
 

--- a/plugins/ecue/import.js
+++ b/plugins/ecue/import.js
@@ -10,6 +10,11 @@ for (const hex of Object.keys(colorNames)) {
   colors[colorNames[hex].toLowerCase().replace(/\s/g, ``)] = hex;
 }
 
+/**
+ * @param {!Buffer} buffer The imported file.
+ * @param {!string} filename The imported file's name.
+ * @returns {!Promise.<!object, !Error>} A Promise resolving to an out object
+**/
 module.exports.import = function importEcue(buffer, filename) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);

--- a/plugins/ecue/import.js
+++ b/plugins/ecue/import.js
@@ -1,5 +1,6 @@
 const colorNames = require(`color-names`);
 const xml2js = require(`xml2js`);
+const promisify = require(`util`).promisify;
 
 module.exports.name = `e:cue`;
 module.exports.version = `0.3.1`;
@@ -9,7 +10,7 @@ for (const hex of Object.keys(colorNames)) {
   colors[colorNames[hex].toLowerCase().replace(/\s/g, ``)] = hex;
 }
 
-module.exports.import = function importEcue(str, filename, resolve, reject) {
+module.exports.import = function importEcue(str, filename) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);
 
@@ -19,16 +20,7 @@ module.exports.import = function importEcue(str, filename, resolve, reject) {
     warnings: {}
   };
 
-  new Promise((res, rej) => {
-    parser.parseString(str, (parseError, xml) => {
-      if (parseError) {
-        rej(parseError);
-      }
-      else {
-        res(xml);
-      }
-    });
-  })
+  return promisify(parser.parseString)(str)
     .then(xml => {
       if (!(`Library` in xml.Document) || !(`Fixtures` in xml.Document.Library[0]) || !(`Manufacturer` in xml.Document.Library[0].Fixtures[0])) {
         throw new Error(`Nothing to import.`);
@@ -57,10 +49,7 @@ module.exports.import = function importEcue(str, filename, resolve, reject) {
         }
       }
 
-      resolve(out);
-    })
-    .catch(parseError => {
-      reject(`Error parsing '${filename}'.\n${parseError.toString()}`);
+      return out;
     });
 
 

--- a/plugins/millumin/export.js
+++ b/plugins/millumin/export.js
@@ -9,7 +9,7 @@ module.exports.supportedOflVersion = `7.3.0`;
 
 module.exports.export = function exportMillumin(fixtures, options) {
   // one JSON file for each fixture
-  return fixtures.map(fixture => {
+  const outFiles = fixtures.map(fixture => {
     let jsonData = JSON.parse(JSON.stringify(fixture.jsonObject));
     jsonData.$schema = `https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/schema-${module.exports.supportedOflVersion}/schemas/fixture.json`;
 
@@ -57,6 +57,8 @@ module.exports.export = function exportMillumin(fixtures, options) {
       fixtures: [fixture]
     };
   });
+
+  return Promise.resolve(outFiles);
 };
 
 /**

--- a/plugins/millumin/export.js
+++ b/plugins/millumin/export.js
@@ -7,6 +7,13 @@ module.exports.version = `0.3.0`;
 // needed for export test
 module.exports.supportedOflVersion = `7.3.0`;
 
+/**
+ * @param {!Array.<Fixture>} fixtures An array of Fixture objects.
+ * @param {!object} options Global options, including:
+ * @param {!string} options.baseDir Absolute path to OFL's root directory.
+ * @param {?Date} options.date The current time.
+ * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
+*/
 module.exports.export = function exportMillumin(fixtures, options) {
   // one JSON file for each fixture
   const outFiles = fixtures.map(fixture => {

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -12,9 +12,9 @@ const schemaPromises = SCHEMA_FILES.map(filename => getSchema(SCHEMA_BASE_URL + 
  * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
  * @param {!string} exportFile.content File content.
  * @param {!string} exportFile.mimetype File mime type.
- * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @param {?Array.<!Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {?string} exportFile.mode Mode's shortName if given file only describes a single mode.
- * @returns {!Promise} Resolve when the test passes or reject with an error or an array of errors if the test fails.
+ * @returns {!Promise.<undefined, !Array.<!string>|!string>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
 **/
 module.exports = function testSchemaConformity(exportFile) {
   return Promise.all(schemaPromises).then(schemas => {

--- a/plugins/ofl/export.js
+++ b/plugins/ofl/export.js
@@ -5,6 +5,13 @@ const manufacturers = require(`../../fixtures/manufacturers.json`);
 module.exports.name = `Open Fixture Library JSON`;
 module.exports.version = require(`../../schemas/fixture.json`).version;
 
+/**
+ * @param {!Array.<Fixture>} fixtures An array of Fixture objects.
+ * @param {!object} options Global options, including:
+ * @param {!string} options.baseDir Absolute path to OFL's root directory.
+ * @param {?Date} options.date The current time.
+ * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
+*/
 module.exports.export = function exportOFL(fixtures, options) {
   const usedManufacturers = new Set();
 

--- a/plugins/ofl/export.js
+++ b/plugins/ofl/export.js
@@ -43,5 +43,5 @@ module.exports.export = function exportOFL(fixtures, options) {
     mimetype: `application/ofl-manufacturers`
   });
 
-  return files;
+  return Promise.resolve(files);
 };

--- a/plugins/ofl/export.js
+++ b/plugins/ofl/export.js
@@ -12,7 +12,7 @@ module.exports.version = require(`../../schemas/fixture.json`).version;
  * @param {?Date} options.date The current time.
  * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
 */
-module.exports.export = function exportOFL(fixtures, options) {
+module.exports.export = function exportOfl(fixtures, options) {
   const usedManufacturers = new Set();
 
   // one JSON file for each fixture

--- a/plugins/qlcplus_4.11.2/export.js
+++ b/plugins/qlcplus_4.11.2/export.js
@@ -32,7 +32,7 @@ module.exports.version = `0.5.0`;
  * @param {?Date} options.date The current time.
  * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
 */
-module.exports.export = function exportQLCplus(fixtures, options) {
+module.exports.export = function exportQlcPlus(fixtures, options) {
   const outFiles = fixtures.map(fixture => {
     const xml = xmlbuilder.begin()
       .declaration(`1.0`, `UTF-8`)

--- a/plugins/qlcplus_4.11.2/export.js
+++ b/plugins/qlcplus_4.11.2/export.js
@@ -26,7 +26,7 @@ module.exports.name = `QLC+ 4.11.2`;
 module.exports.version = `0.5.0`;
 
 module.exports.export = function exportQLCplus(fixtures, options) {
-  return fixtures.map(fixture => {
+  const outFiles = fixtures.map(fixture => {
     const xml = xmlbuilder.begin()
       .declaration(`1.0`, `UTF-8`)
       .element({
@@ -62,6 +62,8 @@ module.exports.export = function exportQLCplus(fixtures, options) {
       fixtures: [fixture]
     };
   });
+
+  return Promise.resolve(outFiles);
 };
 
 /**

--- a/plugins/qlcplus_4.11.2/export.js
+++ b/plugins/qlcplus_4.11.2/export.js
@@ -25,6 +25,13 @@ const {
 module.exports.name = `QLC+ 4.11.2`;
 module.exports.version = `0.5.0`;
 
+/**
+ * @param {!Array.<Fixture>} fixtures An array of Fixture objects.
+ * @param {!object} options Global options, including:
+ * @param {!string} options.baseDir Absolute path to OFL's root directory.
+ * @param {?Date} options.date The current time.
+ * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
+*/
 module.exports.export = function exportQLCplus(fixtures, options) {
   const outFiles = fixtures.map(fixture => {
     const xml = xmlbuilder.begin()

--- a/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
+++ b/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
@@ -1,5 +1,6 @@
 const https = require(`https`);
-const xsd = require(`libxml-xsd`);
+const promisify = require(`util`).promisify;
+const parseXsd = promisify(require(`libxml-xsd`).parse);
 
 const SCHEMA_URL = `https://raw.githubusercontent.com/mcallegari/qlcplus/QLC+_4.11.2/resources/schemas/fixture.xsd`;
 
@@ -8,9 +9,9 @@ const SCHEMA_URL = `https://raw.githubusercontent.com/mcallegari/qlcplus/QLC+_4.
  * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
  * @param {!string} exportFile.content File content.
  * @param {!string} exportFile.mimetype File mime type.
- * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @param {?Array.<!Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {?string} exportFile.mode Mode's shortName if given file only describes a single mode.
- * @returns {!Promise} Resolve when the test passes or reject with an array of errors if the test fails.
+ * @returns {!Promise.<undefined, !Array.<!string>|!string>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
 **/
 module.exports = function testSchemaConformity(exportFile) {
   return new Promise((resolve, reject) => {
@@ -24,24 +25,13 @@ module.exports = function testSchemaConformity(exportFile) {
       });
     });
   })
-    .then(schemaData => new Promise((resolve, reject) => {
-      xsd.parse(schemaData, (err, schema) => {
-        if (err) {
-          reject([err]);
-        }
-        else {
-          schema.validate(exportFile.content, (err, validationErrors) => {
-            if (err) {
-              reject([err]);
-            }
-            else if (validationErrors) {
-              reject(validationErrors.map(err => err.message));
-            }
-            else {
-              resolve();
-            }
-          });
-        }
-      });
-    }));
+    .then(schemaData => parseXsd(schemaData))
+    .then(schema => promisify(schema.validate)(exportFile.content))
+    .then(validationErrors => {
+      if (validationErrors) {
+        return Promise.reject(validationErrors.map(err => err.message));
+      }
+
+      return Promise.resolve();
+    });
 };

--- a/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
+++ b/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
@@ -26,7 +26,7 @@ module.exports = function testSchemaConformity(exportFile) {
     });
   })
     .then(schemaData => parseXsd(schemaData))
-    .then(schema => promisify(schema.validate)(exportFile.content))
+    .then(schema => schema.validate(exportFile.content))
     .then(validationErrors => {
       if (validationErrors) {
         return Promise.reject(validationErrors.map(err => err.message));

--- a/plugins/qlcplus_4.11.2/import.js
+++ b/plugins/qlcplus_4.11.2/import.js
@@ -4,7 +4,7 @@ const promisify = require(`util`).promisify;
 module.exports.name = `QLC+ 4.11.2`;
 module.exports.version = `0.4.2`;
 
-module.exports.import = function importQLCplus(str, filename) {
+module.exports.import = function importQLCplus(buffer, filename) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);
 
@@ -17,7 +17,7 @@ module.exports.import = function importQLCplus(str, filename) {
     $schema: `https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json`
   };
 
-  return promisify(parser.parseString)(str)
+  return promisify(parser.parseString)(buffer.toString())
     .then(xml => {
       const qlcPlusFixture = xml.FixtureDefinition;
       fixture.name = qlcPlusFixture.Model[0];

--- a/plugins/qlcplus_4.11.2/import.js
+++ b/plugins/qlcplus_4.11.2/import.js
@@ -4,6 +4,11 @@ const promisify = require(`util`).promisify;
 module.exports.name = `QLC+ 4.11.2`;
 module.exports.version = `0.4.2`;
 
+/**
+ * @param {!Buffer} buffer The imported file.
+ * @param {!string} filename The imported file's name.
+ * @returns {!Promise.<!object, !Error>} A Promise resolving to an out object
+**/
 module.exports.import = function importQLCplus(buffer, filename) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);

--- a/plugins/qlcplus_4.11.2/import.js
+++ b/plugins/qlcplus_4.11.2/import.js
@@ -9,7 +9,7 @@ module.exports.version = `0.4.2`;
  * @param {!string} filename The imported file's name.
  * @returns {!Promise.<!object, !Error>} A Promise resolving to an out object
 **/
-module.exports.import = function importQLCplus(buffer, filename) {
+module.exports.import = function importQlcPlus(buffer, filename) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);
 

--- a/plugins/qlcplus_4.11.2/import.js
+++ b/plugins/qlcplus_4.11.2/import.js
@@ -1,9 +1,10 @@
 const xml2js = require(`xml2js`);
+const promisify = require(`util`).promisify;
 
 module.exports.name = `QLC+ 4.11.2`;
 module.exports.version = `0.4.2`;
 
-module.exports.import = function importQLCplus(str, filename, resolve, reject) {
+module.exports.import = function importQLCplus(str, filename) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);
 
@@ -16,16 +17,7 @@ module.exports.import = function importQLCplus(str, filename, resolve, reject) {
     $schema: `https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json`
   };
 
-  new Promise((res, rej) => {
-    parser.parseString(str, (parseError, xml) => {
-      if (parseError) {
-        rej(parseError);
-      }
-      else {
-        res(xml);
-      }
-    });
-  })
+  return promisify(parser.parseString)(str)
     .then(xml => {
       const qlcPlusFixture = xml.FixtureDefinition;
       fixture.name = qlcPlusFixture.Model[0];
@@ -76,10 +68,7 @@ module.exports.import = function importQLCplus(str, filename, resolve, reject) {
 
       out.fixtures[fixKey] = fixture;
 
-      resolve(out);
-    })
-    .catch(parseError => {
-      reject(`Error parsing '${filename}'.\n${parseError.toString()}`);
+      return out;
     });
 };
 

--- a/plugins/qlcplus_4.12.0/export.js
+++ b/plugins/qlcplus_4.12.0/export.js
@@ -40,7 +40,7 @@ module.exports.name = `QLC+ 4.12.0`;
 module.exports.version = `1.0.0`;
 
 module.exports.export = function exportQLCplus(fixtures, options) {
-  return fixtures.map(fixture => {
+  const outFiles = fixtures.map(fixture => {
     const xml = xmlbuilder.begin()
       .declaration(`1.0`, `UTF-8`)
       .element({
@@ -80,6 +80,8 @@ module.exports.export = function exportQLCplus(fixtures, options) {
       mimetype: `application/x-qlc-fixture`
     };
   });
+
+  return Promise.resolve(outFiles);
 };
 
 /**

--- a/plugins/qlcplus_4.12.0/export.js
+++ b/plugins/qlcplus_4.12.0/export.js
@@ -39,6 +39,13 @@ const capabilityHelpers = {
 module.exports.name = `QLC+ 4.12.0`;
 module.exports.version = `1.0.0`;
 
+/**
+ * @param {!Array.<Fixture>} fixtures An array of Fixture objects.
+ * @param {!object} options Global options, including:
+ * @param {!string} options.baseDir Absolute path to OFL's root directory.
+ * @param {?Date} options.date The current time.
+ * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
+*/
 module.exports.export = function exportQLCplus(fixtures, options) {
   const outFiles = fixtures.map(fixture => {
     const xml = xmlbuilder.begin()

--- a/plugins/qlcplus_4.12.0/export.js
+++ b/plugins/qlcplus_4.12.0/export.js
@@ -46,7 +46,7 @@ module.exports.version = `1.0.0`;
  * @param {?Date} options.date The current time.
  * @returns {!Promise.<!Array.<object>, !Error>} The generated files.
 */
-module.exports.export = function exportQLCplus(fixtures, options) {
+module.exports.export = function exportQlcPlus(fixtures, options) {
   const outFiles = fixtures.map(fixture => {
     const xml = xmlbuilder.begin()
       .declaration(`1.0`, `UTF-8`)

--- a/plugins/qlcplus_4.12.0/exportTests/fixture-tool-validation.js
+++ b/plugins/qlcplus_4.12.0/exportTests/fixture-tool-validation.js
@@ -20,9 +20,9 @@ const EXPORTED_FIXTURE_PATH = `resources/fixtures/manufacturer/fixture.qxf`;
  * @param {!string} exportFile.name File name, may include slashes to provide a folder structure.
  * @param {!string} exportFile.content File content.
  * @param {!string} exportFile.mimetype File mime type.
- * @param {?Array.<Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be ommited if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @param {?Array.<!Fixture>} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {?string} exportFile.mode Mode's shortName if given file only describes a single mode.
- * @returns {!Promise} Resolve when the test passes or reject with an error or an array of errors if the test fails.
+ * @returns {!Promise.<undefined, !Array.<!string>|!string>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
 **/
 module.exports = function testFixtureToolValidation(exportFile) {
   let directory;

--- a/plugins/qlcplus_4.12.0/exportTests/xsd-schema-conformity.js
+++ b/plugins/qlcplus_4.12.0/exportTests/xsd-schema-conformity.js
@@ -26,7 +26,7 @@ module.exports = function testSchemaConformity(exportFile) {
     });
   })
     .then(schemaData => parseXsd(schemaData))
-    .then(schema => promisify(schema.validate)(exportFile.content))
+    .then(schema => schema.validate(exportFile.content))
     .then(validationErrors => {
       if (validationErrors) {
         return Promise.reject(validationErrors.map(err => err.message));

--- a/server/webhook.js
+++ b/server/webhook.js
@@ -26,9 +26,9 @@ for (const deployment of Object.keys(pm2config.deploy)) {
   startServer(webhooks[deployment].port, deployment);
 }
 
-Promise.all(servers).then(
-  () => console.log(`Exited`)
-);
+Promise.all(servers)
+  .then(() => console.log(`Exited`))
+  .catch(error => console.error(`Exited with error`, error));
 
 
 /**

--- a/tests/fixtures-valid.js
+++ b/tests/fixtures-valid.js
@@ -152,7 +152,7 @@ Promise.all(promises).then(results => {
   let totalWarnings = 0;
 
   // each file
-  for (const result of results) {
+  results.forEach(result => {
     const failed = result.errors.length > 0;
 
     console.log(
@@ -169,7 +169,7 @@ Promise.all(promises).then(results => {
     for (const warning of result.warnings) {
       console.log(`└`, colors.yellow(`Warning:`), warning);
     }
-  }
+  });
 
   // newline
   console.log();
@@ -186,4 +186,4 @@ Promise.all(promises).then(results => {
 
   console.error(colors.red(`[FAIL]`), `${totalFails} of ${results.length} tested files failed.`);
   process.exit(1);
-});
+}).catch(error => console.error(colors.red(`[Error]`), `Test errored:`, error));

--- a/tests/github/export-diff.js
+++ b/tests/github/export-diff.js
@@ -123,7 +123,7 @@ pullRequest.checkEnv()
     }
 
     let lines = [
-      `You can run view your uncommitted changes in plugin exports manually by executing:`,
+      `You can view your uncommitted changes in plugin exports manually by executing:`,
       `\`$ node cli/diff-plugin-outputs.js -p <plugin name> <fixtures>\``,
       ``
     ];

--- a/tests/github/exports-valid.js
+++ b/tests/github/exports-valid.js
@@ -202,30 +202,30 @@ function getTasksForFixtures(changedComponents) {
 function getTaskPromise(task) {
   const plugin = require(path.join(__dirname, `../../plugins/${task.pluginKey}/export.js`));
   const test = require(path.join(__dirname, `../../plugins/${task.pluginKey}/exportTests/${task.testKey}.js`));
-  const files = plugin.export([fixtureFromRepository(task.manKey, task.fixKey)]);
 
-  let failed = false;
-  return Promise.all(files.map(
-    file => test(file)
-      .then(() => {
-        return `    <li>:heavy_check_mark: ${file.name}</li>`;
-      })
-      .catch(err => {
-        failed = true;
-        const errors = Array.isArray(err) ? err : [err];
-        return `    <li><details><summary>:x: ${file.name}</summary>${errors.join(`\n`)}</details></li>`;
-      })
-  ))
-    .then(resultLines => {
-      const emoji = failed ? `:x:` : `:heavy_check_mark:`;
+  return plugin.export([fixtureFromRepository(task.manKey, task.fixKey)])
+    .then(files => {
+      let failed = false;
 
-      return [
-        `<details>`,
-        `  <summary>${emoji} <strong>${task.manKey} / ${task.fixKey}:</strong> ${task.pluginKey} / ${task.testKey}</summary>`,
-        `  <ul>`
-      ].concat(resultLines).concat([
-        `  </ul>`,
-        `</details>`
-      ]);
+      return Promise.all(files.map(
+        file => test(file)
+          .then(() => `    <li>:heavy_check_mark: ${file.name}</li>`)
+          .catch(err => {
+            failed = true;
+            const errors = Array.isArray(err) ? err : [err];
+            return `    <li><details><summary>:x: ${file.name}</summary>${errors.join(`\n`)}</details></li>`;
+          })
+      )).then(resultLines => {
+        const emoji = failed ? `:x:` : `:heavy_check_mark:`;
+
+        return [].concat(
+          `<details>`,
+          `  <summary>${emoji} <strong>${task.manKey} / ${task.fixKey}:</strong> ${task.pluginKey} / ${task.testKey}</summary>`,
+          `  <ul>`,
+          resultLines,
+          `  </ul>`,
+          `</details>`
+        );
+      });
     });
 }

--- a/tests/github/exports-valid.js
+++ b/tests/github/exports-valid.js
@@ -203,29 +203,31 @@ function getTaskPromise(task) {
   const plugin = require(path.join(__dirname, `../../plugins/${task.pluginKey}/export.js`));
   const test = require(path.join(__dirname, `../../plugins/${task.pluginKey}/exportTests/${task.testKey}.js`));
 
-  return plugin.export([fixtureFromRepository(task.manKey, task.fixKey)])
-    .then(files => {
-      let failed = false;
+  return plugin.export([fixtureFromRepository(task.manKey, task.fixKey)], {
+    baseDir: path.join(__dirname, `../..`),
+    date: new Date()
+  }).then(files => {
+    let failed = false;
 
-      return Promise.all(files.map(
-        file => test(file)
-          .then(() => `    <li>:heavy_check_mark: ${file.name}</li>`)
-          .catch(err => {
-            failed = true;
-            const errors = Array.isArray(err) ? err : [err];
-            return `    <li><details><summary>:x: ${file.name}</summary>${errors.join(`\n`)}</details></li>`;
-          })
-      )).then(resultLines => {
-        const emoji = failed ? `:x:` : `:heavy_check_mark:`;
+    return Promise.all(files.map(
+      file => test(file)
+        .then(() => `    <li>:heavy_check_mark: ${file.name}</li>`)
+        .catch(err => {
+          failed = true;
+          const errors = Array.isArray(err) ? err : [err];
+          return `    <li><details><summary>:x: ${file.name}</summary>${errors.join(`\n`)}</details></li>`;
+        })
+    )).then(resultLines => {
+      const emoji = failed ? `:x:` : `:heavy_check_mark:`;
 
-        return [].concat(
-          `<details>`,
-          `  <summary>${emoji} <strong>${task.manKey} / ${task.fixKey}:</strong> ${task.pluginKey} / ${task.testKey}</summary>`,
-          `  <ul>`,
-          resultLines,
-          `  </ul>`,
-          `</details>`
-        );
-      });
+      return [].concat(
+        `<details>`,
+        `  <summary>${emoji} <strong>${task.manKey} / ${task.fixKey}:</strong> ${task.pluginKey} / ${task.testKey}</summary>`,
+        `  <ul>`,
+        resultLines,
+        `  </ul>`,
+        `</details>`
+      );
     });
+  });
 }

--- a/tests/github/exports-valid.js
+++ b/tests/github/exports-valid.js
@@ -202,14 +202,13 @@ function getTasksForFixtures(changedComponents) {
 function getTaskPromise(task) {
   const plugin = require(path.join(__dirname, `../../plugins/${task.pluginKey}/export.js`));
   const test = require(path.join(__dirname, `../../plugins/${task.pluginKey}/exportTests/${task.testKey}.js`));
+  let failed = false;
 
   return plugin.export([fixtureFromRepository(task.manKey, task.fixKey)], {
     baseDir: path.join(__dirname, `../..`),
     date: new Date()
-  }).then(files => {
-    let failed = false;
-
-    return Promise.all(files.map(
+  })
+    .then(files => Promise.all(files.map(
       file => test(file)
         .then(() => `    <li>:heavy_check_mark: ${file.name}</li>`)
         .catch(err => {
@@ -217,7 +216,8 @@ function getTaskPromise(task) {
           const errors = Array.isArray(err) ? err : [err];
           return `    <li><details><summary>:x: ${file.name}</summary>${errors.join(`\n`)}</details></li>`;
         })
-    )).then(resultLines => {
+    )))
+    .then(resultLines => {
       const emoji = failed ? `:x:` : `:heavy_check_mark:`;
 
       return [].concat(
@@ -229,5 +229,4 @@ function getTaskPromise(task) {
         `</details>`
       );
     });
-  });
 }

--- a/tests/http-status.js
+++ b/tests/http-status.js
@@ -4,7 +4,6 @@ const path = require(`path`);
 const colors = require(`colors`);
 const childProcess = require(`child_process`);
 const blc = require(`broken-link-checker`);
-const promisify = require(`util`).promisify;
 const pullRequest = require(`./github/pull-request.js`);
 
 

--- a/tests/http-status.js
+++ b/tests/http-status.js
@@ -66,11 +66,6 @@ const serverProcess = childProcess.execFile(`node`, [path.join(__dirname, `..`, 
 }, (error, stdout, stderr) => {
   // when the server process stops
 
-  if (error) {
-    console.log(colors.red(`Error]`), `Server process errored:`, error);
-    process.exit(1);
-  }
-
   console.log();
   if (stdout) {
     console.log(colors.yellow(`Server output (stdout):`));

--- a/tests/http-status.js
+++ b/tests/http-status.js
@@ -109,7 +109,7 @@ const serverProcess = childProcess.execFile(`node`, [path.join(__dirname, `..`, 
         console.error(`Creating / updating the GitHub PR comment failed.`, error);
       })
     )
-    .finally(() => {
+    .then(() => {
       console.log(statusStr, lines.join(`\n`));
       process.exit(exitCode);
     })

--- a/ui/ajax/add-fixtures.js
+++ b/ui/ajax/add-fixtures.js
@@ -11,6 +11,7 @@ module.exports = function addFixtures(request, response) {
   let pullRequestUrl;
   let error;
 
+  // eslint-disable-next-line promise/catch-or-return
   createPullRequest(getOutObjectFromEditorData(request.body.fixtures))
     .then(prUrl => {
       pullRequestUrl = prUrl;
@@ -18,7 +19,7 @@ module.exports = function addFixtures(request, response) {
     .catch(err => {
       error = err.message;
     })
-    .then(() => response.status(201).json({
+    .finally(() => response.status(201).json({
       pullRequestUrl,
       error
     }));

--- a/ui/ajax/add-fixtures.js
+++ b/ui/ajax/add-fixtures.js
@@ -19,7 +19,7 @@ module.exports = function addFixtures(request, response) {
     .catch(err => {
       error = err.message;
     })
-    .finally(() => response.status(201).json({
+    .then(() => response.status(201).json({
       pullRequestUrl,
       error
     }));

--- a/ui/ajax/add-fixtures.js
+++ b/ui/ajax/add-fixtures.js
@@ -8,12 +8,20 @@ const { checkFixture } = require(`../../tests/fixture-valid.js`);
  * @param {!object} response Passed from Express.
  */
 module.exports = function addFixtures(request, response) {
-  createPullRequest(getOutObjectFromEditorData(request.body.fixtures), (error, pullRequestUrl) => {
-    response.status(201).json({
-      pullRequestUrl: pullRequestUrl,
-      error: error
-    });
-  });
+  let pullRequestUrl;
+  let error;
+
+  createPullRequest(getOutObjectFromEditorData(request.body.fixtures))
+    .then(prUrl => {
+      pullRequestUrl = prUrl;
+    })
+    .catch(err => {
+      error = err.message;
+    })
+    .then(() => response.status(201).json({
+      pullRequestUrl,
+      error
+    }));
 };
 
 


### PR DESCRIPTION
* `createPullRequest` is updated to no longer use the deprecated octokit options.
* `createPullRequest` now returns a Promise.
* Import plugins now return a Promise instead of calling the passed `resolve` and `reject` functions.
* Pass file buffer instead of file content string to import plugins.
* Export plugins can now be implemented asynchronously because they must now return a Promise instead of the result directly.
* Plugin docs are updated.
* Use promisified functions where they make the code more concise and easier to read.
* Add JSDoc comments to all plugin functions.
* Always pass all options to plugin export function.
* Add eslint-plugin-promise and fix errors and warnings by it.

![](https://memegenerator.net/img/instances/65493677/promisify-all-the-things.jpg)