### PR TITLE
Add fixture 'generic/par-mini-rgb3-2'

### DIFF
--- a/fixtures/generic/par-mini-rgb3-2.json
+++ b/fixtures/generic/par-mini-rgb3-2.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "PAR-MINI-RGB3-2",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Ranaivo"],
+    "createDate": "2018-10-12",
+    "lastModifyDate": "2018-10-12"
+  },
+  "links": {
+    "productPage": [
+      "https://www.pssl.com/c/Manuals/MiniPar12.pdf"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "CH1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "CH2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "CH3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": "off",
+        "brightnessEnd": "off"
+      }
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8 channels",
+      "channels": [
+        "CH1",
+        "CH2",
+        "CH3",
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    }
+  ]
+}

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -425,6 +425,11 @@
       "lastActionDate": "2018-09-04",
       "lastAction": "modified"
     },
+    "generic/par-mini-rgb3-2": {
+      "name": "PAR-MINI-RGB3-2",
+      "lastActionDate": "2018-10-12",
+      "lastAction": "created"
+    },
     "generic/rgb-fader": {
       "name": "RGB Fader",
       "lastActionDate": "2018-07-21",
@@ -910,6 +915,7 @@
       "drgb-fader",
       "drgbw-fader",
       "pan-tilt",
+      "par-mini-rgb3-2",
       "rgb-fader",
       "rgba-fader",
       "rgbd-fader",
@@ -1123,6 +1129,7 @@
       "generic/cmy-fader",
       "generic/drgb-fader",
       "generic/drgbw-fader",
+      "generic/par-mini-rgb3-2",
       "generic/rgb-fader",
       "generic/rgba-fader",
       "generic/rgbd-fader",
@@ -1602,6 +1609,9 @@
     "Nils Van Zuijlen": [
       "nicols/led-bar-123-fc-ip"
     ],
+    "Ranaivo": [
+      "generic/par-mini-rgb3-2"
+    ],
     "RAZAKANIRINA": [
       "ibiza-light/par-mini-rgb3"
     ],
@@ -1701,6 +1711,7 @@
     }
   },
   "lastUpdated": [
+    "generic/par-mini-rgb3-2",
     "lixada/mini-gobo-moving-head-light",
     "ibiza-light/par-mini-rgb3",
     "martin/mac-600",


### PR DESCRIPTION
* Add fixture 'generic/par-mini-rgb3-2'
* Update register.json

### Fixture warnings / errors

* generic/par-mini-rgb3-2
  - :warning: Mode '8 channels' should have shortName '8ch'.


Thank you **Ranaivo**!