### PR TITLE
Handle missing RDM information in register generation 

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -108,7 +108,7 @@ class Register {
     });
 
     // add to rdm register
-    if (`rdm` in fixData) {
+    if (`rdm` in fixData && `rdmId` in this._manufacturerData[manKey]) {
       const rdmManufacturerId = this._manufacturerData[manKey].rdmId;
       const rdmModelId = fixData.rdm.modelId;
       this.rdm[rdmManufacturerId].models[rdmModelId] = fixKey;

--- a/tests/fixture-valid.js
+++ b/tests/fixture-valid.js
@@ -1033,7 +1033,7 @@ function checkFixture(manKey, fixKey, fixtureJson, uniqueValues = null) {
     );
 
     if (fixture.manufacturer.rdmId === null) {
-      result.errors.push(`Fixture has RDM data, but manufacturer '${fixture.manufacturer.shortName}' has not.`);
+      result.errors.push(`Fixture has RDM data, but manufacturer '${fixture.manufacturer.name}' has not.`);
     }
 
     const rdmPersonalityIndices = new Set();


### PR DESCRIPTION
Also fixed an old usage of `manufacturer.shortName` (which doesn't exist anymore).