### PR TITLE
Make channel type inference more flexible

### DIFF
--- a/lib/model/CoarseChannel.mjs
+++ b/lib/model/CoarseChannel.mjs
@@ -8,65 +8,29 @@ import scaleDmxValuesJs from '../scale-dmx-values.js';
 const { scaleDmxValue } = scaleDmxValuesJs;
 
 const channelTypeConstraints = {
-  'Single Color': {
-    mandatory: [`ColorIntensity`]
-  },
-  'Multi-Color': {
-    mandatory: [`ColorPreset`, `ColorWheelIndex`]
-  },
-  'Pan': {
-    mandatory: [`Pan`, `PanContinuous`]
-  },
-  'Tilt': {
-    mandatory: [`Tilt`, `TiltContinuous`]
-  },
-  'Focus': {
-    mandatory: [`Focus`]
-  },
-  'Zoom': {
-    mandatory: [`Zoom`]
-  },
-  'Iris': {
-    mandatory: [`Iris`, `IrisEffect`]
-  },
-  'Gobo': {
-    mandatory: [`GoboIndex`, `GoboShake`],
-    optional: [`GoboStencilRotation`, `GoboWheelRotation`, `Effect`, `Maintenance`, `NoFunction`]
-  },
-  'Prism': {
-    mandatory: [`Prism`]
-  },
-  'Color Temperature': {
-    mandatory: [`ColorTemperature`]
-  },
-  'Effect': {
-    mandatory: [`Effect`, `EffectParameter`, `Frost`, `FrostEffect`, `SoundSensitivity`]
-  },
+  'Single Color': [`ColorIntensity`],
+  'Multi-Color': [`ColorPreset`, `ColorWheelIndex`],
+  'Pan': [`Pan`, `PanContinuous`],
+  'Tilt': [`Tilt`, `TiltContinuous`],
+  'Focus': [`Focus`],
+  'Zoom': [`Zoom`],
+  'Iris': [`Iris`, `IrisEffect`],
+  'Gobo': [`GoboIndex`, `GoboShake`],
+  'Prism': [`Prism`],
+  'Color Temperature': [`ColorTemperature`],
+  'Effect': [`Effect`, `EffectParameter`, `Frost`, `FrostEffect`, `SoundSensitivity`],
   'Strobe': {
-    mandatory: [`ShutterStrobe`],
-    optional: [`StrobeSpeed`, `StrobeDuration`, `NoFunction`],
+    required: [`ShutterStrobe`],
     predicate: channel => channel.capabilities.some(
       cap => cap.type === `ShutterStrobe` && ![`Open`, `Closed`].includes(cap.shutterEffect)
     )
   },
-  'Shutter': {
-    mandatory: [`ShutterStrobe`, `BladeInsertion`, `BladeRotation`, `BladeSystemRotation`]
-  },
-  'Fog': {
-    mandatory: [`Fog`, `FogOutput`, `FogType`]
-  },
-  'Speed': {
-    mandatory: [`StrobeSpeed`, `StrobeDuration`, `ColorWheelRotation`, `PanTiltSpeed`, `EffectSpeed`, `EffectDuration`, `GoboStencilRotation`, `GoboWheelRotation`, `PrismRotation`, `Rotation`, `Speed`, `Time`]
-  },
-  'Maintenance': {
-    mandatory: [`Maintenance`]
-  },
-  'Intensity': {
-    mandatory: [`Intensity`, `BeamAngle`, `Generic`]
-  },
-  'NoFunction': {
-    mandatory: [`NoFunction`]
-  }
+  'Shutter': [`ShutterStrobe`, `BladeInsertion`, `BladeRotation`, `BladeSystemRotation`],
+  'Fog': [`Fog`, `FogOutput`, `FogType`],
+  'Speed': [`StrobeSpeed`, `StrobeDuration`, `ColorWheelRotation`, `PanTiltSpeed`, `EffectSpeed`, `EffectDuration`, `GoboStencilRotation`, `GoboWheelRotation`, `PrismRotation`, `Rotation`, `Speed`, `Time`],
+  'Maintenance': [`Maintenance`],
+  'Intensity': [`Intensity`, `BeamAngle`, `Generic`],
+  'NoFunction': [`NoFunction`]
 };
 
 /**
@@ -159,19 +123,21 @@ class CoarseChannel extends AbstractChannel {
       const types = Object.keys(channelTypeConstraints);
 
       this._cache.type = types.find(type => {
-        const constraints = channelTypeConstraints[type];
+        let constraints = channelTypeConstraints[type];
 
-        const mandatoryCapTypeUsed = this.capabilities.some(
-          cap => constraints.mandatory.includes(cap.type)
-        );
+        if (Array.isArray(constraints)) {
+          constraints = {
+            required: constraints
+          };
+        }
 
-        const onlyOptionalCapTypesUsed = !(`optional` in constraints) || this.capabilities.every(
-          cap => constraints.mandatory.concat(constraints.optional || []).includes(cap.type)
+        const requiredCapTypeUsed = this.capabilities.some(
+          cap => constraints.required.includes(cap.type)
         );
 
         const predicateFulfilled = !(`predicate` in constraints) || constraints.predicate(this);
 
-        return mandatoryCapTypeUsed && onlyOptionalCapTypesUsed && predicateFulfilled;
+        return requiredCapTypeUsed && predicateFulfilled;
       }) || `Unknown`;
     }
 

--- a/lib/model/CoarseChannel.mjs
+++ b/lib/model/CoarseChannel.mjs
@@ -8,23 +8,65 @@ import scaleDmxValuesJs from '../scale-dmx-values.js';
 const { scaleDmxValue } = scaleDmxValuesJs;
 
 const channelTypeConstraints = {
-  'Single Color': [`ColorIntensity`],
-  'Multi-Color': [`ColorPreset`, `ColorWheelIndex`],
-  'Pan': [`Pan`, `PanContinuous`],
-  'Tilt': [`Tilt`, `TiltContinuous`],
-  'Focus': [`Focus`],
-  'Zoom': [`Zoom`],
-  'Iris': [`Iris`, `IrisEffect`],
-  'Gobo': [`GoboIndex`, `GoboShake`],
-  'Prism': [`Prism`],
-  'Color Temperature': [`ColorTemperature`],
-  'Effect': [`Effect`, `EffectParameter`, `Frost`, `FrostEffect`, `SoundSensitivity`],
-  'Shutter': [`ShutterStrobe`, `BladeInsertion`, `BladeRotation`, `BladeSystemRotation`],
-  'Fog': [`Fog`, `FogOutput`, `FogType`],
-  'Speed': [`StrobeSpeed`, `StrobeDuration`, `ColorWheelRotation`, `PanTiltSpeed`, `EffectSpeed`, `EffectDuration`, `GoboStencilRotation`, `GoboWheelRotation`, `PrismRotation`, `Rotation`, `Speed`, `Time`],
-  'Maintenance': [`Maintenance`],
-  'Intensity': [`Intensity`, `BeamAngle`, `Generic`],
-  'NoFunction': [`NoFunction`]
+  'Single Color': {
+    mandatory: [`ColorIntensity`]
+  },
+  'Multi-Color': {
+    mandatory: [`ColorPreset`, `ColorWheelIndex`]
+  },
+  'Pan': {
+    mandatory: [`Pan`, `PanContinuous`]
+  },
+  'Tilt': {
+    mandatory: [`Tilt`, `TiltContinuous`]
+  },
+  'Focus': {
+    mandatory: [`Focus`]
+  },
+  'Zoom': {
+    mandatory: [`Zoom`]
+  },
+  'Iris': {
+    mandatory: [`Iris`, `IrisEffect`]
+  },
+  'Gobo': {
+    mandatory: [`GoboIndex`, `GoboShake`],
+    optional: [`GoboStencilRotation`, `GoboWheelRotation`, `Effect`, `Maintenance`, `NoFunction`]
+  },
+  'Prism': {
+    mandatory: [`Prism`]
+  },
+  'Color Temperature': {
+    mandatory: [`ColorTemperature`]
+  },
+  'Effect': {
+    mandatory: [`Effect`, `EffectParameter`, `Frost`, `FrostEffect`, `SoundSensitivity`]
+  },
+  'Strobe': {
+    mandatory: [`ShutterStrobe`],
+    optional: [`StrobeSpeed`, `StrobeDuration`, `NoFunction`],
+    predicate: channel => channel.capabilities.some(
+      cap => cap.type === `ShutterStrobe` && ![`Open`, `Closed`].includes(cap.shutterEffect)
+    )
+  },
+  'Shutter': {
+    mandatory: [`ShutterStrobe`, `BladeInsertion`, `BladeRotation`, `BladeSystemRotation`]
+  },
+  'Fog': {
+    mandatory: [`Fog`, `FogOutput`, `FogType`]
+  },
+  'Speed': {
+    mandatory: [`StrobeSpeed`, `StrobeDuration`, `ColorWheelRotation`, `PanTiltSpeed`, `EffectSpeed`, `EffectDuration`, `GoboStencilRotation`, `GoboWheelRotation`, `PrismRotation`, `Rotation`, `Speed`, `Time`]
+  },
+  'Maintenance': {
+    mandatory: [`Maintenance`]
+  },
+  'Intensity': {
+    mandatory: [`Intensity`, `BeamAngle`, `Generic`]
+  },
+  'NoFunction': {
+    mandatory: [`NoFunction`]
+  }
 };
 
 /**
@@ -115,21 +157,22 @@ class CoarseChannel extends AbstractChannel {
   get type() {
     if (!(`type` in this._cache)) {
       const types = Object.keys(channelTypeConstraints);
-      const usedCapabilityTyprd = this.capabilities.map(cap => cap.type);
 
-      this._cache.type = types.find(type => channelTypeConstraints[type].some(
-        capabilityType => usedCapabilityTyprd.includes(capabilityType)
-      )) || `Unknown`;
+      this._cache.type = types.find(type => {
+        const constraints = channelTypeConstraints[type];
 
-      if (this._cache.type === `Shutter`) {
-        const usesStrobe = this.capabilities.some(cap =>
-          cap.type === `ShutterStrobe` && ![`Open`, `Closed`].includes(cap.shutterEffect)
+        const mandatoryCapTypeUsed = this.capabilities.some(
+          cap => constraints.mandatory.includes(cap.type)
         );
 
-        if (usesStrobe) {
-          this._cache.type = `Strobe`;
-        }
-      }
+        const onlyOptionalCapTypesUsed = !(`optional` in constraints) || this.capabilities.every(
+          cap => constraints.mandatory.concat(constraints.optional || []).includes(cap.type)
+        );
+
+        const predicateFulfilled = !(`predicate` in constraints) || constraints.predicate(this);
+
+        return mandatoryCapTypeUsed && onlyOptionalCapTypesUsed && predicateFulfilled;
+      }) || `Unknown`;
     }
 
     return this._cache.type;


### PR DESCRIPTION
Needed for #659, where `WheelSlot` capabilities can imply both channel types *Multi-Color* and *Gobo*.