### PR TITLE
Improve QLC+ export for inverted Intensity channels

### DIFF
--- a/plugins/qlcplus_4.12.0/export.js
+++ b/plugins/qlcplus_4.12.0/export.js
@@ -208,7 +208,7 @@ function getChannelPreset(channel) {
   // TODO: try to also detect the `cap => false` presets
   const channelPresets = {
     IntensityMasterDimmer: cap => false,
-    IntensityDimmer: cap => cap.type === `Intensity`,
+    IntensityDimmer: cap => cap.type === `Intensity` && cap.brightness[0].number < cap.brightness[1].number,
     IntensityRed: cap => capabilityHelpers.isColorIntensity(cap, `Red`),
     IntensityGreen: cap => capabilityHelpers.isColorIntensity(cap, `Green`),
     IntensityBlue: cap => capabilityHelpers.isColorIntensity(cap, `Blue`),


### PR DESCRIPTION
The capability name now still conveys the correct direction, although QLC+ can't properly handle that case in its visualization.

@mcallegari Is there a way to specify inverted Intensity channels in the QLC+ format? Using the `IntensityDimmer` channel preset assumes brightness off…bright; and there is no `BrightToDark` capability preset (or similar).