### PR TITLE
Add fixture 'showtec/atmos-2000'

### DIFF
--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -760,6 +760,11 @@
       "lastActionDate": "2018-11-11",
       "lastAction": "created"
     },
+    "showtec/atmos-2000": {
+      "name": "Atmos 2000",
+      "lastActionDate": "2018-11-24",
+      "lastAction": "created"
+    },
     "showtec/club-par-12-4-rgbw": {
       "name": "Club PAR 12/4 RGBW",
       "lastActionDate": "2018-11-02",
@@ -1139,6 +1144,7 @@
       "led-flat-par-12x3w-rgbw"
     ],
     "showtec": [
+      "atmos-2000",
       "club-par-12-4-rgbw",
       "dominator",
       "horizon-8",
@@ -1520,7 +1526,8 @@
       "american-dj/fog-fury-jett-pro",
       "look/viper-nt",
       "magicfx/smokejet",
-      "mdg/theone-atmospheric-generator"
+      "mdg/theone-atmospheric-generator",
+      "showtec/atmos-2000"
     ],
     "Stand": [
       "chauvet-dj/gigbar-2",
@@ -1681,6 +1688,7 @@
       "robe/robin-ledbeam-150",
       "robe/robin-ledwash-600",
       "robe/robin-viva-cmy",
+      "showtec/atmos-2000",
       "showtec/dominator",
       "showtec/kanjo-wash-rgb",
       "showtec/led-light-bar-rgb-v3",
@@ -2003,6 +2011,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
+    "showtec/atmos-2000",
     "eurolite/led-tmh-x12",
     "infinity/iw-340-rdm",
     "gruft/pixel-tube",

--- a/fixtures/showtec/atmos-2000.json
+++ b/fixtures/showtec/atmos-2000.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Atmos 2000",
+  "shortName": "ShowtecAtm2000",
+  "categories": ["Smoke"],
+  "meta": {
+    "authors": ["Felix Edelmann"],
+    "createDate": "2018-11-24",
+    "lastModifyDate": "2018-11-24"
+  },
+  "comment": "Ordercode 60873",
+  "links": {
+    "manual": [
+      "https://www.highlite.nl/silver.download/Documents@extern@Manuals/60873_MANUAL_GB_V1.pdf"
+    ],
+    "video": [
+      "https://youtu.be/0WMvc7GCGFQ"
+    ]
+  },
+  "physical": {
+    "dimensions": [320, 320, 500],
+    "weight": 7.04,
+    "power": 2000,
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "Fog": {
+      "defaultValue": 0,
+      "highlightValue": "100%",
+      "capability": {
+        "type": "Fog",
+        "fogType": "Fog",
+        "fogOutputStart": "0m\\^3/min",
+        "fogOutputEnd": "1133m\\^3/min",
+        "comment": "0…40000ft³/min"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "1-channel",
+      "shortName": "1ch",
+      "channels": [
+        "Fog"
+      ]
+    }
+  ]
+}

--- a/fixtures/showtec/atmos-2000.json
+++ b/fixtures/showtec/atmos-2000.json
@@ -5,13 +5,13 @@
   "categories": ["Smoke"],
   "meta": {
     "authors": ["Felix Edelmann"],
-    "createDate": "2018-11-24",
-    "lastModifyDate": "2018-11-24"
+    "createDate": "2018-11-27",
+    "lastModifyDate": "2018-11-27"
   },
   "comment": "Ordercode 60873",
   "links": {
     "manual": [
-      "https://www.highlite.nl/silver.download/Documents@extern@Manuals/60873_MANUAL_GB_V1.pdf"
+      "https://www.highlite.com/media/attachments/MANUAL/60873_MANUAL_GB_V1.pdf"
     ],
     "video": [
       "https://youtu.be/0WMvc7GCGFQ"
@@ -30,9 +30,8 @@
       "capability": {
         "type": "Fog",
         "fogType": "Fog",
-        "fogOutputStart": "0m\\^3/min",
-        "fogOutputEnd": "1133m\\^3/min",
-        "comment": "0…40000ft³/min"
+        "fogOutputStart": "0m^3/min",
+        "fogOutputEnd": "1133m^3/min"
       }
     }
   },


### PR DESCRIPTION
* Add fixture 'showtec/atmos-2000'
* Update register.json

### Fixture warnings / errors

* showtec/atmos-2000
  - :x: File does not match schema. [ { keyword: 'pattern',
    dataPath: '.availableChannels[\'Fog\'].capability.fogOutputStart',
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capability/allOf/0/allOf/35/then/properties/fogOutputStart/oneOf/0/pattern',
    params: { pattern: '^-?[0-9]+(\\.[0-9]+)?m\\^3/min$' },
    message: 'should match pattern "^-?[0-9]+(\\.[0-9]+)?m\\^3/min$"' },
  { keyword: 'pattern',
    dataPath: '.availableChannels[\'Fog\'].capability.fogOutputStart',
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capability/allOf/0/allOf/35/then/properties/fogOutputStart/oneOf/1/pattern',
    params: { pattern: '^-?[0-9]+(\\.[0-9]+)?%$' },
    message: 'should match pattern "^-?[0-9]+(\\.[0-9]+)?%$"' },
  { keyword: 'enum',
    dataPath: '.availableChannels[\'Fog\'].capability.fogOutputStart',
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capability/allOf/0/allOf/35/then/properties/fogOutputStart/oneOf/2/enum',
    params: { allowedValues: [ 'off', 'weak', 'strong' ] },
    message: 'should be equal to one of the allowed values' },
  { keyword: 'oneOf',
    dataPath: '.availableChannels[\'Fog\'].capability.fogOutputStart',
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capability/allOf/0/allOf/35/then/properties/fogOutputStart/oneOf',
    params: { passingSchemas: null },
    message: 'should match exactly one schema in oneOf' } ]


Thank you @Fxedel!