### PR TITLE
Fix ARRI link URLs

### DIFF
--- a/fixtures/arri/skypanel-s30c.json
+++ b/fixtures/arri/skypanel-s30c.json
@@ -9,11 +9,11 @@
   },
   "links": {
     "manual": [
-      "https://www.arri.com/?eID=registration&file_uid=18989",
-      "https://www.arri.com/?eID=registration&file_uid=17293"
+      "https://www.arri.com/resource/blob/31208/e3a435411261f80aee556508014ce2dd/arri-skypanel-user-manual-en-nov2018-l03301-data.pdf",
+      "https://www.arri.com/resource/blob/65958/560471fec7f8f2e186ef8ca9e6cdd489/arri-skypanel-dmx-protocol-specification-v4-4-en-okt2018-data.pdf"
     ],
     "productPage": [
-      "https://www.arri.com/lighting/skypanel/products/s30_c/"
+      "https://www.arri.com/en/lighting/led/skypanel/s30-c"
     ],
     "video": [
       "https://www.youtube.com/watch?v=Qq9xhKwpZqc"

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -18,7 +18,7 @@
   },
   "arri": {
     "name": "ARRI",
-    "website": "https://www.arri.com",
+    "website": "https://www.arri.com/en/",
     "rdmId": 8377
   },
   "ayra": {


### PR DESCRIPTION
ARRI updated their homepage, so our links are now outdated (because they don't know that URLs should not change or how to setup a redirect :unamused:).