### PR TITLE
Add fixture 'briteq/cob-slim-100-rgb'

### DIFF
--- a/fixtures/briteq/cob-slim-100-rgb.json
+++ b/fixtures/briteq/cob-slim-100-rgb.json
@@ -12,6 +12,17 @@
       "comment": "created by Q Light Controller Plus (version 4.11.2 GIT)"
     }
   },
+  "links": {
+    "manual": [
+      "https://briteq-lighting.com/fileuploader/download/download/?d=0&file=custom%2Fupload%2FFile-1496150553.pdf"
+    ],
+    "productPage": [
+      "https://briteq-lighting.com/cob-slim100-rgb"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=wAYsrW8YaZM"
+    ]
+  },
   "physical": {
     "dimensions": [245, 280, 140],
     "weight": 3.46,

--- a/fixtures/briteq/cob-slim-100-rgb.json
+++ b/fixtures/briteq/cob-slim-100-rgb.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "COB Slim 100-RGB",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Thierry", "Flo Edelmann"],
+    "createDate": "2018-12-11",
+    "lastModifyDate": "2018-12-11",
+    "importPlugin": {
+      "plugin": "qlcplus_4.11.2",
+      "date": "2018-12-11",
+      "comment": "created by Q Light Controller Plus (version 4.11.2 GIT)"
+    }
+  },
+  "physical": {
+    "dimensions": [245, 280, 140],
+    "weight": 3.46,
+    "power": 120,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "colorTemperature": 3200
+    },
+    "lens": {
+      "name": "Other",
+      "degreesMinMax": [15, 70]
+    },
+    "focus": {
+      "type": "Fixed"
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "comment": "Red (0-100%)"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Mode": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 190],
+          "type": "Effect",
+          "effectName": "Master dimmer 0% - 100% (full open)"
+        },
+        {
+          "dmxRange": [191, 200],
+          "type": "Effect",
+          "effectName": "Sound Control (7 colors)"
+        },
+        {
+          "dmxRange": [201, 247],
+          "type": "Effect",
+          "effectName": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "Effect",
+          "effectName": "Master dimmer full open"
+        }
+      ]
+    },
+    "Master dimmer": {
+      "capability": {
+        "type": "Intensity",
+        "comment": "Master dimmer (0 - 100%)"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "No strobe (Open)"
+        },
+        {
+          "dmxRange": [8, 37],
+          "type": "ShutterStrobe",
+          "shutterEffect": "StrobeRandom",
+          "comment": "Random Strobe"
+        },
+        {
+          "dmxRange": [38, 67],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "Sound Strobe"
+        },
+        {
+          "dmxRange": [68, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Mode 2": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [8, 247],
+          "type": "Effect",
+          "effectName": "Color fade effect (very",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "Effect",
+          "effectName": "Sound Chase"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "3 channel",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    },
+    {
+      "name": "4LC channel",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Mode"
+      ]
+    },
+    {
+      "name": "4+ channel",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Master dimmer"
+      ]
+    },
+    {
+      "name": "6 channel",
+      "channels": [
+        "Master dimmer",
+        "Strobe",
+        "Mode 2",
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    }
+  ]
+}

--- a/fixtures/briteq/cob-slim-100-rgb.json
+++ b/fixtures/briteq/cob-slim-100-rgb.json
@@ -29,7 +29,7 @@
     "power": 120,
     "DMXconnector": "3-pin",
     "bulb": {
-      "type": "LED",
+      "type": "100W COB RGB LED",
       "colorTemperature": 3200
     },
     "lens": {
@@ -44,8 +44,7 @@
     "Red": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Red",
-        "comment": "Red (0-100%)"
+        "color": "Red"
       }
     },
     "Green": {
@@ -64,32 +63,31 @@
       "capabilities": [
         {
           "dmxRange": [0, 190],
-          "type": "Effect",
-          "effectName": "Master dimmer 0% - 100% (full open)"
+          "type": "Intensity"
         },
         {
           "dmxRange": [191, 200],
           "type": "Effect",
-          "effectName": "Sound Control (7 colors)"
+          "effectName": "Sound Control (7 colors)",
+          "soundControlled": true
         },
         {
           "dmxRange": [201, 247],
-          "type": "Effect",
-          "effectName": "Strobe",
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
           "speedStart": "slow",
           "speedEnd": "fast"
         },
         {
           "dmxRange": [248, 255],
-          "type": "Effect",
-          "effectName": "Master dimmer full open"
+          "type": "Intensity",
+          "brightness": "bright"
         }
       ]
     },
     "Master dimmer": {
       "capability": {
-        "type": "Intensity",
-        "comment": "Master dimmer (0 - 100%)"
+        "type": "Intensity"
       }
     },
     "Strobe": {
@@ -97,14 +95,13 @@
         {
           "dmxRange": [0, 7],
           "type": "ShutterStrobe",
-          "shutterEffect": "Strobe",
-          "comment": "No strobe (Open)"
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [8, 37],
           "type": "ShutterStrobe",
-          "shutterEffect": "StrobeRandom",
-          "comment": "Random Strobe"
+          "shutterEffect": "Strobe",
+          "randomTiming": true
         },
         {
           "dmxRange": [38, 67],
@@ -121,7 +118,7 @@
         }
       ]
     },
-    "Mode 2": {
+    "Effect": {
       "capabilities": [
         {
           "dmxRange": [0, 7],
@@ -130,21 +127,22 @@
         {
           "dmxRange": [8, 247],
           "type": "Effect",
-          "effectName": "Color fade effect (very",
+          "effectPreset": "ColorFade",
           "speedStart": "slow",
           "speedEnd": "fast"
         },
         {
           "dmxRange": [248, 255],
           "type": "Effect",
-          "effectName": "Sound Chase"
+          "effectName": "Sound Chase",
+          "soundControlled": true
         }
       ]
     }
   },
   "modes": [
     {
-      "name": "3 channel",
+      "name": "RGB",
       "channels": [
         "Red",
         "Green",
@@ -153,6 +151,7 @@
     },
     {
       "name": "4LC channel",
+      "shortName": "4LC",
       "channels": [
         "Red",
         "Green",
@@ -162,6 +161,7 @@
     },
     {
       "name": "4+ channel",
+      "shortName": "4+",
       "channels": [
         "Red",
         "Green",
@@ -171,10 +171,11 @@
     },
     {
       "name": "6 channel",
+      "shortName": "6ch",
       "channels": [
         "Master dimmer",
         "Strobe",
-        "Mode 2",
+        "Effect",
         "Red",
         "Green",
         "Blue"

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -41,6 +41,10 @@
     "name": "BoomToneDJ",
     "website": "http://www.boomtonedj.com/"
   },
+  "briteq": {
+    "name": "Briteq",
+    "website": "https://briteq-lighting.com/"
+  },
   "cameo": {
     "name": "cameo",
     "website": "https://www.cameolight.com/"

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -2064,6 +2064,7 @@
     "big-dipper": "#d452e0",
     "blizzard": "#d94426",
     "boomtonedj": "#c5cc66",
+    "briteq": "#40bfb7",
     "cameo": "#6679cc",
     "chauvet-dj": "#d6855c",
     "chauvet-professional": "#5265e0",

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -135,6 +135,11 @@
       "lastActionDate": "2018-08-09",
       "lastAction": "modified"
     },
+    "briteq/cob-slim-100-rgb": {
+      "name": "COB Slim 100-RGB",
+      "lastActionDate": "2018-12-11",
+      "lastAction": "created"
+    },
     "cameo/flash-matrix-250": {
       "name": "Flash Matrix 250",
       "lastActionDate": "2018-07-21",
@@ -984,6 +989,9 @@
       "crazy-spot-30",
       "xtrem-led"
     ],
+    "briteq": [
+      "cob-slim-100-rgb"
+    ],
     "cameo": [
       "flash-matrix-250",
       "flat-par-can-tri-7x-3w-ir",
@@ -1285,6 +1293,7 @@
       "blizzard/puck-rgbaw",
       "boomtonedj/crazy-spot-30",
       "boomtonedj/xtrem-led",
+      "briteq/cob-slim-100-rgb",
       "cameo/flat-par-can-tri-7x-3w-ir",
       "cameo/flat-pro-18",
       "cameo/flat-pro-flood-ip65-tri",
@@ -1639,6 +1648,7 @@
       "ayra/tdc-triple-burst",
       "big-dipper/ls90",
       "boomtonedj/xtrem-led",
+      "briteq/cob-slim-100-rgb",
       "cameo/hydrabeam-100",
       "cameo/hydrabeam-300-rgbw",
       "cameo/outdoor-par-tri-12",
@@ -1938,6 +1948,9 @@
     "stevebrush": [
       "martin/rush-par-2-rgbw-zoom"
     ],
+    "Thierry": [
+      "briteq/cob-slim-100-rgb"
+    ],
     "Thilo Billerbeck": [
       "lightmaxx/dj-scan-led"
     ],
@@ -2103,6 +2116,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
+    "briteq/cob-slim-100-rgb",
     "american-dj/mega-bar-rgba",
     "chauvet-professional/rogue-r2-wash",
     "sun-star/g-2011-nova",


### PR DESCRIPTION
* Add fixture 'briteq/cob-slim-100-rgb'
* Update register.json

### Fixture warnings / errors

* briteq/cob-slim-100-rgb
  - :x: File does not match schema. [ { keyword: 'enum',
    dataPath: '.availableChannels[\'Strobe\'].capabilities[1].shutterEffect',
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capabilities/items/allOf/0/allOf/1/then/properties/shutterEffect/enum',
    params: 
     { allowedValues: 
        [ 'Open',
          'Closed',
          'Strobe',
          'Pulse',
          'RampUp',
          'RampDown',
          'RampUpDown',
          'Lightning',
          'Spikes' ] },
    message: 'should be equal to one of the allowed values' } ]
  - :warning: Please check if manufacturer is correct.


Thank you @FloEdelmann!