### PR TITLE
Add fixture 'dedolight/dedo7-bi'

### DIFF
--- a/fixtures/dedolight/dedo-7---bicolor.json
+++ b/fixtures/dedolight/dedo-7---bicolor.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Dedo 7 - BiColor",
+  "shortName": "DLED7-BI",
+  "categories": ["Dimmer", "Color Changer"],
+  "meta": {
+    "authors": ["PY DOUGNAC"],
+    "createDate": "2018-12-19",
+    "lastModifyDate": "2018-12-19"
+  },
+  "comment": "The DLED7-BI-DMX power supply is needed for DMX control",
+  "links": {
+    "productPage": [
+      "http://www.dedolight.com/dedolight/default.php?la=0&pg=00000400100507&id=DL-DLED4-BI&section=0"
+    ]
+  },
+  "physical": {
+    "dimensions": [109, 200, 100],
+    "weight": 1.3,
+    "power": 70,
+    "DMXconnector": "5-pin",
+    "bulb": {
+      "type": "BIcolor 70w LED"
+    },
+    "lens": {
+      "degreesMinMax": [4, 60]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Color Temperature": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "warm",
+        "colorTemperatureEnd": "cold"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Defaults",
+      "shortName": "defaults",
+      "channels": [
+        "Dimmer",
+        "Color Temperature"
+      ]
+    }
+  ]
+}

--- a/fixtures/dedolight/dled7-bi.json
+++ b/fixtures/dedolight/dled7-bi.json
@@ -1,26 +1,26 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Dedo 7 - BiColor",
-  "shortName": "DLED7-BI",
-  "categories": ["Dimmer", "Color Changer"],
+  "name": "DLED7-BI",
+  "categories": ["Dimmer"],
   "meta": {
     "authors": ["PY DOUGNAC"],
     "createDate": "2018-12-19",
     "lastModifyDate": "2018-12-19"
   },
-  "comment": "The DLED7-BI-DMX power supply is needed for DMX control",
+  "comment": "The DT7-BI-DMX power supply is needed for DMX control.",
+  "helpWanted": "The Dedolight website does not contain an official product page for this fixture. Can you provide the link to a reliable data sheet / manual / product page?",
   "links": {
-    "productPage": [
-      "http://www.dedolight.com/dedolight/default.php?la=0&pg=00000400100507&id=DL-DLED4-BI&section=0"
+    "other": [
+      "https://www.teltec.de/dedolight-dled7-bi.html"
     ]
   },
   "physical": {
     "dimensions": [109, 200, 100],
     "weight": 1.3,
-    "power": 70,
+    "power": 90,
     "DMXconnector": "5-pin",
     "bulb": {
-      "type": "BIcolor 70w LED"
+      "type": "Bicolor 90W LED"
     },
     "lens": {
       "degreesMinMax": [4, 60]
@@ -35,15 +35,14 @@
     "Color Temperature": {
       "capability": {
         "type": "ColorTemperature",
-        "colorTemperatureStart": "warm",
-        "colorTemperatureEnd": "cold"
+        "colorTemperatureStart": "2700K",
+        "colorTemperatureEnd": "6500K"
       }
     }
   },
   "modes": [
     {
-      "name": "Defaults",
-      "shortName": "defaults",
+      "name": "DT7-BI-DMX",
       "channels": [
         "Dimmer",
         "Color Temperature"

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -340,6 +340,11 @@
       "lastActionDate": "2018-11-11",
       "lastAction": "created"
     },
+    "dedolight/dedo-7---bicolor": {
+      "name": "Dedo 7 - BiColor",
+      "lastActionDate": "2018-12-19",
+      "lastAction": "created"
+    },
     "dedolight/dled4-bi": {
       "name": "DLED4-BI",
       "lastActionDate": "2018-11-11",
@@ -1062,6 +1067,7 @@
       "irledflat-5x12SIXb"
     ],
     "dedolight": [
+      "dedo-7---bicolor",
       "dled4-bi"
     ],
     "dts": [
@@ -1351,6 +1357,7 @@
       "clay-paky/spheriscan",
       "coemar/prospot-250-lx",
       "contest/irledflat-5x12SIXb",
+      "dedolight/dedo-7---bicolor",
       "dts/xr1200-wash",
       "elation/acl-360-roller",
       "elation/platinum-hfx",
@@ -1461,6 +1468,7 @@
       "arri/skypanel-s30c",
       "cameo/flat-par-can-tri-7x-3w-ir",
       "chauvet-dj/eve-p-100-ww",
+      "dedolight/dedo-7---bicolor",
       "dedolight/dled4-bi",
       "dts/scena-led-150",
       "eurolite/led-sls-6-uv-floor",
@@ -1965,6 +1973,9 @@
     "Potatoe": [
       "shehds/led-flat-par-12x3w-rgbw"
     ],
+    "PY DOUGNAC": [
+      "dedolight/dedo-7---bicolor"
+    ],
     "Ranaivo": [
       "solena/mini-par-12"
     ],
@@ -2151,6 +2162,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
+    "dedolight/dedo-7---bicolor",
     "hong-yi/hy-g60",
     "tiptop-stage-light/3-10w-battery-led-wedge-par",
     "briteq/bt-ledrotor",

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -340,14 +340,14 @@
       "lastActionDate": "2018-11-11",
       "lastAction": "created"
     },
-    "dedolight/dedo-7---bicolor": {
-      "name": "Dedo 7 - BiColor",
-      "lastActionDate": "2018-12-19",
-      "lastAction": "created"
-    },
     "dedolight/dled4-bi": {
       "name": "DLED4-BI",
       "lastActionDate": "2018-11-11",
+      "lastAction": "created"
+    },
+    "dedolight/dled7-bi": {
+      "name": "DLED7-BI",
+      "lastActionDate": "2018-12-19",
       "lastAction": "created"
     },
     "dts/scena-led-150": {
@@ -1067,8 +1067,8 @@
       "irledflat-5x12SIXb"
     ],
     "dedolight": [
-      "dedo-7---bicolor",
-      "dled4-bi"
+      "dled4-bi",
+      "dled7-bi"
     ],
     "dts": [
       "scena-led-150",
@@ -1357,7 +1357,6 @@
       "clay-paky/spheriscan",
       "coemar/prospot-250-lx",
       "contest/irledflat-5x12SIXb",
-      "dedolight/dedo-7---bicolor",
       "dts/xr1200-wash",
       "elation/acl-360-roller",
       "elation/platinum-hfx",
@@ -1468,8 +1467,8 @@
       "arri/skypanel-s30c",
       "cameo/flat-par-can-tri-7x-3w-ir",
       "chauvet-dj/eve-p-100-ww",
-      "dedolight/dedo-7---bicolor",
       "dedolight/dled4-bi",
+      "dedolight/dled7-bi",
       "dts/scena-led-150",
       "eurolite/led-sls-6-uv-floor",
       "generic/desk-channel",
@@ -1974,7 +1973,7 @@
       "shehds/led-flat-par-12x3w-rgbw"
     ],
     "PY DOUGNAC": [
-      "dedolight/dedo-7---bicolor"
+      "dedolight/dled7-bi"
     ],
     "Ranaivo": [
       "solena/mini-par-12"
@@ -2162,7 +2161,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
-    "dedolight/dedo-7---bicolor",
+    "dedolight/dled7-bi",
     "hong-yi/hy-g60",
     "tiptop-stage-light/3-10w-battery-led-wedge-par",
     "briteq/bt-ledrotor",


### PR DESCRIPTION
* Add fixture 'dedolight/dedo-7---bicolor'
* Update register.json

### Fixture warnings / errors

* dedolight/dedo-7---bicolor
  - :x: Category 'Color Changer' invalid since there are no ColorPreset, ColorWheelIndex and less than two ColorIntensity capabilities.


Thank you **PY DOUGNAC**!