### PR TITLE
Correct usage of StrobeSpeed capabilities

### DIFF
--- a/fixtures/chauvet-dj/gigbar-2.json
+++ b/fixtures/chauvet-dj/gigbar-2.json
@@ -669,9 +669,11 @@
     },
     "White / UV $pixelKey Speed": {
       "capability": {
-        "type": "StrobeSpeed",
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
         "speedStart": "slow",
-        "speedEnd": "fast"
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX value is strobe disabled? When is the lamp constantly on/off?"
       }
     }
   },

--- a/fixtures/chroma-q/color-force-ii-12.json
+++ b/fixtures/chroma-q/color-force-ii-12.json
@@ -212,9 +212,11 @@
     },
     "Strobe Frequency": {
       "capability": {
-        "type": "StrobeSpeed",
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
         "speedStart": "slow",
-        "speedEnd": "fast"
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX value is strobe disabled? When is the lamp constantly on/off?"
       }
     },
     "Strobe Duration": {

--- a/fixtures/chroma-q/color-force-ii-48.json
+++ b/fixtures/chroma-q/color-force-ii-48.json
@@ -236,9 +236,11 @@
     },
     "Strobe Frequency": {
       "capability": {
-        "type": "StrobeSpeed",
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
         "speedStart": "slow",
-        "speedEnd": "fast"
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX value is strobe disabled? When is the lamp constantly on/off?"
       }
     },
     "Strobe Duration": {

--- a/fixtures/chroma-q/color-force-ii-72.json
+++ b/fixtures/chroma-q/color-force-ii-72.json
@@ -259,9 +259,11 @@
     },
     "Strobe Frequency": {
       "capability": {
-        "type": "StrobeSpeed",
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
         "speedStart": "slow",
-        "speedEnd": "fast"
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX value is strobe disabled? When is the lamp constantly on/off?"
       }
     },
     "Strobe Duration": {

--- a/fixtures/contest/irledflat-5x12SIXb.json
+++ b/fixtures/contest/irledflat-5x12SIXb.json
@@ -71,7 +71,8 @@
     },
     "Strobe": {
       "capability": {
-        "type": "StrobeSpeed",
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
         "speedStart": "0Hz",
         "speedEnd": "50Hz",
         "helpWanted": "At which DMX value is the LED constantly on/off (no strobe)?"

--- a/fixtures/magicfx/smokejet.json
+++ b/fixtures/magicfx/smokejet.json
@@ -162,7 +162,8 @@
     },
     "Strobe": {
       "capability": {
-        "type": "StrobeSpeed",
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
         "speedStart": "1Hz",
         "speedEnd": "20Hz",
         "helpWanted": "At which DMX value is strobe disabled? When is the lamp constantly on/off?"


### PR DESCRIPTION
They often should actually be of ShutterStrobe type.