### PR TITLE
Add fixture 'generic/test'

### DIFF
--- a/fixtures/generic/test.json
+++ b/fixtures/generic/test.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "test",
+  "categories": ["Stand"],
+  "meta": {
+    "authors": ["test"],
+    "createDate": "2019-01-11",
+    "lastModifyDate": "2019-01-11"
+  },
+  "links": {
+    "other": [
+      "http://www.test.com"
+    ]
+  },
+  "availableChannels": {
+    "Shutter": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe"
+        },
+        {
+          "dmxRange": [10, 19],
+          "type": "Pan",
+          "angleStart": "0deg",
+          "angleEnd": "240deg"
+        },
+        {
+          "dmxRange": [20, 255],
+          "type": "NoFunction"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "test",
+      "channels": [
+        "Shutter"
+      ]
+    }
+  ]
+}

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -570,6 +570,11 @@
       "lastActionDate": "2018-07-21",
       "lastAction": "modified"
     },
+    "generic/test": {
+      "name": "test",
+      "lastActionDate": "2019-01-11",
+      "lastAction": "created"
+    },
     "ghost/ip-spot-bat": {
       "name": "IP Spot Bat",
       "lastActionDate": "2018-08-09",
@@ -1185,7 +1190,8 @@
       "rgb-fader",
       "rgba-fader",
       "rgbd-fader",
-      "rgbw-fader"
+      "rgbw-fader",
+      "test"
     ],
     "ghost": [
       "ip-spot-bat"
@@ -1730,7 +1736,8 @@
     "Stand": [
       "chauvet-dj/gigbar-2",
       "equinox/gigabar",
-      "eurolite/led-kls-801"
+      "eurolite/led-kls-801",
+      "generic/test"
     ],
     "Strobe": [
       "arri/skypanel-s30c",
@@ -2086,6 +2093,9 @@
     "stevebrush": [
       "martin/rush-par-2-rgbw-zoom"
     ],
+    "test": [
+      "generic/test"
+    ],
     "Thierry": [
       "briteq/cob-slim-100-rgb"
     ],
@@ -2258,6 +2268,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
+    "generic/test",
     "laserworld/ds-1000rgb",
     "eliminator/stealth-wash-zoom",
     "evolight/colours-archspot-54-rgb",


### PR DESCRIPTION
* Add fixture 'generic/test'
* Update register.json

### Fixture warnings / errors

* generic/test
  - :warning: Capability 'Pan 0…240°' (10…19) in channel 'Shutter' defines an exact pan angle. Setting focus.panMax in the fixture's physical data is recommended.
  - :warning: physical.panMax is not defined although there's a Pan channel 'Shutter' in mode 'test'.


Thank you **test**!