### PR TITLE
Add fixture 'eurolite/led-pix-144'

### DIFF
--- a/fixtures/eurolite/led-pix-144.json
+++ b/fixtures/eurolite/led-pix-144.json
@@ -43,6 +43,34 @@
       "Master": ["1", "2", "3", "4", "5", "6", "7", "8"]
     }
   },
+  "availableChannels": {
+    "Auto Program / Strobe": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [1, 5],
+          "type": "Effect",
+          "effectName": "Sound-control 7-color",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [6, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0Hz",
+          "speedEnd": "20Hz"
+        }
+      ]
+    }
+  },
   "templateChannels": {
     "Red $pixelKey": {
       "capability": {
@@ -61,6 +89,37 @@
         "type": "ColorIntensity",
         "color": "Blue"
       }
+    },
+    "Dimmer $pixelKey": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe $pixelKey": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "0Hz",
+        "speedEnd": "20Hz",
+        "helpWanted": "At which DMX value is strobe disabled? When is the lamp constantly on/off?"
+      }
+    },
+    "Auto Program $pixelKey": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "Effect",
+          "effectName": "RGB program",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
     }
   },
   "modes": [
@@ -71,6 +130,83 @@
         "Red Master",
         "Green Master",
         "Blue Master"
+      ]
+    },
+    {
+      "name": "5-channel",
+      "shortName": "5ch",
+      "channels": [
+        "Red Master",
+        "Green Master",
+        "Blue Master",
+        "Dimmer Master",
+        "Auto Program / Strobe"
+      ]
+    },
+    {
+      "name": "6-channel",
+      "shortName": "6ch",
+      "channels": [
+        "Dimmer Master",
+        "Strobe Master",
+        "Red Master",
+        "Green Master",
+        "Blue Master",
+        "Auto Program Master"
+      ]
+    },
+    {
+      "name": "12-channel",
+      "shortName": "12ch",
+      "channels": [
+        {
+          "insert": "matrixChannels",
+          "repeatFor": ["1/2", "2/2"],
+          "channelOrder": "perPixel",
+          "templateChannels": [
+            "Dimmer $pixelKey",
+            "Strobe $pixelKey",
+            "Red $pixelKey",
+            "Green $pixelKey",
+            "Blue $pixelKey",
+            "Auto Program $pixelKey"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "24-channel",
+      "shortName": "24ch",
+      "channels": [
+        {
+          "insert": "matrixChannels",
+          "repeatFor": "eachPixelABC",
+          "channelOrder": "perPixel",
+          "templateChannels": [
+            "Red $pixelKey",
+            "Green $pixelKey",
+            "Blue $pixelKey"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "48-channel",
+      "shortName": "48ch",
+      "channels": [
+        {
+          "insert": "matrixChannels",
+          "repeatFor": "eachPixelABC",
+          "channelOrder": "perPixel",
+          "templateChannels": [
+            "Dimmer $pixelKey",
+            "Strobe $pixelKey",
+            "Red $pixelKey",
+            "Green $pixelKey",
+            "Blue $pixelKey",
+            "Auto Program $pixelKey"
+          ]
+        }
       ]
     }
   ]

--- a/fixtures/eurolite/led-pix-144.json
+++ b/fixtures/eurolite/led-pix-144.json
@@ -20,16 +20,15 @@
     ]
   },
   "physical": {
-    "dimensions": [1020, 80, 65],
+    "dimensions": [1020, 65, 80],
     "weight": 1,
     "power": 25,
     "DMXconnector": "3-pin",
     "bulb": {
-      "type": "LED"
+      "type": "144x RGB-SMD LEDs"
     },
     "focus": {
-      "panMax": 0,
-      "tiltMax": 0
+      "type": "Fixed"
     }
   },
   "availableChannels": {

--- a/fixtures/eurolite/led-pix-144.json
+++ b/fixtures/eurolite/led-pix-144.json
@@ -29,22 +29,34 @@
     },
     "focus": {
       "type": "Fixed"
+    },
+    "matrixPixels": {
+      "dimensions": [125, 65, 0],
+      "spacing": [0, 0, 0]
     }
   },
-  "availableChannels": {
-    "Red": {
+  "matrix": {
+    "pixelCount": [8, 1, 1],
+    "pixelGroups": {
+      "1/2": ["1", "2", "3", "4"],
+      "2/2": ["5", "6", "7", "8"],
+      "Master": ["1", "2", "3", "4", "5", "6", "7", "8"]
+    }
+  },
+  "templateChannels": {
+    "Red $pixelKey": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Red"
       }
     },
-    "Green": {
+    "Green $pixelKey": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Green"
       }
     },
-    "Blue": {
+    "Blue $pixelKey": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Blue"
@@ -53,11 +65,12 @@
   },
   "modes": [
     {
-      "name": "3 channel",
+      "name": "3-channel",
+      "shortName": "3ch",
       "channels": [
-        "Red",
-        "Green",
-        "Blue"
+        "Red Master",
+        "Green Master",
+        "Blue Master"
       ]
     }
   ]

--- a/fixtures/eurolite/led-pix-144.json
+++ b/fixtures/eurolite/led-pix-144.json
@@ -4,8 +4,8 @@
   "categories": ["Color Changer", "Pixel Bar"],
   "meta": {
     "authors": ["Paolo Zanchi"],
-    "createDate": "2019-02-05",
-    "lastModifyDate": "2019-02-05"
+    "createDate": "2019-02-06",
+    "lastModifyDate": "2019-02-06"
   },
   "links": {
     "manual": [

--- a/fixtures/eurolite/led-pix-144.json
+++ b/fixtures/eurolite/led-pix-144.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED PIX-144",
+  "categories": ["Color Changer", "Pixel Bar"],
+  "meta": {
+    "authors": ["Paolo Zanchi"],
+    "createDate": "2019-02-05",
+    "lastModifyDate": "2019-02-05"
+  },
+  "links": {
+    "manual": [
+      "https://www.huss-licht-ton.de/images/products_download/User_Manual_27993_1.pdf"
+    ],
+    "productPage": [
+      "http://eurolite.de"
+    ]
+  },
+  "physical": {
+    "dimensions": [1020, 80, 65],
+    "weight": 1,
+    "power": 25,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "focus": {
+      "panMax": 0,
+      "tiltMax": 0
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "3 channel",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    }
+  ]
+}

--- a/fixtures/eurolite/led-pix-144.json
+++ b/fixtures/eurolite/led-pix-144.json
@@ -9,10 +9,14 @@
   },
   "links": {
     "manual": [
-      "https://www.huss-licht-ton.de/images/products_download/User_Manual_27993_1.pdf"
+      "https://www.steinigke.de/download/51930439-Manual-111069-1.00-eurolite-led-pix-144-rgb-bar-de_en.pdf"
     ],
     "productPage": [
-      "http://eurolite.de"
+      "https://www.steinigke.de/en/mpn51930439-eurolite-led-pix-144-rgb-bar.html"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=O0GaXoeFQaQ",
+      "https://www.youtube.com/watch?v=uWRSK040pnI"
     ]
   },
   "physical": {

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -472,7 +472,7 @@
     },
     "eurolite/led-pix-144": {
       "name": "LED PIX-144",
-      "lastActionDate": "2019-02-05",
+      "lastActionDate": "2019-02-06",
       "lastAction": "created"
     },
     "eurolite/led-ps-4-hcl": {

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -470,6 +470,11 @@
       "lastActionDate": "2019-01-15",
       "lastAction": "created"
     },
+    "eurolite/led-pix-144": {
+      "name": "LED PIX-144",
+      "lastActionDate": "2019-02-05",
+      "lastAction": "created"
+    },
     "eurolite/led-ps-4-hcl": {
       "name": "LED PS-4 HCL",
       "lastActionDate": "2018-08-09",
@@ -1190,6 +1195,7 @@
       "led-ml-56-rgbw",
       "led-par-56-tcl",
       "led-pix-12-hcl",
+      "led-pix-144",
       "led-ps-4-hcl",
       "led-sls-6-uv-floor",
       "led-svf-1",
@@ -1484,6 +1490,7 @@
       "eurolite/led-ml-56-rgbw",
       "eurolite/led-par-56-tcl",
       "eurolite/led-pix-12-hcl",
+      "eurolite/led-pix-144",
       "eurolite/led-ps-4-hcl",
       "eurolite/led-tmh-7",
       "eurolite/led-tmh-9",
@@ -1746,6 +1753,7 @@
       "clay-paky/show-batten-100",
       "epsilon/duo-q-beam-bar",
       "eurolite/led-pix-12-hcl",
+      "eurolite/led-pix-144",
       "glp/impression-x4-bar-10",
       "gruft/pixel-tube",
       "nicols/led-bar-123-fc-ip",
@@ -2112,6 +2120,9 @@
     "NiKoyes": [
       "robe/robin-600e-spot"
     ],
+    "Paolo Zanchi": [
+      "eurolite/led-pix-144"
+    ],
     "Pascal Denis": [
       "contest/irledflat-5x12SIXb"
     ],
@@ -2314,6 +2325,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
+    "eurolite/led-pix-144",
     "generic/rgbww-fader",
     "robe/robin-ledbeam-100",
     "martin/mac-encore-performance",


### PR DESCRIPTION
* Add fixture 'eurolite/led-pix-144'
* Update register.json

### Fixture warnings / errors

* eurolite/led-pix-144
  - :x: Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - :warning: Mode '3 channel' should have shortName '3ch'.


Thank you @LoganBlades!