### PR TITLE
Update ajv to version 6.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "xmlbuilder": "^10.1.1"
   },
   "devDependencies": {
-    "ajv": "^6.7.0",
+    "ajv": "^6.9.1",
     "broken-link-checker": "^0.7.6",
     "colors": "^1.3.3",
     "diff": "^4.0.1",


### PR DESCRIPTION
Skip ajv version 6.9.0, as it was failing our builds. See https://github.com/epoberezkin/ajv/issues/941. Fix #777.