### PR TITLE
Use xmlbuilder's .dtd() instead of deprecated .doctype()

### DIFF
--- a/plugins/qlcplus_4.11.2/export.js
+++ b/plugins/qlcplus_4.11.2/export.js
@@ -56,7 +56,7 @@ module.exports.export = function exportQlcPlus(fixtures, options) {
       addMode(xml, mode);
     }
 
-    xml.doctype(``);
+    xml.dtd(``);
     return {
       name: sanitize(`${fixture.manufacturer.name}-${fixture.name}.qxf`).replace(/\s+/g, `-`),
       content: xml.end({

--- a/plugins/qlcplus_4.12.0/export.js
+++ b/plugins/qlcplus_4.12.0/export.js
@@ -74,7 +74,7 @@ module.exports.export = function exportQlcPlus(fixtures, options) {
       addPhysical(xml, fixture.physical);
     }
 
-    xml.doctype(``);
+    xml.dtd(``);
 
     return {
       name: sanitize(`${fixture.manufacturer.name}/-${fixture.name}.qxf`).replace(/\s+/g, `-`),


### PR DESCRIPTION
Cherry-picked from #793. It has to be merged into `master` first, so that the export test there won't fail.