### PR TITLE
Add fixture 'american-dj/encore-profile-1000-ww'

### DIFF
--- a/fixtures/american-dj/encore-profile-1000-ww.json
+++ b/fixtures/american-dj/encore-profile-1000-ww.json
@@ -5,8 +5,8 @@
   "categories": ["Blinder", "Dimmer"],
   "meta": {
     "authors": ["Gerard Fontanillas"],
-    "createDate": "2019-02-24",
-    "lastModifyDate": "2019-02-24"
+    "createDate": "2019-02-27",
+    "lastModifyDate": "2019-02-27"
   },
   "links": {
     "manual": [

--- a/fixtures/american-dj/encore-profile-1000-ww.json
+++ b/fixtures/american-dj/encore-profile-1000-ww.json
@@ -36,13 +36,13 @@
     }
   },
   "availableChannels": {
-    "White": {
+    "Warm White": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "White"
+        "color": "Warm White"
       }
     },
-    "Master Dimmer": {
+    "Dimmer": {
       "capability": {
         "type": "Intensity"
       }
@@ -68,23 +68,23 @@
       "name": "1-channel",
       "shortName": "1ch",
       "channels": [
-        "White"
+        "Warm White"
       ]
     },
     {
       "name": "2-channel",
       "shortName": "2ch",
       "channels": [
-        "White",
-        "Master Dimmer"
+        "Warm White",
+        "Dimmer"
       ]
     },
     {
       "name": "3-channel",
       "shortName": "3ch",
       "channels": [
-        "White",
-        "Master Dimmer",
+        "Warm White",
+        "Dimmer",
         "Strobe"
       ]
     }

--- a/fixtures/american-dj/encore-profile-1000-ww.json
+++ b/fixtures/american-dj/encore-profile-1000-ww.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "Encore Profile 1000 WW",
-  "shortName": "ADJEncProfile",
+  "shortName": "ADJEncProfile1000WW",
   "categories": ["Blinder", "Dimmer"],
   "meta": {
     "authors": ["Gerard Fontanillas"],

--- a/fixtures/american-dj/encore-profile-1000ww.json
+++ b/fixtures/american-dj/encore-profile-1000ww.json
@@ -65,23 +65,23 @@
   },
   "modes": [
     {
-      "name": "1 Channel",
-      "shortName": "1 channel",
+      "name": "1-channel",
+      "shortName": "1ch",
       "channels": [
         "White"
       ]
     },
     {
-      "name": "2 Channel",
-      "shortName": "2 channel",
+      "name": "2-channel",
+      "shortName": "2ch",
       "channels": [
         "White",
         "Master Dimmer"
       ]
     },
     {
-      "name": "3 channel",
-      "shortName": "3 Channel",
+      "name": "3-channel",
+      "shortName": "3ch",
       "channels": [
         "White",
         "Master Dimmer",

--- a/fixtures/american-dj/encore-profile-1000ww.json
+++ b/fixtures/american-dj/encore-profile-1000ww.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Encore profile 1000WW",
+  "shortName": "Profile 1000\"",
+  "categories": ["Blinder"],
+  "meta": {
+    "authors": ["Gerard Fontanillas"],
+    "createDate": "2019-02-24",
+    "lastModifyDate": "2019-02-24"
+  },
+  "comment": "Profile led 120W",
+  "links": {
+    "manual": [
+      "https://cdb.s3-us-west-1.amazonaws.com/ItemRelatedFiles/8872/encore_profile_1000_ww.pdf"
+    ],
+    "productPage": [
+      "https://www.adj.com/encore-profile-1000-ww"
+    ]
+  },
+  "physical": {
+    "dimensions": [560, 250, 385],
+    "weight": 8.5,
+    "power": 144,
+    "DMXconnector": "3-pin and 5-pin",
+    "bulb": {
+      "type": "LED",
+      "colorTemperature": 3200
+    },
+    "lens": {
+      "name": "Beam Angle",
+      "degreesMinMax": [12, 30]
+    }
+  },
+  "availableChannels": {
+    "White": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Master / Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "16Hz",
+        "speedEnd": "255Hz",
+        "comment": "0-15 no funcion; 16-255 strobing slow->fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "1 Channel",
+      "shortName": "1 channel",
+      "channels": [
+        "White"
+      ]
+    },
+    {
+      "name": "2 Channel",
+      "shortName": "2 channel",
+      "channels": [
+        "White",
+        "Master / Dimmer"
+      ]
+    },
+    {
+      "name": "3 channel",
+      "shortName": "3 Channel",
+      "channels": [
+        "White",
+        "Master / Dimmer",
+        "Strobe"
+      ]
+    }
+  ]
+}

--- a/fixtures/american-dj/encore-profile-1000ww.json
+++ b/fixtures/american-dj/encore-profile-1000ww.json
@@ -1,20 +1,25 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Encore profile 1000WW",
-  "shortName": "Profile 1000\"",
-  "categories": ["Blinder"],
+  "name": "Encore Profile 1000 WW",
+  "shortName": "ADJEncProfile",
+  "categories": ["Blinder", "Dimmer"],
   "meta": {
     "authors": ["Gerard Fontanillas"],
     "createDate": "2019-02-24",
     "lastModifyDate": "2019-02-24"
   },
-  "comment": "Profile led 120W",
   "links": {
     "manual": [
       "https://cdb.s3-us-west-1.amazonaws.com/ItemRelatedFiles/8872/encore_profile_1000_ww.pdf"
     ],
     "productPage": [
       "https://www.adj.com/encore-profile-1000-ww"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=zz6L0bJZoF8",
+      "https://www.youtube.com/watch?v=MdO71QLiFZ4",
+      "https://www.youtube.com/watch?v=SwFZg45s_hE",
+      "https://www.youtube.com/watch?v=2twVkEXGRBg"
     ]
   },
   "physical": {
@@ -33,21 +38,29 @@
   "availableChannels": {
     "White": {
       "capability": {
-        "type": "Intensity"
+        "type": "ColorIntensity",
+        "color": "White"
       }
     },
-    "Master / Dimmer": {
+    "Master Dimmer": {
       "capability": {
         "type": "Intensity"
       }
     },
     "Strobe": {
-      "capability": {
-        "type": "StrobeSpeed",
-        "speedStart": "16Hz",
-        "speedEnd": "255Hz",
-        "comment": "0-15 no funcion; 16-255 strobing slow->fast"
-      }
+      "capabilities": [
+        {
+          "dmxRange": [0, 14],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [15, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
     }
   },
   "modes": [
@@ -63,7 +76,7 @@
       "shortName": "2 channel",
       "channels": [
         "White",
-        "Master / Dimmer"
+        "Master Dimmer"
       ]
     },
     {
@@ -71,7 +84,7 @@
       "shortName": "3 Channel",
       "channels": [
         "White",
-        "Master / Dimmer",
+        "Master Dimmer",
         "Strobe"
       ]
     }

--- a/fixtures/american-dj/encore-profile-1000ww.json
+++ b/fixtures/american-dj/encore-profile-1000ww.json
@@ -18,16 +18,15 @@
     ]
   },
   "physical": {
-    "dimensions": [560, 250, 385],
+    "dimensions": [250, 385, 560],
     "weight": 8.5,
     "power": 144,
     "DMXconnector": "3-pin and 5-pin",
     "bulb": {
-      "type": "LED",
+      "type": "120W warm white COB LED",
       "colorTemperature": 3200
     },
     "lens": {
-      "name": "Beam Angle",
       "degreesMinMax": [12, 30]
     }
   },

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -40,7 +40,7 @@
       "lastActionDate": "2018-08-09",
       "lastAction": "modified"
     },
-    "american-dj/encore-profile-1000ww": {
+    "american-dj/encore-profile-1000-ww": {
       "name": "Encore Profile 1000 WW",
       "lastActionDate": "2019-02-24",
       "lastAction": "created"
@@ -1127,7 +1127,7 @@
       "auto-spot-150",
       "boom-box-fx2",
       "dotz-par",
-      "encore-profile-1000ww",
+      "encore-profile-1000-ww",
       "flat-par-qa12xs",
       "fog-fury-jett-pro",
       "galaxian-3d",
@@ -1472,7 +1472,7 @@
     "Blinder": [
       "adb/alc4",
       "american-dj/dotz-par",
-      "american-dj/encore-profile-1000ww",
+      "american-dj/encore-profile-1000-ww",
       "american-dj/flat-par-qa12xs",
       "cameo/flash-matrix-250",
       "cameo/flat-pro-flood-ip65-tri",
@@ -1679,7 +1679,7 @@
     ],
     "Dimmer": [
       "adb/europe-105",
-      "american-dj/encore-profile-1000ww",
+      "american-dj/encore-profile-1000-ww",
       "american-dj/flat-par-qa12xs",
       "american-dj/saber-spot-rgbw",
       "arri/skypanel-s30c",
@@ -2212,7 +2212,7 @@
       "eliminator/stealth-beam"
     ],
     "Gerard Fontanillas": [
-      "american-dj/encore-profile-1000ww"
+      "american-dj/encore-profile-1000-ww"
     ],
     "jc": [
       "american-dj/inno-pocket-beam-q4"
@@ -2449,7 +2449,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
-    "american-dj/encore-profile-1000ww",
+    "american-dj/encore-profile-1000-ww",
     "beamz/h2000-faze-machine",
     "elation/design-led-par-zoom",
     "cinetec/par-18x15w-rgbwa",

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -40,6 +40,11 @@
       "lastActionDate": "2018-08-09",
       "lastAction": "modified"
     },
+    "american-dj/encore-profile-1000ww": {
+      "name": "Encore profile 1000WW",
+      "lastActionDate": "2019-02-24",
+      "lastAction": "created"
+    },
     "american-dj/flat-par-qa12xs": {
       "name": "Flat Par QA12XS",
       "lastActionDate": "2018-08-09",
@@ -1122,6 +1127,7 @@
       "auto-spot-150",
       "boom-box-fx2",
       "dotz-par",
+      "encore-profile-1000ww",
       "flat-par-qa12xs",
       "fog-fury-jett-pro",
       "galaxian-3d",
@@ -1466,6 +1472,7 @@
     "Blinder": [
       "adb/alc4",
       "american-dj/dotz-par",
+      "american-dj/encore-profile-1000ww",
       "american-dj/flat-par-qa12xs",
       "cameo/flash-matrix-250",
       "cameo/flat-pro-flood-ip65-tri",
@@ -2203,6 +2210,9 @@
     "George Qualley IV": [
       "eliminator/stealth-beam"
     ],
+    "Gerard Fontanillas": [
+      "american-dj/encore-profile-1000ww"
+    ],
     "jc": [
       "american-dj/inno-pocket-beam-q4"
     ],
@@ -2438,6 +2448,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
+    "american-dj/encore-profile-1000ww",
     "beamz/h2000-faze-machine",
     "elation/design-led-par-zoom",
     "cinetec/par-18x15w-rgbwa",

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -41,7 +41,7 @@
       "lastAction": "modified"
     },
     "american-dj/encore-profile-1000ww": {
-      "name": "Encore profile 1000WW",
+      "name": "Encore Profile 1000 WW",
       "lastActionDate": "2019-02-24",
       "lastAction": "created"
     },
@@ -1679,6 +1679,7 @@
     ],
     "Dimmer": [
       "adb/europe-105",
+      "american-dj/encore-profile-1000ww",
       "american-dj/flat-par-qa12xs",
       "american-dj/saber-spot-rgbw",
       "arri/skypanel-s30c",

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -42,7 +42,7 @@
     },
     "american-dj/encore-profile-1000-ww": {
       "name": "Encore Profile 1000 WW",
-      "lastActionDate": "2019-02-24",
+      "lastActionDate": "2019-02-27",
       "lastAction": "created"
     },
     "american-dj/flat-par-qa12xs": {


### PR DESCRIPTION
* Add fixture 'american-dj/encore-profile-1000ww'
* Update register.json

### Fixture warnings / errors

* american-dj/encore-profile-1000ww
  - :warning: Mode '1 Channel' should have shortName '1ch'.
  - :warning: Mode '1 Channel' should have shortName '1ch'.
  - :warning: Mode '2 Channel' should have shortName '2ch'.
  - :warning: Mode '2 Channel' should have shortName '2ch'.
  - :warning: Mode '3 channel' should have shortName '3ch'.
  - :warning: Mode '3 channel' should have shortName '3ch'.


Thank you **Audiovisual Barcelona**!