### PR TITLE
Add fixture 'robe/robin-300e-wash'

### DIFF
--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -2361,6 +2361,7 @@
       "key": "robe",
       "models": {
         "7": "colorspot-2500e-at",
+        "34": "robin-300e-wash",
         "57": "robin-600e-spot",
         "118": "robin-ledwash-600",
         "203": "robin-viva-cmy"

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -932,7 +932,7 @@
     },
     "robe/robin-300e-wash": {
       "name": "Robin 300E Wash",
-      "lastActionDate": "2019-02-24",
+      "lastActionDate": "2019-03-02",
       "lastAction": "created"
     },
     "robe/robin-600e-spot": {

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -930,6 +930,11 @@
       "lastActionDate": "2018-08-09",
       "lastAction": "modified"
     },
+    "robe/robin-300e-wash": {
+      "name": "Robin 300E Wash",
+      "lastActionDate": "2019-02-24",
+      "lastAction": "created"
+    },
     "robe/robin-600e-spot": {
       "name": "Robin 600E Spot",
       "lastActionDate": "2018-09-04",
@@ -1401,6 +1406,7 @@
     "robe": [
       "colorspot-2500e-at",
       "dj-scan-250-xt",
+      "robin-300e-wash",
       "robin-600e-spot",
       "robin-ledbeam-100",
       "robin-ledbeam-150",
@@ -1640,6 +1646,7 @@
       "renkforce/gm107",
       "robe/colorspot-2500e-at",
       "robe/dj-scan-250-xt",
+      "robe/robin-300e-wash",
       "robe/robin-600e-spot",
       "robe/robin-ledbeam-100",
       "robe/robin-ledbeam-150",
@@ -1814,6 +1821,7 @@
       "qtx/lux-ld30w",
       "renkforce/gm107",
       "robe/colorspot-2500e-at",
+      "robe/robin-300e-wash",
       "robe/robin-600e-spot",
       "robe/robin-ledbeam-100",
       "robe/robin-ledbeam-150",
@@ -2156,6 +2164,10 @@
       "stairville/mh-x25",
       "stairville/stage-tri-led"
     ],
+    "stevebrush": [
+      "martin/rush-par-2-rgbw-zoom",
+      "robe/robin-300e-wash"
+    ],
     "TAKU": [
       "american-dj/dotz-par",
       "american-dj/flat-par-qa12xs"
@@ -2256,9 +2268,6 @@
     ],
     "smokris": [
       "blizzard/puck-rgbaw"
-    ],
-    "stevebrush": [
-      "martin/rush-par-2-rgbw-zoom"
     ],
     "TAP": [
       "prolights/polar3000"
@@ -2438,6 +2447,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
+    "robe/robin-300e-wash",
     "beamz/h2000-faze-machine",
     "elation/design-led-par-zoom",
     "cinetec/par-18x15w-rgbwa",

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -7,13 +7,16 @@
     "createDate": "2019-02-24",
     "lastModifyDate": "2019-02-24"
   },
-  "comment": "Hello, I (tried) to report all dmx cases but can't figure out specials functions. I take dmx map from here : https://www.robe.cz/index.php?type=10898&tx_odproducts_f%5baction%5d=downloadFile&tx_odproducts_f%5bfile%5d=robe/downloads/dmx_charts/Robin_300E_Wash_DMX_charts.pdf",
+  "comment": "Hello, I (tried) to report all dmx cases but can't figure out specials functions.",
   "links": {
     "manual": [
-      "https://www.robe.cz/robin-300e-wash/download/#manuals"
+      "https://www.robe.cz/index.php?type=10898&tx_odproducts_f%5baction%5d=downloadFile&tx_odproducts_f%5bfile%5d=robe/downloads/user_manuals/User_manual_Robin_300E_Wash.pdf"
     ],
     "productPage": [
       "https://www.robe.cz/robin-300e-wash/"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=Eb7pz-xpo2g"
     ]
   },
   "physical": {

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -701,7 +701,8 @@
   },
   "modes": [
     {
-      "name": "1",
+      "name": "1st",
+      "rdmPersonalityIndex": 1,
       "channels": [
         "Pan",
         "Pan fine",
@@ -726,7 +727,8 @@
       ]
     },
     {
-      "name": "2",
+      "name": "2nd",
+      "rdmPersonalityIndex": 2,
       "channels": [
         "Pan",
         "Pan fine",
@@ -748,7 +750,8 @@
       ]
     },
     {
-      "name": "3",
+      "name": "3rd",
+      "rdmPersonalityIndex": 3,
       "channels": [
         "Pan",
         "Tilt",

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -91,7 +91,7 @@
   "availableChannels": {
     "Pan": {
       "fineChannelAliases": ["Pan fine"],
-      "dmxValueResolution": "8bit",
+      "defaultValue": "50%",
       "capability": {
         "type": "Pan",
         "angleStart": "0deg",
@@ -100,7 +100,7 @@
     },
     "Tilt": {
       "fineChannelAliases": ["Tilt fine"],
-      "dmxValueResolution": "8bit",
+      "defaultValue": "50%",
       "capability": {
         "type": "Tilt",
         "angleStart": "0deg",
@@ -108,12 +108,12 @@
       }
     },
     "Pan/Tilt Speed": {
+      "defaultValue": 0,
       "capabilities": [
         {
           "dmxRange": [0, 0],
           "type": "PanTiltSpeed",
-          "speed": "fast",
-          "comment": "max speed"
+          "speed": "fast"
         },
         {
           "dmxRange": [1, 255],
@@ -123,102 +123,257 @@
         }
       ]
     },
-    "Power/Special functions": {
-      "capability": {
-        "type": "Generic",
-        "comment": "To activate following functions, stop in DMX value for at least 3 s and shutter must be closed at least 3 s. („Shutter,Strobe” channel 18/16/14 must be at range: 0‐31 DMX). Corresponding menu items are temporarily overriden)."
-      }
-    },
-    "Colour wheel": {
-      "fineChannelAliases": ["Colour wheel fine"],
-      "dmxValueResolution": "8bit",
+    "Power/Special Functions": {
+      "defaultValue": 0,
       "capabilities": [
         {
-          "dmxRange": [0, 15],
-          "type": "ColorPreset",
-          "comment": "Open/white"
+          "dmxRange": [0, 49],
+          "type": "NoFunction",
+          "comment": "Reserved"
         },
         {
-          "dmxRange": [16, 31],
-          "type": "ColorPreset",
-          "comment": "Deep red"
+          "dmxRange": [50, 59],
+          "type": "Maintenance",
+          "comment": "Pan/tilt speed mode (shutter must be closed)",
+          "hold": "3s"
         },
         {
-          "dmxRange": [32, 47],
-          "type": "ColorPreset",
-          "comment": "Deep red"
+          "dmxRange": [60, 69],
+          "type": "Maintenance",
+          "comment": "Pan/tilt time mode (shutter must be closed)",
+          "hold": "3s"
         },
         {
-          "dmxRange": [48, 63],
-          "type": "ColorPreset",
-          "comment": "Orange"
+          "dmxRange": [70, 79],
+          "type": "Maintenance",
+          "comment": "Blackout while pan/tilt moving (shutter must be closed)",
+          "hold": "3s"
         },
         {
-          "dmxRange": [64, 79],
-          "type": "ColorPreset",
-          "comment": "Green"
+          "dmxRange": [80, 89],
+          "type": "Maintenance",
+          "comment": "Disabled blackout while pan/tilt moving (shutter must be closed)",
+          "hold": "3s"
         },
         {
-          "dmxRange": [80, 95],
-          "type": "ColorPreset",
-          "comment": "Light red"
+          "dmxRange": [90, 99],
+          "type": "Maintenance",
+          "comment": "Blackout while color wheel moving (shutter must be closed)",
+          "hold": "3s"
         },
         {
-          "dmxRange": [96, 111],
-          "type": "ColorPreset",
-          "comment": "Amber"
+          "dmxRange": [100, 109],
+          "type": "Maintenance",
+          "comment": "Disabled blackout while color wheel moving (shutter must be closed)",
+          "hold": "3s"
         },
         {
-          "dmxRange": [112, 127],
-          "type": "ColorPreset",
-          "comment": "UV filter"
+          "dmxRange": [110, 129],
+          "type": "NoFunction",
+          "comment": "Reserved"
+        },
+        {
+          "dmxRange": [130, 139],
+          "type": "Maintenance",
+          "comment": "Lamp on + total reset except pan/tilt",
+          "hold": "3s"
+        },
+        {
+          "dmxRange": [140, 149],
+          "type": "Maintenance",
+          "comment": "Pan/tilt reset",
+          "hold": "3s"
+        },
+        {
+          "dmxRange": [150, 159],
+          "type": "Maintenance",
+          "comment": "Color system reset",
+          "hold": "3s"
+        },
+        {
+          "dmxRange": [160, 169],
+          "type": "NoFunction",
+          "comment": "Reserved"
+        },
+        {
+          "dmxRange": [170, 179],
+          "type": "Maintenance",
+          "comment": "Dimmer/shutter/hot-spot reset",
+          "hold": "3s"
+        },
+        {
+          "dmxRange": [180, 189],
+          "type": "Maintenance",
+          "comment": "Zoom reset",
+          "hold": "3s"
+        },
+        {
+          "dmxRange": [190, 199],
+          "type": "NoFunction",
+          "comment": "Reserved"
+        },
+        {
+          "dmxRange": [200, 209],
+          "type": "Maintenance",
+          "comment": "Total reset",
+          "hold": "3s"
+        },
+        {
+          "dmxRange": [210, 229],
+          "type": "NoFunction",
+          "comment": "Reserved"
+        },
+        {
+          "dmxRange": [230, 239],
+          "type": "Maintenance",
+          "comment": "Lamp off",
+          "hold": "3s"
+        },
+        {
+          "dmxRange": [240, 255],
+          "type": "NoFunction",
+          "comment": "Reserved"
+        }
+      ]
+    },
+    "Color Wheel": {
+      "fineChannelAliases": ["Color Wheel fine"],
+      "dmxValueResolution": "8bit",
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [1, 15],
+          "type": "WheelSlot",
+          "slotNumberStart": 1,
+          "slotNumberEnd": 2
+        },
+        {
+          "dmxRange": [16, 16],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [17, 31],
+          "type": "WheelSlot",
+          "slotNumberStart": 2,
+          "slotNumberEnd": 3
+        },
+        {
+          "dmxRange": [32, 32],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [33, 47],
+          "type": "WheelSlot",
+          "slotNumberStart": 3,
+          "slotNumberEnd": 4
+        },
+        {
+          "dmxRange": [48, 48],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [49, 63],
+          "type": "WheelSlot",
+          "slotNumberStart": 4,
+          "slotNumberEnd": 5
+        },
+        {
+          "dmxRange": [64, 64],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [65, 79],
+          "type": "WheelSlot",
+          "slotNumberStart": 5,
+          "slotNumberEnd": 6
+        },
+        {
+          "dmxRange": [80, 80],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [81, 95],
+          "type": "WheelSlot",
+          "slotNumberStart": 6,
+          "slotNumberEnd": 7
+        },
+        {
+          "dmxRange": [96, 96],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [97, 111],
+          "type": "WheelSlot",
+          "slotNumberStart": 7,
+          "slotNumberEnd": 8
+        },
+        {
+          "dmxRange": [112, 112],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [113, 127],
+          "type": "WheelSlot",
+          "slotNumberStart": 8,
+          "slotNumberEnd": 9
         },
         {
           "dmxRange": [128, 129],
-          "type": "ColorPreset",
-          "comment": "White"
+          "type": "WheelSlot",
+          "slotNumber": 1
         },
         {
           "dmxRange": [130, 137],
-          "type": "ColorPreset",
-          "comment": "Deep red"
+          "type": "WheelSlot",
+          "slotNumber": 2
         },
         {
           "dmxRange": [138, 145],
-          "type": "ColorPreset",
-          "comment": "Deep blue"
+          "type": "WheelSlot",
+          "slotNumber": 3
         },
         {
           "dmxRange": [146, 153],
-          "type": "ColorPreset",
-          "comment": "Orange"
+          "type": "WheelSlot",
+          "slotNumber": 4
         },
         {
           "dmxRange": [154, 163],
-          "type": "ColorPreset",
-          "comment": "Green"
+          "type": "WheelSlot",
+          "slotNumber": 5
         },
         {
           "dmxRange": [164, 171],
-          "type": "ColorPreset",
-          "comment": "Light red"
+          "type": "WheelSlot",
+          "slotNumber": 6
         },
         {
           "dmxRange": [172, 181],
-          "type": "ColorPreset",
-          "comment": "Amber"
+          "type": "WheelSlot",
+          "slotNumber": 7
         },
         {
           "dmxRange": [182, 189],
-          "type": "ColorPreset",
-          "comment": "UV filter"
+          "type": "WheelSlot",
+          "slotNumber": 8
         },
         {
           "dmxRange": [190, 215],
           "type": "WheelRotation",
-          "speedStart": "fast CW",
-          "speedEnd": "slow CW",
-          "comment": "Forwards rainbow effect from fast to slow"
+          "speedStart": "fast CCW",
+          "speedEnd": "slow CCW"
         },
         {
           "dmxRange": [216, 217],
@@ -233,309 +388,314 @@
         },
         {
           "dmxRange": [244, 249],
-          "type": "ColorPreset",
-          "comment": "Random colour selection by audio control"
+          "type": "Effect",
+          "effectName": "Random color sound-controlled",
+          "soundControlled": true
         },
         {
           "dmxRange": [250, 255],
-          "type": "ColorPreset",
-          "comment": "Auto random colour selection from fast to slow"
+          "type": "Effect",
+          "effectName": "Random color",
+          "speedStart": "fast",
+          "speedEnd": "slow"
         }
       ]
     },
     "Cyan": {
+      "defaultValue": 0,
       "capability": {
         "type": "ColorIntensity",
         "color": "Cyan"
       }
     },
     "Magenta": {
+      "defaultValue": 0,
       "capability": {
         "type": "ColorIntensity",
         "color": "Magenta"
       }
     },
     "Yellow": {
+      "defaultValue": 0,
       "capability": {
         "type": "ColorIntensity",
         "color": "Yellow"
       }
     },
-    "CTO filter": {
+    "CTO Filter": {
+      "defaultValue": 0,
       "capability": {
         "type": "ColorTemperature",
         "colorTemperatureStart": "8800K",
         "colorTemperatureEnd": "3200K"
       }
     },
-    "CMY colour macros": {
+    "CMY Color Macros": {
+      "defaultValue": 0,
       "capabilities": [
         {
           "dmxRange": [0, 7],
-          "type": "WheelSlot",
-          "slotNumber": 1
+          "type": "NoFunction"
         },
         {
           "dmxRange": [8, 15],
-          "type": "WheelSlot",
-          "slotNumber": 2
+          "type": "Effect",
+          "effectName": "Macro 1"
         },
         {
           "dmxRange": [16, 23],
-          "type": "WheelSlot",
-          "slotNumber": 3
+          "type": "Effect",
+          "effectName": "Macro 2"
         },
         {
           "dmxRange": [24, 31],
-          "type": "WheelSlot",
-          "slotNumber": 4
+          "type": "Effect",
+          "effectName": "Macro 3"
         },
         {
           "dmxRange": [32, 39],
-          "type": "WheelSlot",
-          "slotNumber": 5
+          "type": "Effect",
+          "effectName": "Macro 4"
         },
         {
           "dmxRange": [40, 47],
-          "type": "WheelSlot",
-          "slotNumber": 6
+          "type": "Effect",
+          "effectName": "Macro 5"
         },
         {
           "dmxRange": [48, 55],
-          "type": "WheelSlot",
-          "slotNumber": 7
+          "type": "Effect",
+          "effectName": "Macro 6"
         },
         {
           "dmxRange": [56, 63],
-          "type": "WheelSlot",
-          "slotNumber": 8
+          "type": "Effect",
+          "effectName": "Macro 7"
         },
         {
           "dmxRange": [64, 71],
-          "type": "WheelSlot",
-          "slotNumber": 9
+          "type": "Effect",
+          "effectName": "Macro 8"
         },
         {
           "dmxRange": [72, 79],
-          "type": "WheelSlot",
-          "slotNumber": 10
+          "type": "Effect",
+          "effectName": "Macro 9"
         },
         {
           "dmxRange": [80, 87],
-          "type": "WheelSlot",
-          "slotNumber": 11
+          "type": "Effect",
+          "effectName": "Macro 10"
         },
         {
           "dmxRange": [88, 95],
-          "type": "WheelSlot",
-          "slotNumber": 12
+          "type": "Effect",
+          "effectName": "Macro 11"
         },
         {
           "dmxRange": [96, 103],
-          "type": "WheelSlot",
-          "slotNumber": 13
+          "type": "Effect",
+          "effectName": "Macro 12"
         },
         {
           "dmxRange": [104, 111],
-          "type": "WheelSlot",
-          "slotNumber": 14
+          "type": "Effect",
+          "effectName": "Macro 13"
         },
         {
           "dmxRange": [112, 119],
-          "type": "WheelSlot",
-          "slotNumber": 15
+          "type": "Effect",
+          "effectName": "Macro 14"
         },
         {
           "dmxRange": [120, 127],
-          "type": "WheelSlot",
-          "slotNumber": 16
+          "type": "Effect",
+          "effectName": "Macro 15"
         },
         {
           "dmxRange": [128, 135],
-          "type": "WheelSlot",
-          "slotNumber": 17
+          "type": "Effect",
+          "effectName": "Macro 16"
         },
         {
           "dmxRange": [136, 143],
-          "type": "WheelSlot",
-          "slotNumber": 18
+          "type": "Effect",
+          "effectName": "Macro 17"
         },
         {
           "dmxRange": [144, 151],
-          "type": "WheelSlot",
-          "slotNumber": 19
+          "type": "Effect",
+          "effectName": "Macro 18"
         },
         {
           "dmxRange": [152, 159],
-          "type": "WheelSlot",
-          "slotNumber": 20
+          "type": "Effect",
+          "effectName": "Macro 19"
         },
         {
           "dmxRange": [160, 167],
-          "type": "WheelSlot",
-          "slotNumber": 21
+          "type": "Effect",
+          "effectName": "Macro 20"
         },
         {
           "dmxRange": [168, 175],
-          "type": "WheelSlot",
-          "slotNumber": 22
+          "type": "Effect",
+          "effectName": "Macro 21"
         },
         {
           "dmxRange": [176, 183],
-          "type": "WheelSlot",
-          "slotNumber": 23
+          "type": "Effect",
+          "effectName": "Macro 22"
         },
         {
           "dmxRange": [184, 191],
-          "type": "WheelSlot",
-          "slotNumber": 24
+          "type": "Effect",
+          "effectName": "Macro 23"
         },
         {
           "dmxRange": [192, 199],
-          "type": "WheelSlot",
-          "slotNumber": 25
+          "type": "Effect",
+          "effectName": "Macro 24"
         },
         {
           "dmxRange": [200, 207],
-          "type": "WheelSlot",
-          "slotNumber": 26
+          "type": "Effect",
+          "effectName": "Macro 25"
         },
         {
           "dmxRange": [208, 215],
-          "type": "WheelSlot",
-          "slotNumber": 27
+          "type": "Effect",
+          "effectName": "Macro 26"
         },
         {
           "dmxRange": [216, 223],
-          "type": "WheelSlot",
-          "slotNumber": 28
+          "type": "Effect",
+          "effectName": "Macro 27"
         },
         {
           "dmxRange": [224, 231],
-          "type": "WheelSlot",
-          "slotNumber": 29
+          "type": "Effect",
+          "effectName": "Macro 28"
         },
         {
           "dmxRange": [232, 239],
-          "type": "WheelSlot",
-          "slotNumber": 30
+          "type": "Effect",
+          "effectName": "Macro 29"
         },
         {
-          "dmxRange": [240, 247],
-          "type": "WheelSlot",
-          "slotNumber": 31
+          "dmxRange": [240, 243],
+          "type": "Effect",
+          "effectName": "Macro 30"
         },
         {
-          "dmxRange": [248, 255],
-          "type": "WheelSlot",
-          "slotNumber": 32
+          "dmxRange": [244, 249],
+          "type": "Effect",
+          "effectName": "Random color macro sound-controlled",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "Effect",
+          "effectName": "Random color macro",
+          "speedStart": "fast",
+          "speedEnd": "slow"
         }
       ]
     },
     "CMY & CTO Speed": {
+      "defaultValue": 0,
       "capability": {
         "type": "Speed",
         "speedStart": "fast",
         "speedEnd": "slow",
-        "comment": "Speed of flags movement from max. to min."
+        "comment": "Flags movement"
       }
     },
     "Zoom": {
       "fineChannelAliases": ["Zoom fine"],
-      "dmxValueResolution": "8bit",
       "capability": {
         "type": "Zoom",
         "angleStart": "narrow",
         "angleEnd": "wide"
       }
     },
-    "Hot‐Spot": {
+    "Hot-Spot": {
+      "defaultValue": 0,
       "capability": {
-        "type": "Frost",
-        "frostIntensityStart": "high",
-        "frostIntensityEnd": "low",
-        "comment": "Beam distribution control from max. to min. intensity"
+        "type": "Maintenance",
+        "parameterStart": "high",
+        "parameterEnd": "low",
+        "comment": "Beam distribution"
       }
     },
-    "Shutter/ strobe": {
+    "Shutter / Strobe": {
       "capabilities": [
         {
           "dmxRange": [0, 31],
           "type": "ShutterStrobe",
           "shutterEffect": "Closed",
-          "comment": "Shutter closed, Lamp power reduced to 180W"
+          "comment": "Lamp power = 180W"
         },
         {
           "dmxRange": [32, 63],
           "type": "ShutterStrobe",
-          "shutterEffect": "Open",
-          "comment": "Shutter open, Full lamp power"
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [64, 95],
-          "type": "StrobeSpeed",
-          "speedStart": "slow",
-          "speedEnd": "fast",
-          "comment": "Strobe‐effect from slow to fast"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0Hz",
+          "speedEnd": "15Hz"
         },
         {
           "dmxRange": [96, 127],
           "type": "ShutterStrobe",
           "shutterEffect": "Open",
-          "comment": "Shutter open, Lamp power reduced to 180 W"
+          "comment": "Lamp power = 180W"
         },
         {
           "dmxRange": [128, 143],
           "type": "ShutterStrobe",
-          "shutterEffect": "Pulse",
-          "soundControlled": false,
+          "shutterEffect": "RampUp",
           "speedStart": "slow",
-          "speedEnd": "fast",
-          "comment": "Opening pulse in sequences from slow to fast"
+          "speedEnd": "fast"
         },
         {
           "dmxRange": [144, 159],
           "type": "ShutterStrobe",
-          "shutterEffect": "Pulse",
-          "soundControlled": false,
+          "shutterEffect": "RampDown",
           "speedStart": "fast",
-          "speedEnd": "slow",
-          "comment": "Closing pulse in sequences from fast to slow"
+          "speedEnd": "slow"
         },
         {
           "dmxRange": [160, 191],
           "type": "ShutterStrobe",
           "shutterEffect": "Strobe",
-          "soundControlled": false,
-          "speedStart": "slow",
-          "speedEnd": "fast",
-          "comment": "Shutter open, Electronic strobing „ZAP” from slow to fast"
+          "speedStart": "0Hz",
+          "speedEnd": "33Hz",
+          "comment": "electronic zapping"
         },
         {
           "dmxRange": [192, 223],
           "type": "ShutterStrobe",
           "shutterEffect": "Strobe",
-          "soundControlled": false,
           "speedStart": "slow",
           "speedEnd": "fast",
-          "randomTiming": true,
-          "comment": "Random strobe‐effect from slow to fast"
+          "randomTiming": true
         },
         {
           "dmxRange": [224, 255],
           "type": "ShutterStrobe",
-          "shutterEffect": "Open",
-          "comment": "Shutter open, Full lamp power"
+          "shutterEffect": "Open"
         }
       ]
     },
-    "Dimmer intensity": {
-      "fineChannelAliases": ["Dimmer intensity fine"],
-      "dmxValueResolution": "8bit",
+    "Dimmer": {
+      "fineChannelAliases": ["Dimmer fine"],
+      "defaultValue": 0,
       "capability": {
-        "type": "Intensity",
-        "brightnessStart": "0%",
-        "brightnessEnd": "100%"
+        "type": "Intensity"
       }
     }
   },
@@ -548,21 +708,21 @@
         "Tilt",
         "Tilt fine",
         "Pan/Tilt Speed",
-        "Power/Special functions",
-        "Colour wheel",
-        "Colour wheel fine",
+        "Power/Special Functions",
+        "Color Wheel",
+        "Color Wheel fine",
         "Cyan",
         "Magenta",
         "Yellow",
-        "CTO filter",
-        "CMY colour macros",
+        "CTO Filter",
+        "CMY Color Macros",
         "CMY & CTO Speed",
         "Zoom",
         "Zoom fine",
-        "Hot‐Spot",
-        "Shutter/ strobe",
-        "Dimmer intensity",
-        "Dimmer intensity fine"
+        "Hot-Spot",
+        "Shutter / Strobe",
+        "Dimmer",
+        "Dimmer fine"
       ]
     },
     {
@@ -573,18 +733,18 @@
         "Tilt",
         "Tilt fine",
         "Pan/Tilt Speed",
-        "Power/Special functions",
-        "Colour wheel",
+        "Power/Special Functions",
+        "Color Wheel",
         "Cyan",
         "Magenta",
         "Yellow",
-        "CTO filter",
-        "CMY colour macros",
+        "CTO Filter",
+        "CMY Color Macros",
         "CMY & CTO Speed",
         "Zoom",
-        "Hot‐Spot",
-        "Shutter/ strobe",
-        "Dimmer intensity"
+        "Hot-Spot",
+        "Shutter / Strobe",
+        "Dimmer"
       ]
     },
     {
@@ -593,18 +753,18 @@
         "Pan",
         "Tilt",
         "Pan/Tilt Speed",
-        "Power/Special functions",
-        "Colour wheel",
+        "Power/Special Functions",
+        "Color Wheel",
         "Cyan",
         "Magenta",
         "Yellow",
-        "CTO filter",
-        "CMY colour macros",
+        "CTO Filter",
+        "CMY Color Macros",
         "CMY & CTO Speed",
         "Zoom",
-        "Hot‐Spot",
-        "Shutter/ strobe",
-        "Dimmer intensity"
+        "Hot-Spot",
+        "Shutter / Strobe",
+        "Dimmer"
       ]
     }
   ]

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -614,8 +614,8 @@
       "fineChannelAliases": ["Zoom fine"],
       "capability": {
         "type": "Zoom",
-        "angleStart": "narrow",
-        "angleEnd": "wide"
+        "angleStart": "4deg",
+        "angleEnd": "40deg"
       }
     },
     "Hot-Spot": {

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -4,8 +4,8 @@
   "categories": ["Moving Head", "Color Changer"],
   "meta": {
     "authors": ["stevebrush"],
-    "createDate": "2019-02-24",
-    "lastModifyDate": "2019-02-24"
+    "createDate": "2019-03-02",
+    "lastModifyDate": "2019-03-02"
   },
   "links": {
     "manual": [

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "Robin 300E Wash",
-  "categories": ["Color Changer", "Moving Head"],
+  "categories": ["Moving Head", "Color Changer"],
   "meta": {
     "authors": ["stevebrush"],
     "createDate": "2019-02-24",

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -1,0 +1,658 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Robin 300E Wash",
+  "categories": ["Color Changer", "Moving Head"],
+  "meta": {
+    "authors": ["stevebrush"],
+    "createDate": "2019-02-24",
+    "lastModifyDate": "2019-02-24"
+  },
+  "comment": "Hello, I (tried) to report all dmx cases but can't figure out specials functions. I take dmx map from here : https://www.robe.cz/index.php?type=10898&tx_odproducts_f%5baction%5d=downloadFile&tx_odproducts_f%5bfile%5d=robe/downloads/dmx_charts/Robin_300E_Wash_DMX_charts.pdf",
+  "links": {
+    "manual": [
+      "https://www.robe.cz/robin-300e-wash/download/#manuals"
+    ],
+    "productPage": [
+      "https://www.robe.cz/robin-300e-wash/"
+    ]
+  },
+  "physical": {
+    "dimensions": [383.3, 516.2, 409.2],
+    "weight": 20,
+    "power": 440,
+    "DMXconnector": "3-pin and 5-pin",
+    "bulb": {
+      "type": "high-presure metal halide lamp"
+    },
+    "lens": {
+      "degreesMinMax": [4, 40]
+    },
+    "focus": {
+      "type": "Head",
+      "panMax": 540,
+      "tiltMax": 260
+    }
+  },
+  "wheels": {
+    "CMY colour macros": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "260deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "PanTiltSpeed",
+          "speed": "fast",
+          "comment": "max speed"
+        },
+        {
+          "dmxRange": [1, 255],
+          "type": "PanTiltSpeed",
+          "speedStart": "fast",
+          "speedEnd": "slow"
+        }
+      ]
+    },
+    "Power/Special functions": {
+      "capability": {
+        "type": "Generic",
+        "comment": "To activate following functions, stop in DMX value for at least 3 s and shutter must be closed at least 3 s. („Shutter,Strobe” channel 18/16/14 must be at range: 0‐31 DMX). Corresponding menu items are temporarily overriden)."
+      }
+    },
+    "Colour wheel": {
+      "fineChannelAliases": ["Colour wheel fine"],
+      "dmxValueResolution": "8bit",
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "ColorPreset",
+          "comment": "Open/white"
+        },
+        {
+          "dmxRange": [16, 31],
+          "type": "ColorPreset",
+          "comment": "Deep red"
+        },
+        {
+          "dmxRange": [32, 47],
+          "type": "ColorPreset",
+          "comment": "Deep red"
+        },
+        {
+          "dmxRange": [48, 63],
+          "type": "ColorPreset",
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [64, 79],
+          "type": "ColorPreset",
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [80, 95],
+          "type": "ColorPreset",
+          "comment": "Light red"
+        },
+        {
+          "dmxRange": [96, 111],
+          "type": "ColorPreset",
+          "comment": "Amber"
+        },
+        {
+          "dmxRange": [112, 127],
+          "type": "ColorPreset",
+          "comment": "UV filter"
+        },
+        {
+          "dmxRange": [128, 129],
+          "type": "ColorPreset",
+          "comment": "White"
+        },
+        {
+          "dmxRange": [130, 137],
+          "type": "ColorPreset",
+          "comment": "Deep red"
+        },
+        {
+          "dmxRange": [138, 145],
+          "type": "ColorPreset",
+          "comment": "Deep blue"
+        },
+        {
+          "dmxRange": [146, 153],
+          "type": "ColorPreset",
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [154, 163],
+          "type": "ColorPreset",
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [164, 171],
+          "type": "ColorPreset",
+          "comment": "Light red"
+        },
+        {
+          "dmxRange": [172, 181],
+          "type": "ColorPreset",
+          "comment": "Amber"
+        },
+        {
+          "dmxRange": [182, 189],
+          "type": "ColorPreset",
+          "comment": "UV filter"
+        },
+        {
+          "dmxRange": [190, 215],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW",
+          "comment": "Forwards rainbow effect from fast to slow"
+        },
+        {
+          "dmxRange": [216, 217],
+          "type": "WheelRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [218, 243],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [244, 249],
+          "type": "ColorPreset",
+          "comment": "Random colour selection by audio control"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "ColorPreset",
+          "comment": "Auto random colour selection from fast to slow"
+        }
+      ]
+    },
+    "Cyan": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Cyan"
+      }
+    },
+    "Magenta": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Magenta"
+      }
+    },
+    "Yellow": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Yellow"
+      }
+    },
+    "CTO filter": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "8800K",
+        "colorTemperatureEnd": "3200K"
+      }
+    },
+    "CMY colour macros": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "WheelSlot",
+          "slotNumber": 10
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "WheelSlot",
+          "slotNumber": 11
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "WheelSlot",
+          "slotNumber": 12
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "WheelSlot",
+          "slotNumber": 13
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "WheelSlot",
+          "slotNumber": 14
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "WheelSlot",
+          "slotNumber": 15
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelSlot",
+          "slotNumber": 16
+        },
+        {
+          "dmxRange": [128, 135],
+          "type": "WheelSlot",
+          "slotNumber": 17
+        },
+        {
+          "dmxRange": [136, 143],
+          "type": "WheelSlot",
+          "slotNumber": 18
+        },
+        {
+          "dmxRange": [144, 151],
+          "type": "WheelSlot",
+          "slotNumber": 19
+        },
+        {
+          "dmxRange": [152, 159],
+          "type": "WheelSlot",
+          "slotNumber": 20
+        },
+        {
+          "dmxRange": [160, 167],
+          "type": "WheelSlot",
+          "slotNumber": 21
+        },
+        {
+          "dmxRange": [168, 175],
+          "type": "WheelSlot",
+          "slotNumber": 22
+        },
+        {
+          "dmxRange": [176, 183],
+          "type": "WheelSlot",
+          "slotNumber": 23
+        },
+        {
+          "dmxRange": [184, 191],
+          "type": "WheelSlot",
+          "slotNumber": 24
+        },
+        {
+          "dmxRange": [192, 199],
+          "type": "WheelSlot",
+          "slotNumber": 25
+        },
+        {
+          "dmxRange": [200, 207],
+          "type": "WheelSlot",
+          "slotNumber": 26
+        },
+        {
+          "dmxRange": [208, 215],
+          "type": "WheelSlot",
+          "slotNumber": 27
+        },
+        {
+          "dmxRange": [216, 223],
+          "type": "WheelSlot",
+          "slotNumber": 28
+        },
+        {
+          "dmxRange": [224, 231],
+          "type": "WheelSlot",
+          "slotNumber": 29
+        },
+        {
+          "dmxRange": [232, 239],
+          "type": "WheelSlot",
+          "slotNumber": 30
+        },
+        {
+          "dmxRange": [240, 247],
+          "type": "WheelSlot",
+          "slotNumber": 31
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "WheelSlot",
+          "slotNumber": 32
+        }
+      ]
+    },
+    "CMY & CTO Speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "fast",
+        "speedEnd": "slow",
+        "comment": "Speed of flags movement from max. to min."
+      }
+    },
+    "Zoom": {
+      "fineChannelAliases": ["Zoom fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "narrow",
+        "angleEnd": "wide"
+      }
+    },
+    "Hot‐Spot": {
+      "capability": {
+        "type": "Frost",
+        "frostIntensityStart": "high",
+        "frostIntensityEnd": "low",
+        "comment": "Beam distribution control from max. to min. intensity"
+      }
+    },
+    "Shutter/ strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 31],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed",
+          "comment": "Shutter closed, Lamp power reduced to 180W"
+        },
+        {
+          "dmxRange": [32, 63],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open",
+          "comment": "Shutter open, Full lamp power"
+        },
+        {
+          "dmxRange": [64, 95],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Strobe‐effect from slow to fast"
+        },
+        {
+          "dmxRange": [96, 127],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open",
+          "comment": "Shutter open, Lamp power reduced to 180 W"
+        },
+        {
+          "dmxRange": [128, 143],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse",
+          "soundControlled": false,
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Opening pulse in sequences from slow to fast"
+        },
+        {
+          "dmxRange": [144, 159],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse",
+          "soundControlled": false,
+          "speedStart": "fast",
+          "speedEnd": "slow",
+          "comment": "Closing pulse in sequences from fast to slow"
+        },
+        {
+          "dmxRange": [160, 191],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "soundControlled": false,
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Shutter open, Electronic strobing „ZAP” from slow to fast"
+        },
+        {
+          "dmxRange": [192, 223],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "soundControlled": false,
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "randomTiming": true,
+          "comment": "Random strobe‐effect from slow to fast"
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open",
+          "comment": "Shutter open, Full lamp power"
+        }
+      ]
+    },
+    "Dimmer intensity": {
+      "fineChannelAliases": ["Dimmer intensity fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "1",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Pan/Tilt Speed",
+        "Power/Special functions",
+        "Colour wheel",
+        "Colour wheel fine",
+        "Cyan",
+        "Magenta",
+        "Yellow",
+        "CTO filter",
+        "CMY colour macros",
+        "CMY & CTO Speed",
+        "Zoom",
+        "Zoom fine",
+        "Hot‐Spot",
+        "Shutter/ strobe",
+        "Dimmer intensity",
+        "Dimmer intensity fine"
+      ]
+    },
+    {
+      "name": "2",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Pan/Tilt Speed",
+        "Power/Special functions",
+        "Colour wheel",
+        "Cyan",
+        "Magenta",
+        "Yellow",
+        "CTO filter",
+        "CMY colour macros",
+        "CMY & CTO Speed",
+        "Zoom",
+        "Hot‐Spot",
+        "Shutter/ strobe",
+        "Dimmer intensity"
+      ]
+    },
+    {
+      "name": "3",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Pan/Tilt Speed",
+        "Power/Special functions",
+        "Colour wheel",
+        "Cyan",
+        "Magenta",
+        "Yellow",
+        "CTO filter",
+        "CMY colour macros",
+        "CMY & CTO Speed",
+        "Zoom",
+        "Hot‐Spot",
+        "Shutter/ strobe",
+        "Dimmer intensity"
+      ]
+    }
+  ]
+}

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -7,7 +7,6 @@
     "createDate": "2019-02-24",
     "lastModifyDate": "2019-02-24"
   },
-  "comment": "Hello, I (tried) to report all dmx cases but can't figure out specials functions.",
   "links": {
     "manual": [
       "https://www.robe.cz/index.php?type=10898&tx_odproducts_f%5baction%5d=downloadFile&tx_odproducts_f%5bfile%5d=robe/downloads/user_manuals/User_manual_Robin_300E_Wash.pdf",

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -20,12 +20,14 @@
     ]
   },
   "physical": {
-    "dimensions": [383.3, 516.2, 409.2],
+    "dimensions": [432.6, 516.2, 409.2],
     "weight": 20,
     "power": 440,
     "DMXconnector": "3-pin and 5-pin",
     "bulb": {
-      "type": "high-presure metal halide lamp"
+      "type": "Philips MSR Gold 300/2 MiniFastFit",
+      "colorTemperature": 9300,
+      "lumens": 23000
     },
     "lens": {
       "degreesMinMax": [4, 40]

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -10,7 +10,8 @@
   "comment": "Hello, I (tried) to report all dmx cases but can't figure out specials functions.",
   "links": {
     "manual": [
-      "https://www.robe.cz/index.php?type=10898&tx_odproducts_f%5baction%5d=downloadFile&tx_odproducts_f%5bfile%5d=robe/downloads/user_manuals/User_manual_Robin_300E_Wash.pdf"
+      "https://www.robe.cz/index.php?type=10898&tx_odproducts_f%5baction%5d=downloadFile&tx_odproducts_f%5bfile%5d=robe/downloads/user_manuals/User_manual_Robin_300E_Wash.pdf",
+      "https://www.robe.cz/index.php?type=10898&tx_odproducts_f%5baction%5d=downloadFile&tx_odproducts_f%5bfile%5d=robe/downloads/gobo_config/CW_7_1_Robin_300E_Wash.pdf"
     ],
     "productPage": [
       "https://www.robe.cz/robin-300e-wash/"
@@ -43,103 +44,46 @@
     "softwareVersion": "2.9"
   },
   "wheels": {
-    "CMY colour macros": {
+    "Color Wheel": {
+      "direction": "CCW",
       "slots": [
         {
           "type": "Open"
         },
         {
-          "type": "Open"
+          "type": "Color",
+          "name": "Deep red (99011881)",
+          "colors": ["#e23022"]
         },
         {
-          "type": "Open"
+          "type": "Color",
+          "name": "Deep blue (99011882)",
+          "colors": ["#0251ab"]
         },
         {
-          "type": "Open"
+          "type": "Color",
+          "name": "Orange (99011884)",
+          "colors": ["#ffa54d"]
         },
         {
-          "type": "Open"
+          "type": "Color",
+          "name": "Green (99011883)",
+          "colors": ["#00ab4f"]
         },
         {
-          "type": "Open"
+          "type": "Color",
+          "name": "Light red (99011887)",
+          "colors": ["#ff4f40"]
         },
         {
-          "type": "Open"
+          "type": "Color",
+          "name": "Amber (99011886)",
+          "colors": ["#ffc64f"]
         },
         {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Open"
+          "type": "Color",
+          "name": "UV (99011885)",
+          "colors": ["#1d2971"]
         }
       ]
     }

--- a/fixtures/robe/robin-300e-wash.json
+++ b/fixtures/robe/robin-300e-wash.json
@@ -38,6 +38,10 @@
       "tiltMax": 260
     }
   },
+  "rdm": {
+    "modelId": 34,
+    "softwareVersion": "2.9"
+  },
   "wheels": {
     "CMY colour macros": {
       "slots": [


### PR DESCRIPTION
* Add fixture 'robe/robin-300e-wash'
* Update register.json

### Fixture warnings / errors

* robe/robin-300e-wash
  - :x: Capability 'Wheel rotation CW fast…slow (Forwards rainbow effect from fast to slow)' (190…215) in channel 'Colour wheel' does not explicitly reference any wheel, but the default wheel 'Colour wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation stop' (216…217) in channel 'Colour wheel' does not explicitly reference any wheel, but the default wheel 'Colour wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (218…243) in channel 'Colour wheel' does not explicitly reference any wheel, but the default wheel 'Colour wheel' (through the channel name) does not exist.
  - :warning: Name of wheel 'CMY colour macros' does not contain the word 'wheel' or 'disk', which could lead to confusing capability names.


Thank you @steevebrush!