### PR TITLE
Add fixture 'american-dj/starbust'

### DIFF
--- a/fixtures/american-dj/starburst.json
+++ b/fixtures/american-dj/starburst.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "Starbust",
   "shortName": "ADJStarburst",
-  "categories": ["Flower", "Moving Head", "Color Changer"],
+  "categories": ["Effect", "Flower", "Color Changer"],
   "meta": {
     "authors": ["Gerard Fontanillas"],
     "createDate": "2019-03-03",
@@ -32,10 +32,6 @@
     "lens": {
       "name": "34 beams",
       "degreesMinMax": [1, 1]
-    },
-    "focus": {
-      "type": "Head",
-      "panMax": "infinite"
     }
   },
   "availableChannels": {
@@ -145,7 +141,7 @@
         "type": "Intensity"
       }
     },
-    "Pan": {
+    "Rotation": {
       "defaultValue": 143,
       "capabilities": [
         {
@@ -154,18 +150,18 @@
         },
         {
           "dmxRange": [31, 140],
-          "type": "PanContinuous",
+          "type": "Rotation",
           "speedStart": "fast CW",
           "speedEnd": "slow CW"
         },
         {
           "dmxRange": [141, 145],
-          "type": "PanContinuous",
+          "type": "Rotation",
           "speed": "stop"
         },
         {
           "dmxRange": [146, 255],
-          "type": "PanContinuous",
+          "type": "Rotation",
           "speedStart": "slow CCW",
           "speedEnd": "fast CCW"
         }
@@ -186,7 +182,7 @@
         {
           "dmxRange": [206, 255],
           "type": "Effect",
-          "effectPreset": "ColorFade",
+          "effectPreset": "ColorJump",
           "speedStart": "fast",
           "speedEnd": "slow"
         }
@@ -269,7 +265,7 @@
         "UV",
         "Strobe",
         "Dimmer",
-        "Pan",
+        "Rotation",
         "Color Macros",
         "Programs",
         "Reset"

--- a/fixtures/american-dj/starburst.json
+++ b/fixtures/american-dj/starburst.json
@@ -22,15 +22,20 @@
     ]
   },
   "physical": {
-    "dimensions": [318, 318, 412.5],
+    "dimensions": [318, 412.5, 318],
     "weight": 3.65,
     "power": 55,
     "DMXconnector": "3-pin",
     "bulb": {
-      "type": "HEX LED"
+      "type": "5x 15W RGBWAUV LEDs"
+    },
+    "lens": {
+      "name": "34 beams",
+      "degreesMinMax": [1, 1]
     },
     "focus": {
-      "type": "Fixed"
+      "type": "Head",
+      "panMax": "infinite"
     }
   },
   "availableChannels": {

--- a/fixtures/american-dj/starburst.json
+++ b/fixtures/american-dj/starburst.json
@@ -40,176 +40,239 @@
   },
   "availableChannels": {
     "Red": {
-      "defaultValue": 1,
+      "defaultValue": 0,
       "capability": {
         "type": "ColorIntensity",
         "color": "Red"
       }
     },
     "Green": {
-      "defaultValue": 2,
+      "defaultValue": 0,
       "capability": {
         "type": "ColorIntensity",
         "color": "Green"
       }
     },
     "Blue": {
-      "defaultValue": 3,
+      "defaultValue": 0,
       "capability": {
         "type": "ColorIntensity",
         "color": "Blue"
       }
     },
     "White": {
-      "defaultValue": 4,
+      "defaultValue": 0,
       "capability": {
         "type": "ColorIntensity",
         "color": "White"
       }
     },
-    "Yellow": {
-      "defaultValue": 5,
+    "Amber": {
+      "defaultValue": 0,
       "capability": {
         "type": "ColorIntensity",
-        "color": "Yellow"
+        "color": "Amber"
       }
     },
-    "Purple": {
-      "defaultValue": 6,
+    "UV": {
+      "defaultValue": 0,
       "capability": {
         "type": "ColorIntensity",
-        "color": "Magenta"
+        "color": "UV"
       }
     },
     "Strobe": {
-      "defaultValue": 7,
+      "defaultValue": 8,
       "capabilities": [
         {
           "dmxRange": [0, 7],
-          "type": "NoFunction",
-          "comment": "OFF"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
         },
         {
           "dmxRange": [8, 15],
-          "type": "StrobeSpeed",
-          "speed": "slow",
-          "comment": "LED ON"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [16, 131],
-          "type": "StrobeSpeed",
-          "speed": "slow",
-          "comment": "STROBING SLOW-FAST"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
         },
         {
           "dmxRange": [132, 139],
-          "type": "StrobeSpeed",
-          "speed": "stop",
-          "comment": "LED ON"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [140, 181],
-          "type": "StrobeSpeed",
-          "speed": "stop",
-          "comment": "SLOW OPEN - FAST CLOSE"
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUp"
         },
         {
           "dmxRange": [182, 189],
-          "type": "StrobeSpeed",
-          "speed": "stop",
-          "comment": "LED ON"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [190, 231],
-          "type": "StrobeSpeed",
-          "speed": "fast",
-          "comment": "FAST OPEN - SLOW CLOSE"
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampDown"
         },
         {
           "dmxRange": [232, 239],
-          "type": "StrobeSpeed",
-          "speed": "stop",
-          "comment": "LED ON"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [240, 247],
-          "type": "StrobeSpeed",
-          "speed": "stop",
-          "comment": "RANDOM STROBE"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true
         },
         {
           "dmxRange": [248, 255],
-          "type": "StrobeSpeed",
-          "speed": "stop",
-          "comment": "LED ON"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
         }
       ]
     },
     "Dimmer": {
-      "defaultValue": 8,
+      "defaultValue": 0,
       "capability": {
-        "type": "Intensity",
-        "comment": "MASTER DIMMER"
+        "type": "Intensity"
       }
     },
     "Pan": {
-      "defaultValue": 9,
+      "defaultValue": 143,
       "capabilities": [
         {
           "dmxRange": [0, 30],
-          "type": "NoFunction",
-          "comment": "NO ROTATION"
+          "type": "NoFunction"
         },
         {
           "dmxRange": [31, 140],
-          "type": "Pan",
-          "angle": "360deg",
-          "comment": "CLOCKWISE ROTATION FAST - SLOW"
+          "type": "PanContinuous",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
         },
         {
           "dmxRange": [141, 145],
-          "type": "Pan",
-          "angle": "0deg",
-          "comment": "STOP"
+          "type": "PanContinuous",
+          "speed": "stop"
         },
         {
           "dmxRange": [146, 255],
-          "type": "Pan",
-          "angle": "0deg",
-          "comment": "COUNTER CLOCKWISE RATIATION SLOW-FAST"
+          "type": "PanContinuous",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
         }
       ]
     },
     "Color Macros": {
-      "defaultValue": 10,
+      "defaultValue": 0,
       "capabilities": [
         {
           "dmxRange": [0, 25],
           "type": "NoFunction"
         },
         {
-          "dmxRange": [26, 255],
+          "dmxRange": [26, 205],
           "type": "ColorPreset",
-          "comment": "COLOR MACROS"
+          "helpWanted": "Which color macros can be selected at which DMX values?"
+        },
+        {
+          "dmxRange": [206, 255],
+          "type": "Effect",
+          "effectPreset": "ColorFade",
+          "speedStart": "fast",
+          "speedEnd": "slow"
+        }
+      ]
+    },
+    "Programs": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 55],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [56, 75],
+          "type": "Effect",
+          "effectName": "Sound-active",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [76, 105],
+          "type": "Effect",
+          "effectName": "Red CW"
+        },
+        {
+          "dmxRange": [106, 135],
+          "type": "Effect",
+          "effectName": "Blue CCW"
+        },
+        {
+          "dmxRange": [136, 165],
+          "type": "Effect",
+          "effectName": "7-color change CW"
+        },
+        {
+          "dmxRange": [166, 195],
+          "type": "Effect",
+          "effectName": "7-color change CCW"
+        },
+        {
+          "dmxRange": [196, 225],
+          "type": "Effect",
+          "effectName": "7-color change with strobe CW"
+        },
+        {
+          "dmxRange": [226, 255],
+          "type": "Effect",
+          "effectName": "7-color change with strobe CCW"
+        }
+      ]
+    },
+    "Reset": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 69],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [70, 85],
+          "type": "Maintenance",
+          "comment": "Reset"
+        },
+        {
+          "dmxRange": [86, 255],
+          "type": "NoFunction"
         }
       ]
     }
   },
   "modes": [
     {
-      "name": "Manual",
-      "shortName": "Manual",
+      "name": "12-channel",
+      "shortName": "12ch",
       "channels": [
         "Red",
         "Green",
         "Blue",
         "White",
-        "Yellow",
-        "Purple",
+        "Amber",
+        "UV",
         "Strobe",
         "Dimmer",
         "Pan",
-        "Color Macros"
+        "Color Macros",
+        "Programs",
+        "Reset"
       ]
     }
   ]

--- a/fixtures/american-dj/starburst.json
+++ b/fixtures/american-dj/starburst.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Starbust 5x15W RGBWY+UV LED",
-  "shortName": "Starburst ",
+  "name": "Starbust",
+  "shortName": "ADJStarburst",
   "categories": ["Moving Head", "Color Changer", "Dimmer"],
   "meta": {
     "authors": ["gerard fontanillas"],

--- a/fixtures/american-dj/starburst.json
+++ b/fixtures/american-dj/starburst.json
@@ -2,11 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "Starbust",
   "shortName": "ADJStarburst",
-  "categories": ["Moving Head", "Color Changer", "Dimmer"],
+  "categories": ["Flower", "Moving Head", "Color Changer"],
   "meta": {
-    "authors": ["gerard fontanillas"],
-    "createDate": "2019-03-01",
-    "lastModifyDate": "2019-03-01"
+    "authors": ["Gerard Fontanillas"],
+    "createDate": "2019-03-03",
+    "lastModifyDate": "2019-03-03"
   },
   "links": {
     "manual": [

--- a/fixtures/american-dj/starbust-5x15w-rgbwy-uv-led.json
+++ b/fixtures/american-dj/starbust-5x15w-rgbwy-uv-led.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Starbust 5x15W RGBWY+UV LED",
+  "shortName": "Starburst ",
+  "categories": ["Moving Head", "Color Changer", "Dimmer"],
+  "meta": {
+    "authors": ["gerard fontanillas"],
+    "createDate": "2019-03-01",
+    "lastModifyDate": "2019-03-01"
+  },
+  "links": {
+    "manual": [
+      "https://cdb.s3-us-west-1.amazonaws.com/ItemRelatedFiles/8787/starburst.pdf"
+    ],
+    "productPage": [
+      "https://www.adj.com/starburst"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=SetHSmR7J6c",
+      "https://www.youtube.com/watch?v=haRjymezIig",
+      "https://www.youtube.com/watch?v=WXHROB4soLs"
+    ]
+  },
+  "physical": {
+    "dimensions": [318, 318, 412.5],
+    "weight": 3.65,
+    "power": 55,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "HEX LED"
+    },
+    "focus": {
+      "type": "Fixed"
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "defaultValue": 1,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 2,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 3,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 4,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Yellow": {
+      "defaultValue": 5,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Yellow"
+      }
+    },
+    "Purple": {
+      "defaultValue": 6,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Magenta"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 7,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction",
+          "comment": "OFF"
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "StrobeSpeed",
+          "speed": "slow",
+          "comment": "LED ON"
+        },
+        {
+          "dmxRange": [16, 131],
+          "type": "StrobeSpeed",
+          "speed": "slow",
+          "comment": "STROBING SLOW-FAST"
+        },
+        {
+          "dmxRange": [132, 139],
+          "type": "StrobeSpeed",
+          "speed": "stop",
+          "comment": "LED ON"
+        },
+        {
+          "dmxRange": [140, 181],
+          "type": "StrobeSpeed",
+          "speed": "stop",
+          "comment": "SLOW OPEN - FAST CLOSE"
+        },
+        {
+          "dmxRange": [182, 189],
+          "type": "StrobeSpeed",
+          "speed": "stop",
+          "comment": "LED ON"
+        },
+        {
+          "dmxRange": [190, 231],
+          "type": "StrobeSpeed",
+          "speed": "fast",
+          "comment": "FAST OPEN - SLOW CLOSE"
+        },
+        {
+          "dmxRange": [232, 239],
+          "type": "StrobeSpeed",
+          "speed": "stop",
+          "comment": "LED ON"
+        },
+        {
+          "dmxRange": [240, 247],
+          "type": "StrobeSpeed",
+          "speed": "stop",
+          "comment": "RANDOM STROBE"
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "StrobeSpeed",
+          "speed": "stop",
+          "comment": "LED ON"
+        }
+      ]
+    },
+    "Dimmer": {
+      "defaultValue": 8,
+      "capability": {
+        "type": "Intensity",
+        "comment": "MASTER DIMMER"
+      }
+    },
+    "Pan": {
+      "defaultValue": 9,
+      "capabilities": [
+        {
+          "dmxRange": [0, 30],
+          "type": "NoFunction",
+          "comment": "NO ROTATION"
+        },
+        {
+          "dmxRange": [31, 140],
+          "type": "Pan",
+          "angle": "360deg",
+          "comment": "CLOCKWISE ROTATION FAST - SLOW"
+        },
+        {
+          "dmxRange": [141, 145],
+          "type": "Pan",
+          "angle": "0deg",
+          "comment": "STOP"
+        },
+        {
+          "dmxRange": [146, 255],
+          "type": "Pan",
+          "angle": "0deg",
+          "comment": "COUNTER CLOCKWISE RATIATION SLOW-FAST"
+        }
+      ]
+    },
+    "Color Macros": {
+      "defaultValue": 10,
+      "capabilities": [
+        {
+          "dmxRange": [0, 25],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [26, 255],
+          "type": "ColorPreset",
+          "comment": "COLOR MACROS"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "Manual",
+      "shortName": "Manual",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Yellow",
+        "Purple",
+        "Strobe",
+        "Dimmer",
+        "Pan",
+        "Color Macros"
+      ]
+    }
+  ]
+}

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -105,8 +105,8 @@
       "lastActionDate": "2018-11-01",
       "lastAction": "created"
     },
-    "american-dj/starbust-5x15w-rgbwy-uv-led": {
-      "name": "Starbust 5x15W RGBWY+UV LED",
+    "american-dj/starburst": {
+      "name": "Starbust",
       "lastActionDate": "2019-03-01",
       "lastAction": "created"
     },
@@ -1160,7 +1160,7 @@
       "revo-burst",
       "revo-sweep",
       "saber-spot-rgbw",
-      "starbust-5x15w-rgbwy-uv-led",
+      "starburst",
       "vizi-spot-led-pro",
       "xs-400"
     ],
@@ -1528,7 +1528,7 @@
       "american-dj/revo-4-ir",
       "american-dj/revo-sweep",
       "american-dj/saber-spot-rgbw",
-      "american-dj/starbust-5x15w-rgbwy-uv-led",
+      "american-dj/starburst",
       "american-dj/vizi-spot-led-pro",
       "american-dj/xs-400",
       "arri/skypanel-s30c",
@@ -1710,7 +1710,7 @@
       "american-dj/encore-profile-1000-ww",
       "american-dj/flat-par-qa12xs",
       "american-dj/saber-spot-rgbw",
-      "american-dj/starbust-5x15w-rgbwy-uv-led",
+      "american-dj/starburst",
       "arri/skypanel-s30c",
       "cameo/flat-par-can-tri-7x-3w-ir",
       "chauvet-dj/eve-p-100-ww",
@@ -1788,7 +1788,7 @@
       "adb/warp-m",
       "american-dj/auto-spot-150",
       "american-dj/inno-pocket-beam-q4",
-      "american-dj/starbust-5x15w-rgbwy-uv-led",
+      "american-dj/starburst",
       "american-dj/vizi-spot-led-pro",
       "american-dj/xs-400",
       "ayrton/magicblade-fx",
@@ -2251,7 +2251,7 @@
       "eliminator/stealth-beam"
     ],
     "gerard fontanillas": [
-      "american-dj/starbust-5x15w-rgbwy-uv-led"
+      "american-dj/starburst"
     ],
     "Gerard Fontanillas": [
       "american-dj/encore-profile-1000-ww"
@@ -2490,7 +2490,7 @@
   },
   "lastUpdated": [
     "robe/robin-300e-wash",
-    "american-dj/starbust-5x15w-rgbwy-uv-led",
+    "american-dj/starburst",
     "american-dj/encore-profile-1000-ww",
     "american-dj/mega-hex-par",
     "blizzard/rokbox-rgbw",

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -107,7 +107,7 @@
     },
     "american-dj/starburst": {
       "name": "Starbust",
-      "lastActionDate": "2019-03-01",
+      "lastActionDate": "2019-03-03",
       "lastAction": "created"
     },
     "american-dj/vizi-spot-led-pro": {
@@ -1710,7 +1710,6 @@
       "american-dj/encore-profile-1000-ww",
       "american-dj/flat-par-qa12xs",
       "american-dj/saber-spot-rgbw",
-      "american-dj/starburst",
       "arri/skypanel-s30c",
       "cameo/flat-par-can-tri-7x-3w-ir",
       "chauvet-dj/eve-p-100-ww",
@@ -1748,6 +1747,7 @@
       "american-dj/revo-4-ir",
       "american-dj/revo-burst",
       "american-dj/revo-sweep",
+      "american-dj/starburst",
       "boomtonedj/xtrem-led",
       "cameo/storm",
       "eurolite/led-fe-1500",
@@ -2167,6 +2167,10 @@
       "beamz/h2000-faze-machine",
       "blizzard/rokbox-rgbw"
     ],
+    "Gerard Fontanillas": [
+      "american-dj/encore-profile-1000-ww",
+      "american-dj/starburst"
+    ],
     "Jean-François Losson": [
       "arri/skypanel-s30c",
       "dedolight/dled4-bi"
@@ -2249,12 +2253,6 @@
     ],
     "George Qualley IV": [
       "eliminator/stealth-beam"
-    ],
-    "gerard fontanillas": [
-      "american-dj/starburst"
-    ],
-    "Gerard Fontanillas": [
-      "american-dj/encore-profile-1000-ww"
     ],
     "jc": [
       "american-dj/inno-pocket-beam-q4"
@@ -2489,8 +2487,8 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
-    "robe/robin-300e-wash",
     "american-dj/starburst",
+    "robe/robin-300e-wash",
     "american-dj/encore-profile-1000-ww",
     "american-dj/mega-hex-par",
     "blizzard/rokbox-rgbw",

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -105,6 +105,11 @@
       "lastActionDate": "2018-11-01",
       "lastAction": "created"
     },
+    "american-dj/starbust-5x15w-rgbwy-uv-led": {
+      "name": "Starbust 5x15W RGBWY+UV LED",
+      "lastActionDate": "2019-03-01",
+      "lastAction": "created"
+    },
     "american-dj/vizi-spot-led-pro": {
       "name": "Vizi Spot LED Pro",
       "lastActionDate": "2018-08-09",
@@ -1150,6 +1155,7 @@
       "revo-burst",
       "revo-sweep",
       "saber-spot-rgbw",
+      "starbust-5x15w-rgbwy-uv-led",
       "vizi-spot-led-pro",
       "xs-400"
     ],
@@ -1516,6 +1522,7 @@
       "american-dj/revo-4-ir",
       "american-dj/revo-sweep",
       "american-dj/saber-spot-rgbw",
+      "american-dj/starbust-5x15w-rgbwy-uv-led",
       "american-dj/vizi-spot-led-pro",
       "american-dj/xs-400",
       "arri/skypanel-s30c",
@@ -1696,6 +1703,7 @@
       "american-dj/encore-profile-1000-ww",
       "american-dj/flat-par-qa12xs",
       "american-dj/saber-spot-rgbw",
+      "american-dj/starbust-5x15w-rgbwy-uv-led",
       "arri/skypanel-s30c",
       "cameo/flat-par-can-tri-7x-3w-ir",
       "chauvet-dj/eve-p-100-ww",
@@ -1773,6 +1781,7 @@
       "adb/warp-m",
       "american-dj/auto-spot-150",
       "american-dj/inno-pocket-beam-q4",
+      "american-dj/starbust-5x15w-rgbwy-uv-led",
       "american-dj/vizi-spot-led-pro",
       "american-dj/xs-400",
       "ayrton/magicblade-fx",
@@ -2229,6 +2238,9 @@
     "George Qualley IV": [
       "eliminator/stealth-beam"
     ],
+    "gerard fontanillas": [
+      "american-dj/starbust-5x15w-rgbwy-uv-led"
+    ],
     "Gerard Fontanillas": [
       "american-dj/encore-profile-1000-ww"
     ],
@@ -2467,6 +2479,7 @@
     "venue": "#78cc33"
   },
   "lastUpdated": [
+    "american-dj/starbust-5x15w-rgbwy-uv-led",
     "american-dj/encore-profile-1000-ww",
     "american-dj/mega-hex-par",
     "blizzard/rokbox-rgbw",

--- a/fixtures/register.json
+++ b/fixtures/register.json
@@ -1726,6 +1726,7 @@
     ],
     "Effect": [
       "american-dj/revo-burst",
+      "american-dj/starburst",
       "ayra/tdc-triple-burst",
       "eurolite/led-h2o",
       "magicfx/psyco2jet",
@@ -1788,7 +1789,6 @@
       "adb/warp-m",
       "american-dj/auto-spot-150",
       "american-dj/inno-pocket-beam-q4",
-      "american-dj/starburst",
       "american-dj/vizi-spot-led-pro",
       "american-dj/xs-400",
       "ayrton/magicblade-fx",


### PR DESCRIPTION
* Add fixture 'american-dj/starbust-5x15w-rgbwy-uv-led'
* Update register.json

### Fixture warnings / errors

* american-dj/starbust-5x15w-rgbwy-uv-led
  - :x: Category 'Moving Head' invalid since focus.type is not 'Head'.
  - :warning: Capability 'Pan 360° (CLOCKWISE ROTATION FAST - SLOW)' (31…140) in channel 'Pan' defines an exact pan angle. Setting focus.panMax in the fixture's physical data is recommended.
  - :warning: Capability 'Pan 0° (STOP)' (141…145) in channel 'Pan' defines an exact pan angle. Setting focus.panMax in the fixture's physical data is recommended.
  - :warning: Capability 'Pan 0° (COUNTER CLOCKWISE RATIATION SLOW-FAST)' (146…255) in channel 'Pan' defines an exact pan angle. Setting focus.panMax in the fixture's physical data is recommended.
  - :warning: physical.panMax is not defined although there's a Pan channel 'Pan' in mode 'Manual'.


Thank you **AUDIOVISUAL BARCELONA**!