### PR TITLE
Add fixture 'martin/rush-scanner-1-led'

### DIFF
--- a/fixtures/martin/rush-scanner-1-led.json
+++ b/fixtures/martin/rush-scanner-1-led.json
@@ -1,0 +1,1403 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Rush Scanner 1 LED",
+  "shortName": "MartinRushScan1",
+  "categories": ["Scanner", "Color Changer"],
+  "meta": {
+    "authors": ["Felix Edelmann"],
+    "createDate": "2019-03-07",
+    "lastModifyDate": "2019-03-07"
+  },
+  "links": {
+    "manual": [
+      "https://adn.harmanpro.com/site_elements/executables/6809_1526699780/UM_RUSHScanner1LED_EN_B_original.pdf"
+    ],
+    "productPage": [
+      "https://www.martin.com/en-US/products/rush-scanner-1-led"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=Hz23QxIo-Zc"
+    ]
+  },
+  "physical": {
+    "dimensions": [303, 193, 588],
+    "weight": 9.6,
+    "power": 168,
+    "DMXconnector": "3-pin and 5-pin",
+    "bulb": {
+      "type": "90W LED"
+    },
+    "focus": {
+      "type": "Mirror",
+      "panMax": 170,
+      "tiltMax": 75
+    }
+  },
+  "wheels": {
+    "Color Wheel 1": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Color",
+          "name": "Red"
+        },
+        {
+          "type": "Color",
+          "name": "Deep Blue"
+        },
+        {
+          "type": "Color",
+          "name": "Lavender"
+        },
+        {
+          "type": "Color",
+          "name": "Magenta"
+        },
+        {
+          "type": "Color",
+          "name": "Yellow"
+        },
+        {
+          "type": "Color",
+          "name": "Orange"
+        },
+        {
+          "type": "Color",
+          "name": "Light green"
+        },
+        {
+          "type": "Color",
+          "name": "Light blue"
+        },
+        {
+          "type": "Open"
+        }
+      ]
+    },
+    "Color Wheel 2": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Color",
+          "name": "Pink"
+        },
+        {
+          "type": "Color",
+          "name": "CTO",
+          "colorTemperature": "3200K"
+        },
+        {
+          "type": "Color",
+          "name": "UV Purple"
+        },
+        {
+          "type": "Color",
+          "name": "Light yellow"
+        },
+        {
+          "type": "Color",
+          "name": "Green"
+        },
+        {
+          "type": "Color",
+          "name": "Aquamarine"
+        },
+        {
+          "type": "Color",
+          "name": "CTO",
+          "colorTemperature": "5600K"
+        },
+        {
+          "type": "Color",
+          "name": "Blue"
+        },
+        {
+          "type": "Open"
+        }
+      ]
+    },
+    "Gobo Wheel 1": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        }
+      ]
+    },
+    "Gobo Wheel 2": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "fineChannelAliases": ["Dimmer fine"],
+      "dmxValueResolution": "8bit",
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 8,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [16, 131],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [132, 167],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUp"
+        },
+        {
+          "dmxRange": [168, 203],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampDown"
+        },
+        {
+          "dmxRange": [204, 239],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse"
+        },
+        {
+          "dmxRange": [240, 247],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Color Wheel 1": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [1, 14],
+          "type": "WheelSlot",
+          "slotNumberStart": 1,
+          "slotNumberEnd": 2
+        },
+        {
+          "dmxRange": [15, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [16, 29],
+          "type": "WheelSlot",
+          "slotNumberStart": 2,
+          "slotNumberEnd": 3
+        },
+        {
+          "dmxRange": [30, 30],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [31, 44],
+          "type": "WheelSlot",
+          "slotNumberStart": 3,
+          "slotNumberEnd": 4
+        },
+        {
+          "dmxRange": [45, 45],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [46, 59],
+          "type": "WheelSlot",
+          "slotNumberStart": 4,
+          "slotNumberEnd": 5
+        },
+        {
+          "dmxRange": [60, 60],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [61, 74],
+          "type": "WheelSlot",
+          "slotNumberStart": 5,
+          "slotNumberEnd": 6
+        },
+        {
+          "dmxRange": [75, 75],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [76, 89],
+          "type": "WheelSlot",
+          "slotNumberStart": 6,
+          "slotNumberEnd": 7
+        },
+        {
+          "dmxRange": [90, 90],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [91, 104],
+          "type": "WheelSlot",
+          "slotNumberStart": 7,
+          "slotNumberEnd": 8
+        },
+        {
+          "dmxRange": [105, 105],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [106, 119],
+          "type": "WheelSlot",
+          "slotNumberStart": 8,
+          "slotNumberEnd": 9
+        },
+        {
+          "dmxRange": [120, 120],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [121, 134],
+          "type": "WheelSlot",
+          "slotNumberStart": 9,
+          "slotNumberEnd": 10
+        },
+        {
+          "dmxRange": [135, 160],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [161, 163],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [164, 166],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [167, 169],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [170, 172],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [173, 175],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [176, 178],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [179, 181],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [182, 184],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [185, 192],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [193, 214],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [215, 221],
+          "type": "WheelRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [222, 243],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        },
+        {
+          "dmxRange": [244, 247],
+          "type": "Effect",
+          "effectName": "Random color",
+          "speed": "fast"
+        },
+        {
+          "dmxRange": [248, 251],
+          "type": "Effect",
+          "effectName": "Random color",
+          "speed": "50%"
+        },
+        {
+          "dmxRange": [252, 255],
+          "type": "Effect",
+          "effectName": "Random color",
+          "speed": "slow"
+        }
+      ]
+    },
+    "Color Wheel 2": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [1, 14],
+          "type": "WheelSlot",
+          "slotNumberStart": 1,
+          "slotNumberEnd": 2
+        },
+        {
+          "dmxRange": [15, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [16, 29],
+          "type": "WheelSlot",
+          "slotNumberStart": 2,
+          "slotNumberEnd": 3
+        },
+        {
+          "dmxRange": [30, 30],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [31, 44],
+          "type": "WheelSlot",
+          "slotNumberStart": 3,
+          "slotNumberEnd": 4
+        },
+        {
+          "dmxRange": [45, 45],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [46, 59],
+          "type": "WheelSlot",
+          "slotNumberStart": 4,
+          "slotNumberEnd": 5
+        },
+        {
+          "dmxRange": [60, 60],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [61, 74],
+          "type": "WheelSlot",
+          "slotNumberStart": 5,
+          "slotNumberEnd": 6
+        },
+        {
+          "dmxRange": [75, 75],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [76, 89],
+          "type": "WheelSlot",
+          "slotNumberStart": 6,
+          "slotNumberEnd": 7
+        },
+        {
+          "dmxRange": [90, 90],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [91, 104],
+          "type": "WheelSlot",
+          "slotNumberStart": 7,
+          "slotNumberEnd": 8
+        },
+        {
+          "dmxRange": [105, 105],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [106, 119],
+          "type": "WheelSlot",
+          "slotNumberStart": 8,
+          "slotNumberEnd": 9
+        },
+        {
+          "dmxRange": [120, 120],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [121, 134],
+          "type": "WheelSlot",
+          "slotNumberStart": 9,
+          "slotNumberEnd": 10
+        },
+        {
+          "dmxRange": [135, 160],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [161, 163],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [164, 166],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [167, 169],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [170, 172],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [173, 175],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [176, 178],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [179, 181],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [182, 184],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [185, 192],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [193, 214],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [215, 221],
+          "type": "WheelRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [222, 243],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        },
+        {
+          "dmxRange": [244, 247],
+          "type": "Effect",
+          "effectName": "Random color",
+          "speed": "fast"
+        },
+        {
+          "dmxRange": [248, 251],
+          "type": "Effect",
+          "effectName": "Random color",
+          "speed": "50%"
+        },
+        {
+          "dmxRange": [252, 255],
+          "type": "Effect",
+          "effectName": "Random color",
+          "speed": "slow"
+        }
+      ]
+    },
+    "Gobo Wheel 1": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 4],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [5, 9],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "indexing"
+        },
+        {
+          "dmxRange": [10, 14],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "indexing"
+        },
+        {
+          "dmxRange": [15, 19],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "indexing"
+        },
+        {
+          "dmxRange": [20, 24],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "indexing"
+        },
+        {
+          "dmxRange": [25, 29],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "indexing"
+        },
+        {
+          "dmxRange": [30, 34],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "indexing"
+        },
+        {
+          "dmxRange": [35, 39],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "rotating"
+        },
+        {
+          "dmxRange": [40, 44],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "rotating"
+        },
+        {
+          "dmxRange": [45, 49],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "rotating"
+        },
+        {
+          "dmxRange": [50, 54],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "rotating"
+        },
+        {
+          "dmxRange": [55, 59],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "rotating"
+        },
+        {
+          "dmxRange": [60, 64],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "rotating"
+        },
+        {
+          "dmxRange": [65, 88],
+          "type": "WheelShake",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [89, 112],
+          "type": "WheelShake",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [113, 136],
+          "type": "WheelShake",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [137, 160],
+          "type": "WheelShake",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [161, 184],
+          "type": "WheelShake",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [185, 208],
+          "type": "WheelShake",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [209, 209],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [210, 232],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [233, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        }
+      ]
+    },
+    "Gobo 1 Indexing": {
+      "capability": {
+        "type": "WheelSlotRotation",
+        "angleStart": "0deg",
+        "angleEnd": "180deg"
+      }
+    },
+    "Gobo 1 Rotation": {
+      "defaultValue": 128,
+      "capabilities": [
+        {
+          "dmxRange": [0, 2],
+          "type": "WheelSlotRotation",
+          "angle": "0deg"
+        },
+        {
+          "dmxRange": [3, 126],
+          "type": "WheelSlotRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [127, 129],
+          "type": "WheelSlotRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [130, 253],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        },
+        {
+          "dmxRange": [254, 255],
+          "type": "WheelSlotRotation",
+          "speed": "stop"
+        }
+      ]
+    },
+    "Gobo Wheel 2": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [1, 14],
+          "type": "WheelSlot",
+          "slotNumberStart": 1,
+          "slotNumberEnd": 2
+        },
+        {
+          "dmxRange": [15, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [16, 29],
+          "type": "WheelSlot",
+          "slotNumberStart": 2,
+          "slotNumberEnd": 3
+        },
+        {
+          "dmxRange": [30, 30],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [31, 44],
+          "type": "WheelSlot",
+          "slotNumberStart": 3,
+          "slotNumberEnd": 4
+        },
+        {
+          "dmxRange": [45, 45],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [46, 59],
+          "type": "WheelSlot",
+          "slotNumberStart": 4,
+          "slotNumberEnd": 5
+        },
+        {
+          "dmxRange": [60, 60],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [61, 74],
+          "type": "WheelSlot",
+          "slotNumberStart": 5,
+          "slotNumberEnd": 6
+        },
+        {
+          "dmxRange": [75, 75],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [76, 89],
+          "type": "WheelSlot",
+          "slotNumberStart": 6,
+          "slotNumberEnd": 7
+        },
+        {
+          "dmxRange": [90, 90],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [91, 104],
+          "type": "WheelSlot",
+          "slotNumberStart": 7,
+          "slotNumberEnd": 8
+        },
+        {
+          "dmxRange": [105, 105],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [106, 119],
+          "type": "WheelSlot",
+          "slotNumberStart": 8,
+          "slotNumberEnd": 9
+        },
+        {
+          "dmxRange": [120, 160],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [161, 163],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [164, 166],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [167, 169],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [170, 172],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [173, 175],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [176, 178],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [179, 181],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [182, 192],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [193, 214],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [215, 221],
+          "type": "WheelRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [222, 243],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        },
+        {
+          "dmxRange": [244, 247],
+          "type": "Effect",
+          "effectName": "Random gobo",
+          "speed": "fast"
+        },
+        {
+          "dmxRange": [248, 251],
+          "type": "Effect",
+          "effectName": "Random gobo",
+          "speed": "50%"
+        },
+        {
+          "dmxRange": [252, 255],
+          "type": "Effect",
+          "effectName": "Random gobo",
+          "speed": "slow"
+        }
+      ]
+    },
+    "Prism": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 138],
+          "type": "Prism",
+          "comment": "indexed"
+        },
+        {
+          "dmxRange": [139, 255],
+          "type": "Prism",
+          "comment": "rotating"
+        }
+      ]
+    },
+    "Prism Indexing": {
+      "capability": {
+        "type": "PrismRotation",
+        "angleStart": "0deg",
+        "angleEnd": "180deg"
+      }
+    },
+    "Prism Rotation": {
+      "defaultValue": 128,
+      "capabilities": [
+        {
+          "dmxRange": [0, 2],
+          "type": "PrismRotation",
+          "angle": "0deg"
+        },
+        {
+          "dmxRange": [3, 126],
+          "type": "PrismRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [127, 129],
+          "type": "PrismRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [130, 253],
+          "type": "PrismRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        },
+        {
+          "dmxRange": [254, 255],
+          "type": "PrismRotation",
+          "speed": "stop"
+        }
+      ]
+    },
+    "Focus": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "far",
+        "distanceEnd": "near"
+      }
+    },
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "170deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "75deg"
+      }
+    },
+    "Functions / Settings": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [10, 14],
+          "type": "Maintenance",
+          "comment": "Reset all"
+        },
+        {
+          "dmxRange": [15, 19],
+          "type": "Maintenance",
+          "comment": "Reset color"
+        },
+        {
+          "dmxRange": [20, 24],
+          "type": "Maintenance",
+          "comment": "Reset gobo"
+        },
+        {
+          "dmxRange": [25, 29],
+          "type": "Maintenance",
+          "comment": "Reset focus"
+        },
+        {
+          "dmxRange": [30, 34],
+          "type": "Maintenance",
+          "comment": "Reset prism"
+        },
+        {
+          "dmxRange": [35, 39],
+          "type": "Maintenance",
+          "comment": "Reset pan/tilt"
+        },
+        {
+          "dmxRange": [40, 54],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [55, 59],
+          "type": "Maintenance",
+          "comment": "Enable calibration"
+        },
+        {
+          "dmxRange": [60, 79],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [80, 84],
+          "type": "Maintenance",
+          "comment": "Pan/tilt speed = normal"
+        },
+        {
+          "dmxRange": [85, 89],
+          "type": "Maintenance",
+          "comment": "Pan/tilt speed = fast (default)"
+        },
+        {
+          "dmxRange": [90, 94],
+          "type": "Maintenance",
+          "comment": "Pan/tilt speed = slow"
+        },
+        {
+          "dmxRange": [95, 99],
+          "type": "Maintenance",
+          "comment": "Parameter shortcuts = On (default)"
+        },
+        {
+          "dmxRange": [100, 104],
+          "type": "Maintenance",
+          "comment": "Parameter shortcuts = Off"
+        },
+        {
+          "dmxRange": [105, 144],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [145, 149],
+          "type": "Maintenance",
+          "comment": "Blackout = On (fixture goes to standby when no DMX signal)"
+        },
+        {
+          "dmxRange": [150, 154],
+          "type": "Maintenance",
+          "comment": "Blackout = Off (default setting: fixture enters standalone operation when no DMX signal)"
+        },
+        {
+          "dmxRange": [155, 159],
+          "type": "Maintenance",
+          "comment": "Illuminate control panel display"
+        },
+        {
+          "dmxRange": [160, 164],
+          "type": "Maintenance",
+          "comment": "Turn off control panel display"
+        },
+        {
+          "dmxRange": [165, 194],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [195, 199],
+          "type": "Maintenance",
+          "comment": "Store color wheel 1 calibration"
+        },
+        {
+          "dmxRange": [200, 204],
+          "type": "Maintenance",
+          "comment": "Store color wheel 2 calibration"
+        },
+        {
+          "dmxRange": [205, 209],
+          "type": "Maintenance",
+          "comment": "Store gobo wheel 1 wheel calibration"
+        },
+        {
+          "dmxRange": [210, 214],
+          "type": "Maintenance",
+          "comment": "Store gobo wheel 1 gobo calibration"
+        },
+        {
+          "dmxRange": [215, 219],
+          "type": "Maintenance",
+          "comment": "Store gobo wheel 2 calibration"
+        },
+        {
+          "dmxRange": [220, 224],
+          "type": "Maintenance",
+          "comment": "Store focus calibration"
+        },
+        {
+          "dmxRange": [225, 229],
+          "type": "Maintenance",
+          "comment": "Store prism calibration"
+        },
+        {
+          "dmxRange": [230, 234],
+          "type": "Maintenance",
+          "comment": "Store prism rotation calibration"
+        },
+        {
+          "dmxRange": [235, 239],
+          "type": "Maintenance",
+          "comment": "Store pan calibration"
+        },
+        {
+          "dmxRange": [240, 244],
+          "type": "Maintenance",
+          "comment": "Store tilt calibration"
+        },
+        {
+          "dmxRange": [245, 249],
+          "type": "Maintenance",
+          "comment": "Reset all calibration settings to factory defaults"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "NoFunction"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "16-channel",
+      "shortName": "16ch",
+      "channels": [
+        "Dimmer",
+        "Dimmer fine",
+        "Strobe",
+        "Color Wheel 1",
+        "Color Wheel 2",
+        "Gobo Wheel 1",
+        "Gobo 1 Indexing",
+        "Gobo 1 Rotation",
+        "Gobo Wheel 2",
+        "Prism",
+        "Prism Indexing",
+        "Prism Rotation",
+        "Focus",
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Functions / Settings"
+      ]
+    }
+  ]
+}

--- a/fixtures/martin/rush-scanner-1-led.json
+++ b/fixtures/martin/rush-scanner-1-led.json
@@ -114,7 +114,7 @@
         }
       ]
     },
-    "Gobo Wheel 1": {
+    "Rotating Gobo Wheel": {
       "slots": [
         {
           "type": "Open"
@@ -139,7 +139,7 @@
         }
       ]
     },
-    "Gobo Wheel 2": {
+    "Static Gobo Wheel": {
       "slots": [
         {
           "type": "Open"
@@ -603,7 +603,7 @@
         }
       ]
     },
-    "Gobo Wheel 1": {
+    "Rotating Gobo Wheel": {
       "defaultValue": 0,
       "capabilities": [
         {
@@ -611,7 +611,7 @@
           "type": "WheelSlot",
           "slotNumber": 1,
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -620,7 +620,7 @@
           "slotNumber": 2,
           "comment": "indexing",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -629,7 +629,7 @@
           "slotNumber": 3,
           "comment": "indexing",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -638,7 +638,7 @@
           "slotNumber": 4,
           "comment": "indexing",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -647,7 +647,7 @@
           "slotNumber": 5,
           "comment": "indexing",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -656,7 +656,7 @@
           "slotNumber": 6,
           "comment": "indexing",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -665,7 +665,7 @@
           "slotNumber": 7,
           "comment": "indexing",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -674,7 +674,7 @@
           "slotNumber": 2,
           "comment": "rotating",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+            "Gobo Indexing / Rotation": "Gobo Rotation"
           }
         },
         {
@@ -683,7 +683,7 @@
           "slotNumber": 3,
           "comment": "rotating",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+            "Gobo Indexing / Rotation": "Gobo Rotation"
           }
         },
         {
@@ -692,7 +692,7 @@
           "slotNumber": 4,
           "comment": "rotating",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+            "Gobo Indexing / Rotation": "Gobo Rotation"
           }
         },
         {
@@ -701,7 +701,7 @@
           "slotNumber": 5,
           "comment": "rotating",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+            "Gobo Indexing / Rotation": "Gobo Rotation"
           }
         },
         {
@@ -710,7 +710,7 @@
           "slotNumber": 6,
           "comment": "rotating",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+            "Gobo Indexing / Rotation": "Gobo Rotation"
           }
         },
         {
@@ -719,7 +719,7 @@
           "slotNumber": 7,
           "comment": "rotating",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+            "Gobo Indexing / Rotation": "Gobo Rotation"
           }
         },
         {
@@ -727,7 +727,7 @@
           "type": "WheelShake",
           "slotNumber": 2,
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -735,7 +735,7 @@
           "type": "WheelShake",
           "slotNumber": 3,
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -743,7 +743,7 @@
           "type": "WheelShake",
           "slotNumber": 4,
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -751,7 +751,7 @@
           "type": "WheelShake",
           "slotNumber": 5,
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -759,7 +759,7 @@
           "type": "WheelShake",
           "slotNumber": 6,
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -767,14 +767,14 @@
           "type": "WheelShake",
           "slotNumber": 7,
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
           "dmxRange": [209, 209],
           "type": "NoFunction",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -783,7 +783,7 @@
           "speedStart": "fast CW",
           "speedEnd": "slow CW",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         },
         {
@@ -792,57 +792,57 @@
           "speedStart": "slow CCW",
           "speedEnd": "fast CCW",
           "switchChannels": {
-            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+            "Gobo Indexing / Rotation": "Gobo Indexing"
           }
         }
       ]
     },
-    "Gobo 1 Indexing": {
+    "Gobo Indexing": {
       "capability": {
         "type": "WheelSlotRotation",
-        "wheel": "Gobo Wheel 1",
+        "wheel": "Rotating Gobo Wheel",
         "angleStart": "0deg",
         "angleEnd": "180deg"
       }
     },
-    "Gobo 1 Rotation": {
+    "Gobo Rotation": {
       "defaultValue": 128,
       "capabilities": [
         {
           "dmxRange": [0, 2],
           "type": "WheelSlotRotation",
-          "wheel": "Gobo Wheel 1",
+          "wheel": "Rotating Gobo Wheel",
           "angle": "0deg"
         },
         {
           "dmxRange": [3, 126],
           "type": "WheelSlotRotation",
-          "wheel": "Gobo Wheel 1",
+          "wheel": "Rotating Gobo Wheel",
           "speedStart": "fast CW",
           "speedEnd": "slow CW"
         },
         {
           "dmxRange": [127, 129],
           "type": "WheelSlotRotation",
-          "wheel": "Gobo Wheel 1",
+          "wheel": "Rotating Gobo Wheel",
           "speed": "stop"
         },
         {
           "dmxRange": [130, 253],
           "type": "WheelSlotRotation",
-          "wheel": "Gobo Wheel 1",
+          "wheel": "Rotating Gobo Wheel",
           "speedStart": "slow CCW",
           "speedEnd": "fast CCW"
         },
         {
           "dmxRange": [254, 255],
           "type": "WheelSlotRotation",
-          "wheel": "Gobo Wheel 1",
+          "wheel": "Rotating Gobo Wheel",
           "speed": "stop"
         }
       ]
     },
-    "Gobo Wheel 2": {
+    "Static Gobo Wheel": {
       "defaultValue": 0,
       "capabilities": [
         {
@@ -1223,17 +1223,17 @@
         {
           "dmxRange": [205, 209],
           "type": "Maintenance",
-          "comment": "Store gobo wheel 1 wheel calibration"
+          "comment": "Store rotating gobo wheel calibration"
         },
         {
           "dmxRange": [210, 214],
           "type": "Maintenance",
-          "comment": "Store gobo wheel 1 gobo calibration"
+          "comment": "Store rotating gobo calibration"
         },
         {
           "dmxRange": [215, 219],
           "type": "Maintenance",
-          "comment": "Store gobo wheel 2 calibration"
+          "comment": "Store static gobo wheel calibration"
         },
         {
           "dmxRange": [220, 224],
@@ -1282,9 +1282,9 @@
         "Strobe",
         "Color Wheel 1",
         "Color Wheel 2",
-        "Gobo Wheel 1",
-        "Gobo 1 Indexing / Rotation",
-        "Gobo Wheel 2",
+        "Rotating Gobo Wheel",
+        "Gobo Indexing / Rotation",
+        "Static Gobo Wheel",
         "Prism",
         "Prism Indexing / Rotation",
         "Focus",

--- a/fixtures/martin/rush-scanner-1-led.json
+++ b/fixtures/martin/rush-scanner-1-led.json
@@ -742,6 +742,7 @@
           "dmxRange": [65, 88],
           "type": "WheelShake",
           "slotNumber": 2,
+          "isShaking": "slot",
           "switchChannels": {
             "Gobo Indexing / Rotation": "Gobo Indexing"
           }
@@ -750,6 +751,7 @@
           "dmxRange": [89, 112],
           "type": "WheelShake",
           "slotNumber": 3,
+          "isShaking": "slot",
           "switchChannels": {
             "Gobo Indexing / Rotation": "Gobo Indexing"
           }
@@ -758,6 +760,7 @@
           "dmxRange": [113, 136],
           "type": "WheelShake",
           "slotNumber": 4,
+          "isShaking": "slot",
           "switchChannels": {
             "Gobo Indexing / Rotation": "Gobo Indexing"
           }
@@ -766,6 +769,7 @@
           "dmxRange": [137, 160],
           "type": "WheelShake",
           "slotNumber": 5,
+          "isShaking": "slot",
           "switchChannels": {
             "Gobo Indexing / Rotation": "Gobo Indexing"
           }
@@ -774,6 +778,7 @@
           "dmxRange": [161, 184],
           "type": "WheelShake",
           "slotNumber": 6,
+          "isShaking": "slot",
           "switchChannels": {
             "Gobo Indexing / Rotation": "Gobo Indexing"
           }
@@ -782,6 +787,7 @@
           "dmxRange": [185, 208],
           "type": "WheelShake",
           "slotNumber": 7,
+          "isShaking": "slot",
           "switchChannels": {
             "Gobo Indexing / Rotation": "Gobo Indexing"
           }

--- a/fixtures/martin/rush-scanner-1-led.json
+++ b/fixtures/martin/rush-scanner-1-led.json
@@ -609,125 +609,191 @@
         {
           "dmxRange": [0, 4],
           "type": "WheelSlot",
-          "slotNumber": 1
+          "slotNumber": 1,
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [5, 9],
           "type": "WheelSlot",
           "slotNumber": 2,
-          "comment": "indexing"
+          "comment": "indexing",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [10, 14],
           "type": "WheelSlot",
           "slotNumber": 3,
-          "comment": "indexing"
+          "comment": "indexing",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [15, 19],
           "type": "WheelSlot",
           "slotNumber": 4,
-          "comment": "indexing"
+          "comment": "indexing",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [20, 24],
           "type": "WheelSlot",
           "slotNumber": 5,
-          "comment": "indexing"
+          "comment": "indexing",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [25, 29],
           "type": "WheelSlot",
           "slotNumber": 6,
-          "comment": "indexing"
+          "comment": "indexing",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [30, 34],
           "type": "WheelSlot",
           "slotNumber": 7,
-          "comment": "indexing"
+          "comment": "indexing",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [35, 39],
           "type": "WheelSlot",
           "slotNumber": 2,
-          "comment": "rotating"
+          "comment": "rotating",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+          }
         },
         {
           "dmxRange": [40, 44],
           "type": "WheelSlot",
           "slotNumber": 3,
-          "comment": "rotating"
+          "comment": "rotating",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+          }
         },
         {
           "dmxRange": [45, 49],
           "type": "WheelSlot",
           "slotNumber": 4,
-          "comment": "rotating"
+          "comment": "rotating",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+          }
         },
         {
           "dmxRange": [50, 54],
           "type": "WheelSlot",
           "slotNumber": 5,
-          "comment": "rotating"
+          "comment": "rotating",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+          }
         },
         {
           "dmxRange": [55, 59],
           "type": "WheelSlot",
           "slotNumber": 6,
-          "comment": "rotating"
+          "comment": "rotating",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+          }
         },
         {
           "dmxRange": [60, 64],
           "type": "WheelSlot",
           "slotNumber": 7,
-          "comment": "rotating"
+          "comment": "rotating",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Rotation"
+          }
         },
         {
           "dmxRange": [65, 88],
           "type": "WheelShake",
-          "slotNumber": 2
+          "slotNumber": 2,
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [89, 112],
           "type": "WheelShake",
-          "slotNumber": 3
+          "slotNumber": 3,
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [113, 136],
           "type": "WheelShake",
-          "slotNumber": 4
+          "slotNumber": 4,
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [137, 160],
           "type": "WheelShake",
-          "slotNumber": 5
+          "slotNumber": 5,
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [161, 184],
           "type": "WheelShake",
-          "slotNumber": 6
+          "slotNumber": 6,
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [185, 208],
           "type": "WheelShake",
-          "slotNumber": 7
+          "slotNumber": 7,
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [209, 209],
-          "type": "NoFunction"
+          "type": "NoFunction",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [210, 232],
           "type": "WheelRotation",
           "speedStart": "fast CW",
-          "speedEnd": "slow CW"
+          "speedEnd": "slow CW",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         },
         {
           "dmxRange": [233, 255],
           "type": "WheelRotation",
           "speedStart": "slow CCW",
-          "speedEnd": "fast CCW"
+          "speedEnd": "fast CCW",
+          "switchChannels": {
+            "Gobo 1 Indexing / Rotation": "Gobo 1 Indexing"
+          }
         }
       ]
     },
@@ -954,17 +1020,26 @@
       "capabilities": [
         {
           "dmxRange": [0, 10],
-          "type": "NoFunction"
+          "type": "NoFunction",
+          "switchChannels": {
+            "Prism Indexing / Rotation": "Prism Indexing"
+          }
         },
         {
           "dmxRange": [11, 138],
           "type": "Prism",
-          "comment": "indexed"
+          "comment": "indexed",
+          "switchChannels": {
+            "Prism Indexing / Rotation": "Prism Indexing"
+          }
         },
         {
           "dmxRange": [139, 255],
           "type": "Prism",
-          "comment": "rotating"
+          "comment": "rotating",
+          "switchChannels": {
+            "Prism Indexing / Rotation": "Prism Rotation"
+          }
         }
       ]
     },
@@ -1208,12 +1283,10 @@
         "Color Wheel 1",
         "Color Wheel 2",
         "Gobo Wheel 1",
-        "Gobo 1 Indexing",
-        "Gobo 1 Rotation",
+        "Gobo 1 Indexing / Rotation",
         "Gobo Wheel 2",
         "Prism",
-        "Prism Indexing",
-        "Prism Rotation",
+        "Prism Indexing / Rotation",
         "Focus",
         "Pan",
         "Pan fine",

--- a/fixtures/martin/rush-scanner-1-led.json
+++ b/fixtures/martin/rush-scanner-1-led.json
@@ -70,9 +70,6 @@
         {
           "type": "Color",
           "name": "Light blue"
-        },
-        {
-          "type": "Open"
         }
       ]
     },
@@ -114,9 +111,6 @@
         {
           "type": "Color",
           "name": "Blue"
-        },
-        {
-          "type": "Open"
         }
       ]
     },
@@ -149,183 +143,6 @@
       "slots": [
         {
           "type": "Open"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Open"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
-        },
-        {
-          "type": "Gobo"
         },
         {
           "type": "Gobo"
@@ -917,6 +734,7 @@
     "Gobo 1 Indexing": {
       "capability": {
         "type": "WheelSlotRotation",
+        "wheel": "Gobo Wheel 1",
         "angleStart": "0deg",
         "angleEnd": "180deg"
       }
@@ -927,28 +745,33 @@
         {
           "dmxRange": [0, 2],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel 1",
           "angle": "0deg"
         },
         {
           "dmxRange": [3, 126],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel 1",
           "speedStart": "fast CW",
           "speedEnd": "slow CW"
         },
         {
           "dmxRange": [127, 129],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel 1",
           "speed": "stop"
         },
         {
           "dmxRange": [130, 253],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel 1",
           "speedStart": "slow CCW",
           "speedEnd": "fast CCW"
         },
         {
           "dmxRange": [254, 255],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel 1",
           "speed": "stop"
         }
       ]

--- a/fixtures/martin/rush-scanner-1-led.json
+++ b/fixtures/martin/rush-scanner-1-led.json
@@ -41,35 +41,43 @@
         },
         {
           "type": "Color",
-          "name": "Red"
+          "name": "Red",
+          "colors": ["#ff0000"]
         },
         {
           "type": "Color",
-          "name": "Deep Blue"
+          "name": "Deep Blue",
+          "colors": ["#0000b4"]
         },
         {
           "type": "Color",
-          "name": "Lavender"
+          "name": "Lavender",
+          "colors": ["#ff80ff"]
         },
         {
           "type": "Color",
-          "name": "Magenta"
+          "name": "Magenta",
+          "colors": ["#ff00ff"]
         },
         {
           "type": "Color",
-          "name": "Yellow"
+          "name": "Yellow",
+          "colors": ["#ffff00"]
         },
         {
           "type": "Color",
-          "name": "Orange"
+          "name": "Orange",
+          "colors": ["#ff8000"]
         },
         {
           "type": "Color",
-          "name": "Light green"
+          "name": "Light green",
+          "colors": ["#80ff00"]
         },
         {
           "type": "Color",
-          "name": "Light blue"
+          "name": "Light blue",
+          "colors": ["#0080ff"]
         }
       ]
     },
@@ -80,37 +88,45 @@
         },
         {
           "type": "Color",
-          "name": "Pink"
+          "name": "Pink",
+          "colors": ["#ff9696"]
         },
         {
           "type": "Color",
           "name": "CTO",
-          "colorTemperature": "3200K"
+          "colorTemperature": "3200K",
+          "colors": ["#fff0c8"]
         },
         {
           "type": "Color",
-          "name": "UV Purple"
+          "name": "UV Purple",
+          "colors": ["#b400ff"]
         },
         {
           "type": "Color",
-          "name": "Light yellow"
+          "name": "Light yellow",
+          "colors": ["#ffff80"]
         },
         {
           "type": "Color",
-          "name": "Green"
+          "name": "Green",
+          "colors": ["#00ff00"]
         },
         {
           "type": "Color",
-          "name": "Aquamarine"
+          "name": "Aquamarine",
+          "colors": ["#00ff80"]
         },
         {
           "type": "Color",
           "name": "CTO",
-          "colorTemperature": "5600K"
+          "colorTemperature": "5600K",
+          "colors": ["#fff0c8"]
         },
         {
           "type": "Color",
-          "name": "Blue"
+          "name": "Blue",
+          "colors": ["#0000ff"]
         }
       ]
     },


### PR DESCRIPTION
* Add fixture 'martin/rush-scanner-1-led'

### Fixture warnings / errors

* martin/rush-scanner-1-led
  - :x: Capability 'Wheel slot rotation 0…180°' (0…255) in channel 'Gobo 1 Indexing' does not explicitly reference any wheel, but the default wheel 'Gobo 1 Indexing' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation 0°' (0…2) in channel 'Gobo 1 Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo 1 Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation CW fast…slow' (3…126) in channel 'Gobo 1 Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo 1 Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation stop' (127…129) in channel 'Gobo 1 Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo 1 Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation CCW slow…fast' (130…253) in channel 'Gobo 1 Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo 1 Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation stop' (254…255) in channel 'Gobo 1 Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo 1 Rotation' (through the channel name) does not exist.
  - :x: Mode '16-channel' should have 16 channels according to its name but actually has 18.
  - :x: Mode '16-channel' should have 16 channels according to its shortName but actually has 18.
  - :warning: Unused wheel slot(s): Gobo Wheel 2 (slot 10), Gobo Wheel 2 (slot 11), Gobo Wheel 2 (slot 12), Gobo Wheel 2 (slot 13), Gobo Wheel 2 (slot 14), Gobo Wheel 2 (slot 15), Gobo Wheel 2 (slot 16), Gobo Wheel 2 (slot 17), Gobo Wheel 2 (slot 18), Gobo Wheel 2 (slot 19), Gobo Wheel 2 (slot 20), Gobo Wheel 2 (slot 21), Gobo Wheel 2 (slot 22), Gobo Wheel 2 (slot 23), Gobo Wheel 2 (slot 24), Gobo Wheel 2 (slot 25), Gobo Wheel 2 (slot 26), Gobo Wheel 2 (slot 27), Gobo Wheel 2 (slot 28), Gobo Wheel 2 (slot 29), Gobo Wheel 2 (slot 30), Gobo Wheel 2 (slot 31), Gobo Wheel 2 (slot 32), Gobo Wheel 2 (slot 33), Gobo Wheel 2 (slot 34), Gobo Wheel 2 (slot 35), Gobo Wheel 2 (slot 36), Gobo Wheel 2 (slot 37), Gobo Wheel 2 (slot 38), Gobo Wheel 2 (slot 39), Gobo Wheel 2 (slot 40), Gobo Wheel 2 (slot 41), Gobo Wheel 2 (slot 42), Gobo Wheel 2 (slot 43), Gobo Wheel 2 (slot 44), Gobo Wheel 2 (slot 45), Gobo Wheel 2 (slot 46), Gobo Wheel 2 (slot 47), Gobo Wheel 2 (slot 48), Gobo Wheel 2 (slot 49), Gobo Wheel 2 (slot 50), Gobo Wheel 2 (slot 51), Gobo Wheel 2 (slot 52), Gobo Wheel 2 (slot 53), Gobo Wheel 2 (slot 54), Gobo Wheel 2 (slot 55), Gobo Wheel 2 (slot 56), Gobo Wheel 2 (slot 57), Gobo Wheel 2 (slot 58), Gobo Wheel 2 (slot 59), Gobo Wheel 2 (slot 60), Gobo Wheel 2 (slot 61), Gobo Wheel 2 (slot 62), Gobo Wheel 2 (slot 63), Gobo Wheel 2 (slot 64), Gobo Wheel 2 (slot 65), Gobo Wheel 2 (slot 66), Gobo Wheel 2 (slot 67)


Thank you @Fxedel!