### PR TITLE
Add fixture 'eurolite/x'

### DIFF
--- a/fixtures/eurolite/x.json
+++ b/fixtures/eurolite/x.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "x",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["xxxx"],
+    "createDate": "2019-03-09",
+    "lastModifyDate": "2019-03-09"
+  },
+  "links": {
+    "other": [
+      "http://xxxx.net"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "1": {
+      "defaultValue": 1,
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": "bright",
+        "brightnessEnd": "dark"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "x",
+      "channels": [
+        "1"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'eurolite/x'

### Fixture warnings / errors

* eurolite/x
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.


Thank you **xxxx**!