### PR TITLE
Hide Anonymous from register's contributors 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ clean:
 fixtures/register.json: \
 fixtures/*/*.json \
 fixtures/manufacturers.json \
-cli/make-register.js
+cli/make-register.js \
+lib/register.js
 	node cli/make-register.js
 	@echo ""
 

--- a/lib/register.js
+++ b/lib/register.js
@@ -192,7 +192,7 @@ class Register {
       }
 
       return localeSort(nameA, nameB);
-    });
+    }).filter(contributor => contributor !== `Anonymous`);
     sortedContributors.forEach(contributor => {
       sortedRegister.contributors[contributor] = this.contributors[contributor].sort(localeSort);
     });


### PR DESCRIPTION
Currently, "Anonymous" is the top 5 contributor, which is less encouraging than an actual person. "Anonymous" isn't even a (single) person and therefore can't be a "contributor".