### PR TITLE
Update Nuxt to version 2.5.1

### DIFF
--- a/main.js
+++ b/main.js
@@ -154,19 +154,21 @@ const nuxt = new Nuxt(nuxtConfig);
 // render every remaining route with Nuxt.js
 app.use(nuxt.render);
 
+let startNuxt;
 if (nuxtConfig.dev) {
   console.log(`Starting dev server with hot reloading...`);
-  new Builder(nuxt).build()
-    .then(listen)
-    .catch(error => {
-      console.error(error);
-      process.exit(1);
-    });
+  startNuxt = new Builder(nuxt).build();
 }
 else {
   // build has been done already
-  listen();
+  startNuxt = nuxt.ready();
 }
+
+startNuxt.then(listen)
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "multer": "^1.4.1",
     "node-env-file": "^0.1.8",
     "node-sass": "^4.11.0",
-    "nuxt": "^2.5.1",
+    "nuxt": "~2.5.1",
     "sanitize-filename": "^1.6.1",
     "sass-loader": "^7.1.0",
     "scroll-into-view": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "multer": "^1.4.1",
     "node-env-file": "^0.1.8",
     "node-sass": "^4.11.0",
-    "nuxt": "^2.4.2",
+    "nuxt": "^2.5.1",
     "sanitize-filename": "^1.6.1",
     "sass-loader": "^7.1.0",
     "scroll-into-view": "^1.9.3",


### PR DESCRIPTION
Fixes #837 and hopefully prevents rough Nuxt updates in the future, since every new minor version will be out of our specified range and thus triggers a new PR.