### PR TITLE
Explicitly upgrade @octokit/rest to 16.23.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1445,11 +1445,12 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.22.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.22.0.tgz",
-      "integrity": "sha512-1PGUwDxLuG7AZsiKaIdxJr918jcZ1FtPX0kGqxoUlssn+fIzzlwQY623gnM8vY9c9jfASD+QUQmflHh3FwBthw==",
+      "version": "16.23.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.23.1.tgz",
+      "integrity": "sha512-Kwjt6Ue6lgRcc6enQ2O6QLkDtK1yTDJgfjrfyGar5R+fsESVomOTl1D9iq9NNSQMPaDctcpUD8C/HudjYAeoWw==",
       "requires": {
         "@octokit/request": "2.4.2",
+        "atob-lite": "^2.0.0",
         "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
         "deprecation": "^1.0.1",
@@ -2151,6 +2152,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
     },
     "autoprefixer": {
       "version": "9.5.0",
@@ -7857,9 +7863,9 @@
       }
     },
     "macos-release": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.1.0.tgz",
-      "integrity": "sha512-8TCbwvN1mfNxbBv0yBtfyIFMo3m1QsNbKHv7PYIp/abRBKVQBXN7ecu3aeGGgT18VC/Tf397LBDGZF9KBGJFFw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA=="
     },
     "make-dir": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@heise/embetty-server": "^1.2.2",
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/style-resources": "^0.1.1",
-    "@octokit/rest": "^16.14.1",
+    "@octokit/rest": "^16.23.1",
     "a11y-dialog": "^5.2.0",
     "color": "^3.1.0",
     "color-hash": "^1.0.3",


### PR DESCRIPTION
Like Greenkeeper has correctly issued, version 16.23.0 has an error that makes our project crash. This was fixed with 16.23.1.

Closes #856.