### PR TITLE
Replace colors dependency with chalk

### DIFF
--- a/cli/debug-env-variables.js
+++ b/cli/debug-env-variables.js
@@ -1,6 +1,6 @@
 #!/usr/bin/node
 
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 
 const usedVariables = [
   `ALLOW_SEARCH_INDEXING`,
@@ -31,13 +31,13 @@ printVariables();
  */
 function printVariables() {
   for (const key of usedVariables) {
-    let str = colors.yellow(key);
+    let str = chalk.yellow(key);
 
     if (key in process.env) {
-      str += `=${colors.blue(process.env[key])}`;
+      str += `=${chalk.blue(process.env[key])}`;
     }
     else {
-      str += colors.red(` is unset`);
+      str += chalk.red(` is unset`);
     }
 
     console.log(str);

--- a/cli/diff-plugin-outputs.js
+++ b/cli/diff-plugin-outputs.js
@@ -2,7 +2,7 @@
 
 const path = require(`path`);
 const minimist = require(`minimist`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 
 const diffPluginOutputs = require(`../lib/diff-plugin-outputs.js`);
 
@@ -43,7 +43,7 @@ if (args.help) {
 }
 
 if (!args.plugin) {
-  console.error(`${colors.red(`[Error]`)} Plugin has to be specified using --plugin`);
+  console.error(`${chalk.red(`[Error]`)} Plugin has to be specified using --plugin`);
   console.log(helpMessage);
   process.exit(1);
 }
@@ -54,7 +54,7 @@ if (!args.comparePlugin) {
 }
 
 if (args.fixtures.length === 0 && !args.testFix) {
-  console.log(`${colors.yellow(`[Warning]`)} No fixtures specified. See --help for usage.`);
+  console.log(`${chalk.yellow(`[Warning]`)} No fixtures specified. See --help for usage.`);
 }
 
 diffPluginOutputs(args.plugin, args.comparePlugin, args.ref, args.testFix ? testFixtures : args.fixtures);

--- a/cli/export-fixture.js
+++ b/cli/export-fixture.js
@@ -2,7 +2,7 @@
 const fs = require(`fs`);
 const path = require(`path`);
 const minimist = require(`minimist`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 const mkdirp = require(`mkdirp`);
 
 const plugins = require(`../plugins/plugins.json`);
@@ -31,17 +31,17 @@ if (args.help) {
 }
 
 if (!args.plugin) {
-  console.error(`${colors.red(`[Error]`)} No plugin specified. See --help for usage.`);
+  console.error(`${chalk.red(`[Error]`)} No plugin specified. See --help for usage.`);
   process.exit(1);
 }
 
 if (args._.length === 0 && !args.a) {
-  console.error(`${colors.red(`[Error]`)} No fixtures specified. See --help for usage.`);
+  console.error(`${chalk.red(`[Error]`)} No fixtures specified. See --help for usage.`);
   process.exit(1);
 }
 
 if (!plugins.exportPlugins.includes(args.plugin)) {
-  console.error(`${colors.red(`[Error]`)} Plugin '${args.plugin}' does not exist or does not support exporting.\n\navailable plugins: ${Object.keys(plugins.exportPlugins).join(`, `)}`);
+  console.error(`${chalk.red(`[Error]`)} Plugin '${args.plugin}' does not exist or does not support exporting.\n\navailable plugins: ${Object.keys(plugins.exportPlugins).join(`, `)}`);
   process.exit(1);
 }
 
@@ -81,12 +81,12 @@ plugin.export(
         console.log(`Created file ${filePath}`);
       }
       else {
-        console.log(`\n${colors.yellow(`File name: '${file.name}'`)}`);
+        console.log(`\n${chalk.yellow(`File name: '${file.name}'`)}`);
         console.log(file.content);
       }
     });
   })
   .catch(error => {
-    console.error(`${colors.red(`[Error]`)} Exporting failed:`, error);
+    console.error(`${chalk.red(`[Error]`)} Exporting failed:`, error);
     process.exit(1);
   });

--- a/cli/make-dereferenced-schemas.js
+++ b/cli/make-dereferenced-schemas.js
@@ -2,7 +2,7 @@
 
 const fs = require(`fs`);
 const path = require(`path`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 const schemaRefParser = require(`json-schema-ref-parser`);
 
 const schemaDir = path.join(__dirname, `../schemas/`);
@@ -28,9 +28,9 @@ for (const schemaFile of schemaFiles) {
       `${JSON.stringify(dereferencedSchema, null, 2)}\n`
     ))
     .then(() => {
-      console.log(`${colors.green(`[Success]`)} Updated dereferenced schema ${dereferencedSchemaFile}.`);
+      console.log(`${chalk.green(`[Success]`)} Updated dereferenced schema ${dereferencedSchemaFile}.`);
     })
     .catch(error => {
-      console.error(colors.red(`[Error]`), error);
+      console.error(chalk.red(`[Error]`), error);
     });
 }

--- a/cli/make-plugin-data.js
+++ b/cli/make-plugin-data.js
@@ -2,7 +2,7 @@
 
 const path = require(`path`);
 const fs = require(`fs`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 
 const plugins = {
   importPlugins: [],
@@ -106,9 +106,9 @@ plugins.data = sortedPluginData;
 const filename = path.join(pluginDir, `plugins.json`);
 fs.writeFile(filename, `${JSON.stringify(plugins, null, 2)}\n`, `utf8`, error => {
   if (error) {
-    console.error(`${colors.red(`[Fail]`)} Could not write plugin data file.`, error);
+    console.error(`${chalk.red(`[Fail]`)} Could not write plugin data file.`, error);
     process.exit(1);
   }
-  console.log(`${colors.green(`[Success]`)} Updated plugin data file ${filename}`);
+  console.log(`${chalk.green(`[Success]`)} Updated plugin data file ${filename}`);
   process.exit(0);
 });

--- a/cli/make-register.js
+++ b/cli/make-register.js
@@ -2,7 +2,7 @@
 
 const fs = require(`fs`);
 const path = require(`path`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 
 const { Register } = require(`../lib/register.js`);
 const manufacturers = require(`../fixtures/manufacturers.json`);
@@ -54,9 +54,9 @@ const fileContents = `${JSON.stringify(register.getAsSortedObject(), null, 2)}\n
 
 fs.writeFile(filename, fileContents, `utf8`, error => {
   if (error) {
-    console.error(`${colors.red(`[Fail]`)} Could not write register file.`, error);
+    console.error(`${chalk.red(`[Fail]`)} Could not write register file.`, error);
     process.exit(1);
   }
-  console.log(`${colors.green(`[Success]`)} Updated register file ${filename}`);
+  console.log(`${chalk.green(`[Success]`)} Updated register file ${filename}`);
   process.exit(0);
 });

--- a/cli/make-test-fixtures.js
+++ b/cli/make-test-fixtures.js
@@ -7,7 +7,7 @@
 
 const fs = require(`fs`);
 const path = require(`path`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 
 const { fixtureFromRepository } = require(`../lib/model.js`);
 const register = require(`../fixtures/register.json`);
@@ -38,7 +38,7 @@ for (const featureFile of fs.readdirSync(fixFeaturesDir)) {
 
       // check uniqueness of id
       if (fixFeature.id in featuresUsed) {
-        console.error(`${colors.red(`[Error]`)} Fixture feature id '${fixFeature.id}' is used multiple times.`);
+        console.error(`${chalk.red(`[Error]`)} Fixture feature id '${fixFeature.id}' is used multiple times.`);
         process.exit(1);
       }
 
@@ -102,26 +102,26 @@ fixtures.sort((a, b) => {
   return `${a.man}/${a.key}`.localeCompare(`${b.man}/${b.key}`, `en`);
 });
 
-console.log(colors.yellow(`Generated list of test fixtures:`));
+console.log(chalk.yellow(`Generated list of test fixtures:`));
 for (const fixture of fixtures) {
   console.log(` - ${fixture.man}/${fixture.key}`);
 }
 
 fs.writeFile(jsonFile, `${JSON.stringify(fixtures, null, 2)}\n`, `utf8`, error => {
   if (error) {
-    console.error(`${colors.red(`[Fail]`)} Could not write test-fixtures.json`, error);
+    console.error(`${chalk.red(`[Fail]`)} Could not write test-fixtures.json`, error);
   }
   else {
-    console.log(`${colors.green(`[Success]`)} Updated ${jsonFile}`);
+    console.log(`${chalk.green(`[Success]`)} Updated ${jsonFile}`);
   }
 });
 
 fs.writeFile(markdownFile, getMarkdownCode(), `utf8`, error => {
   if (error) {
-    console.error(`${colors.red(`[Fail]`)} Could not write test-fixtures.md`, error);
+    console.error(`${chalk.red(`[Fail]`)} Could not write test-fixtures.md`, error);
   }
   else {
-    console.log(`${colors.green(`[Success]`)} Updated ${markdownFile}`);
+    console.log(`${chalk.green(`[Success]`)} Updated ${markdownFile}`);
   }
 });
 

--- a/cli/run-export-test.js
+++ b/cli/run-export-test.js
@@ -1,7 +1,7 @@
 #!/usr/bin/node
 const path = require(`path`);
 const minimist = require(`minimist`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 
 const plugins = require(`../plugins/plugins.json`);
 const { fixtureFromFile, fixtureFromRepository } = require(`../lib/model.js`);
@@ -29,19 +29,19 @@ if (args.help) {
 }
 
 if (!args.plugin) {
-  console.error(`${colors.red(`[Error]`)} Plugin has to be specified using --plugin`);
+  console.error(`${chalk.red(`[Error]`)} Plugin has to be specified using --plugin`);
   console.log(helpMessage);
   process.exit(1);
 }
 
 if (!plugins.exportPlugins.includes(args.plugin)) {
-  console.error(`${colors.red(`[Error]`)} Plugin '${args.plugin}' is not a valid export plugin.\nAvailable export plugins: ${plugins.exportPlugins.join(`, `)}`);
+  console.error(`${chalk.red(`[Error]`)} Plugin '${args.plugin}' is not a valid export plugin.\nAvailable export plugins: ${plugins.exportPlugins.join(`, `)}`);
   process.exit(1);
 }
 
 const pluginData = plugins.data[args.plugin];
 if (pluginData.exportTests.length === 0) {
-  console.log(`${colors.green(`[PASS]`)} Plugin '${args.plugin}' has no export tests.`);
+  console.log(`${chalk.green(`[PASS]`)} Plugin '${args.plugin}' has no export tests.`);
   process.exit(0);
 }
 
@@ -68,23 +68,23 @@ pluginExport.export(fixtures, {
 
       const filePromises = files.map(file =>
         exportTest(file)
-          .then(() => `${colors.green(`[PASS]`)} ${file.name}`)
+          .then(() => `${chalk.green(`[PASS]`)} ${file.name}`)
           .catch(err => {
             const errors = Array.isArray(err) ? err : [err];
 
-            return [`${colors.red(`[FAIL]`)} ${file.name}`].concat(
+            return [`${chalk.red(`[FAIL]`)} ${file.name}`].concat(
               errors.map(error => `- ${error}`)
             ).join(`\n`);
           })
       );
 
       return Promise.all(filePromises).then(outputPerFile => {
-        console.log(`\n${colors.yellow(`Test ${testKey}`)}`);
+        console.log(`\n${chalk.yellow(`Test ${testKey}`)}`);
         console.log(outputPerFile.join(`\n`));
       });
     })
   ))
   .catch(error => {
-    console.error(`${colors.red(`[Error]`)} Exporting failed:`, error);
+    console.error(`${chalk.red(`[Error]`)} Exporting failed:`, error);
     process.exit(1);
   });

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -2,7 +2,7 @@ const fs = require(`fs`);
 const path = require(`path`);
 const childProcess = require(`child_process`);
 const JSZip = require(`jszip`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 const disparity = require(`disparity`);
 const dirCompare = require(`dir-compare`);
 const promisify = require(`util`).promisify;
@@ -47,7 +47,7 @@ module.exports = function diffPluginOutputs(currentPluginKey, comparePluginKey, 
 
   const tempDir = path.join(__dirname, `..`, `tmp`);
   if (process.cwd().match(tempDir)) {
-    console.error(`${colors.red(`[Error]`)} This script can't be run from inside the tmp directory.`);
+    console.error(`${chalk.red(`[Error]`)} This script can't be run from inside the tmp directory.`);
     process.exit(1);
   }
 
@@ -65,7 +65,7 @@ module.exports = function diffPluginOutputs(currentPluginKey, comparePluginKey, 
       path.join(__dirname, `..`)
     ))
     .catch(error => {
-      console.error(`${colors.red(`[Error]`)} Exporting with current plugin script failed:`, error);
+      console.error(`${chalk.red(`[Error]`)} Exporting with current plugin script failed:`, error);
       process.exit(1);
     })
 
@@ -79,7 +79,7 @@ module.exports = function diffPluginOutputs(currentPluginKey, comparePluginKey, 
         encoding: `utf-8`
       })
         .catch(error => {
-          console.error(`${colors.red(`[Error]`)} Failed to download compare plugin script: ${error.message}`);
+          console.error(`${chalk.red(`[Error]`)} Failed to download compare plugin script: ${error.message}`);
           process.exit(1);
         })
 
@@ -112,7 +112,7 @@ module.exports = function diffPluginOutputs(currentPluginKey, comparePluginKey, 
           unzipDir
         ))
         .catch(error => {
-          console.error(`${colors.red(`[Error]`)} Exporting with compare plugin script failed:`, error);
+          console.error(`${chalk.red(`[Error]`)} Exporting with compare plugin script failed:`, error);
           process.exit(1);
         });
     })
@@ -139,7 +139,7 @@ module.exports = function diffPluginOutputs(currentPluginKey, comparePluginKey, 
           case `left`:
             name = getRelativePath(difference.relativePath, difference.name1, difference.type1);
 
-            console.log(colors.red(`File or directory ${name} was removed.`));
+            console.log(chalk.red(`File or directory ${name} was removed.`));
 
             outputData.removedFiles.push(name);
             continue;
@@ -147,7 +147,7 @@ module.exports = function diffPluginOutputs(currentPluginKey, comparePluginKey, 
           case `right`:
             name = getRelativePath(difference.relativePath, difference.name2, difference.type2);
 
-            console.log(colors.green(`File or directory ${name} was added.`));
+            console.log(chalk.green(`File or directory ${name} was added.`));
 
             outputData.addedFiles.push(name);
             continue;
@@ -157,7 +157,7 @@ module.exports = function diffPluginOutputs(currentPluginKey, comparePluginKey, 
             const file1 = fs.readFileSync(path.join(difference.path1, difference.name1), `utf8`);
             const file2 = fs.readFileSync(path.join(difference.path2, difference.name2), `utf8`);
 
-            console.log(colors.yellow(`Diff for ${name}`));
+            console.log(chalk.yellow(`Diff for ${name}`));
             console.log(disparity.unified(file1, file2));
 
             outputData.changedFiles[name] = disparity.unifiedNoColor(file1, file2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1917,7 +1917,8 @@
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "anymatch": {
       "version": "2.0.0",
@@ -2603,6 +2604,21 @@
         "robots-txt-parse": "~0.0.4",
         "urlcache": "~0.7.0",
         "urlobj": "0.0.11"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        }
       }
     },
     "brorand": {
@@ -2929,15 +2945,34 @@
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "char-spinner": {
@@ -3214,12 +3249,6 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
-    },
-    "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-      "dev": true
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -6353,6 +6382,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -6900,7 +6930,6 @@
       "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
       "requires": {
         "ansi-escapes": "^1.1.0",
-        "chalk": "^1.0.0",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^2.0.1",
@@ -8439,7 +8468,6 @@
       "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
       "requires": {
         "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
         "cross-spawn": "^3.0.0",
         "gaze": "^1.0.0",
         "get-stdin": "^4.0.1",
@@ -10862,7 +10890,6 @@
       "integrity": "sha512-I+5FfV+Hb29U5Nt8DbslWOBgRmTv1M/EwOn4/4rc6Aqy9yjygoa8UTnyCFXfTZV8FoQyIBZbEyKSBryhByqQbA==",
       "requires": {
         "async": "^2.1.4",
-        "chalk": "^1.1.3",
         "glob": "^7.1.1",
         "loader-utils": "^1.0.4"
       }
@@ -10921,7 +10948,6 @@
           "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
           "requires": {
             "babel-polyfill": "6.23.0",
-            "chalk": "1.1.3",
             "inquirer": "3.0.6",
             "minimist": "1.2.0",
             "node-fetch": "1.6.3",
@@ -11783,7 +11809,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "svg-inline-loader": {
       "version": "0.8.0",
@@ -12880,7 +12907,6 @@
       "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.10.tgz",
       "integrity": "sha512-UYoCEutBpKzL2fKCwx8zlRtRtwxbPZXKTqbl2iIF4yRZUNO/ovrHyDAJDljft0kd+K0tZhN53XRHkgvCZoIhug==",
       "requires": {
-        "chalk": "^1.1.3",
         "hash-sum": "^1.0.2",
         "he": "^1.1.0",
         "lodash.template": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "ajv": "^6.9.1",
     "broken-link-checker": "^0.7.6",
-    "colors": "^1.3.3",
+    "chalk": "^2.4.2",
     "diff": "^4.0.1",
     "dir-compare": "^1.7.1",
     "disparity": "^2.0.0",

--- a/tests/dmx-value-scaling.js
+++ b/tests/dmx-value-scaling.js
@@ -1,5 +1,5 @@
 #!/usr/bin/node
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 
 // see https://github.com/standard-things/esm#getting-started
 require = require(`esm`)(module); // eslint-disable-line no-global-assign
@@ -29,11 +29,11 @@ testRandomChannelDownscaling(3);
 
 console.log();
 if (errorCount > 0) {
-  console.log(`${colors.red(`[FAIL]`)} Test failed with ${errorCount} error${errorCount > 1 ? `s` : ``}.`);
+  console.log(`${chalk.red(`[FAIL]`)} Test failed with ${errorCount} error${errorCount > 1 ? `s` : ``}.`);
   process.exit(1);
 }
 else {
-  console.log(`${colors.green(`[PASS]`)} Test passed.`);
+  console.log(`${chalk.green(`[PASS]`)} Test passed.`);
   process.exit(0);
 }
 
@@ -316,10 +316,10 @@ function testArraysEqual(description, array, desiredArray) {
  */
 function parseTestResult(passed, passString, failString) {
   if (passed) {
-    console.log(`${colors.green(`[PASS]`)} ${passString}`);
+    console.log(`${chalk.green(`[PASS]`)} ${passString}`);
   }
   else {
-    console.log(`${colors.red(`[FAIL]`)} ${failString}`);
+    console.log(`${chalk.red(`[FAIL]`)} ${failString}`);
     errorCount++;
   }
 }

--- a/tests/fixtures-valid.js
+++ b/tests/fixtures-valid.js
@@ -2,7 +2,7 @@
 
 const fs = require(`fs`);
 const path = require(`path`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 const Ajv = require(`ajv`);
 
 const manufacturerSchema = require(`../schemas/dereferenced/manufacturers.json`);
@@ -156,18 +156,18 @@ Promise.all(promises).then(results => {
     const failed = result.errors.length > 0;
 
     console.log(
-      failed ? colors.red(`[FAIL]`) : colors.green(`[PASS]`),
+      failed ? chalk.red(`[FAIL]`) : chalk.green(`[PASS]`),
       result.name
     );
 
     totalFails += failed ? 1 : 0;
     for (const error of result.errors) {
-      console.log(`└`, colors.red(`Error:`), error);
+      console.log(`└`, chalk.red(`Error:`), error);
     }
 
     totalWarnings += result.warnings.length;
     for (const warning of result.warnings) {
-      console.log(`└`, colors.yellow(`Warning:`), warning);
+      console.log(`└`, chalk.yellow(`Warning:`), warning);
     }
   });
 
@@ -176,14 +176,14 @@ Promise.all(promises).then(results => {
 
   // summary
   if (totalWarnings > 0) {
-    console.log(colors.yellow(`[INFO]`), `${totalWarnings} unresolved warning(s)`);
+    console.log(chalk.yellow(`[INFO]`), `${totalWarnings} unresolved warning(s)`);
   }
 
   if (totalFails === 0) {
-    console.log(colors.green(`[PASS]`), `All ${results.length} tested files were valid.`);
+    console.log(chalk.green(`[PASS]`), `All ${results.length} tested files were valid.`);
     process.exit(0);
   }
 
-  console.error(colors.red(`[FAIL]`), `${totalFails} of ${results.length} tested files failed.`);
+  console.error(chalk.red(`[FAIL]`), `${totalFails} of ${results.length} tested files failed.`);
   process.exit(1);
-}).catch(error => console.error(colors.red(`[Error]`), `Test errored:`, error));
+}).catch(error => console.error(chalk.red(`[Error]`), `Test errored:`, error));

--- a/tests/http-status.js
+++ b/tests/http-status.js
@@ -1,7 +1,7 @@
 #!/usr/bin/node
 
 const path = require(`path`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 const childProcess = require(`child_process`);
 const blc = require(`broken-link-checker`);
 const pullRequest = require(`./github/pull-request.js`);
@@ -42,19 +42,19 @@ const siteChecker = new blc.SiteChecker({
     }
   },
   link(result, customData) {
-    let location = colors.cyan(`(ex)`);
-    let failStr = colors.yellow(`[WARN]`);
+    let location = chalk.cyan(`(ex)`);
+    let failStr = chalk.yellow(`[WARN]`);
     if (result.internal) {
-      location = colors.magenta(`(in)`);
-      failStr = colors.red(`[FAIL]`);
+      location = chalk.magenta(`(in)`);
+      failStr = chalk.red(`[FAIL]`);
     }
 
     if ((result.internal && result.brokenReason === `HTTP_201`) || (!result.internal && !result.broken)) {
-      foundLinks[result.base.resolved].push(` └ ${colors.green(`[PASS]`)} ${location} ${result.url.resolved}`);
+      foundLinks[result.base.resolved].push(` └ ${chalk.green(`[PASS]`)} ${location} ${result.url.resolved}`);
     }
     else if (result.broken) {
       foundLinks[result.base.resolved].push(` └ ${failStr} ${location} ${result.url.resolved}`);
-      foundLinks[result.base.resolved].push(`    └ ${colors.red(blc[result.brokenReason])}`);
+      foundLinks[result.base.resolved].push(`    └ ${chalk.red(blc[result.brokenReason])}`);
       fails[result.internal ? `internal` : `external`].add(result.url.resolved);
     }
   },
@@ -62,11 +62,11 @@ const siteChecker = new blc.SiteChecker({
     const resolvedUrl = resolvedUrls[pageUrl];
 
     if (error) {
-      console.log(`${colors.red(`[FAIL]`)} ${resolvedUrl}\n └ ${error}`);
+      console.log(`${chalk.red(`[FAIL]`)} ${resolvedUrl}\n └ ${error}`);
       fails.internal.add(resolvedUrl);
     }
     else {
-      foundLinks[resolvedUrl].unshift(`${colors.green(`[PASS]`)} ${resolvedUrl}`);
+      foundLinks[resolvedUrl].unshift(`${chalk.green(`[PASS]`)} ${resolvedUrl}`);
       console.log(foundLinks[resolvedUrl].join(`\n`));
     }
   },
@@ -87,15 +87,15 @@ const serverProcess = childProcess.execFile(`node`, [path.join(__dirname, `..`, 
 
   console.log();
   if (stdout) {
-    console.log(colors.yellow(`Server output (stdout):`));
+    console.log(chalk.yellow(`Server output (stdout):`));
     console.log(stdout);
   }
   if (stderr) {
-    console.log(colors.red(`Server errors (stderr):`));
+    console.log(chalk.red(`Server errors (stderr):`));
     console.log(stderr);
   }
 
-  let statusStr = colors.green(`[PASS]`);
+  let statusStr = chalk.green(`[PASS]`);
   let exitCode = 0;
 
   const lines = [
@@ -108,11 +108,11 @@ const serverProcess = childProcess.execFile(`node`, [path.join(__dirname, `..`, 
   let githubCommentLines = [];
 
   if (fails.internal.size > 0) {
-    statusStr = colors.red(`[FAIL]`);
+    statusStr = chalk.red(`[FAIL]`);
     exitCode = 1;
   }
   else if (fails.external.size > 0) {
-    statusStr = colors.yellow(`[WARN]`);
+    statusStr = chalk.yellow(`[WARN]`);
     githubCommentLines = lines;
   }
 

--- a/tests/make-targets-updated.js
+++ b/tests/make-targets-updated.js
@@ -1,7 +1,7 @@
 #!/usr/bin/node
 
 const path = require(`path`);
-const colors = require(`colors`);
+const chalk = require(`chalk`);
 const childProcess = require(`child_process`);
 
 
@@ -11,7 +11,7 @@ try {
   childProcess.execSync(`make --always-make --directory=${path.join(__dirname, `..`)}`);
 }
 catch (error) {
-  console.error(`${colors.red(`[FAIL]`)} Unable to run Makefile:`, error);
+  console.error(`${chalk.red(`[FAIL]`)} Unable to run Makefile:`, error);
   process.exit(1);
 }
 
@@ -25,9 +25,9 @@ console.log(`\n`);
 
 
 if (result.status !== 0) {
-  console.error(`${colors.red(`[FAIL]`)} Make targets are not up-to-date or there are other unstaged changes. Please run \`make -B\` and stage (git add) all changes.`);
+  console.error(`${chalk.red(`[FAIL]`)} Make targets are not up-to-date or there are other unstaged changes. Please run \`make -B\` and stage (git add) all changes.`);
   process.exit(1);
 }
 
-console.log(`${colors.green(`[PASS]`)} Make targets are up-to-date.`);
+console.log(`${chalk.green(`[PASS]`)} Make targets are up-to-date.`);
 process.exit(0);


### PR DESCRIPTION
The `colors` package seems to break our CI build on open-fixture-library.org since we started to use `package-lock.json`/`npm ci` and we wanted to switch anyway for quite some time (see #439).

**Bonus:** `chalk` was already a transitive dependency before, so now we have less dependencies overall! :tada: