### PR TITLE
Add fixture 'robe/spot-160xt'

### DIFF
--- a/fixtures/robe/spot-160-xt.json
+++ b/fixtures/robe/spot-160-xt.json
@@ -33,6 +33,7 @@
       "degreesMinMax": [19, 19]
     },
     "focus": {
+      "type": "Head",
       "panMax": 530,
       "tiltMax": 280
     }

--- a/fixtures/robe/spot-160-xt.json
+++ b/fixtures/robe/spot-160-xt.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "Spot 160 XT",
-  "categories": ["Moving Head"],
+  "shortName": "RobeSpot160XT",
+  "categories": ["Moving Head", "Color Changer"],
   "meta": {
     "authors": ["Ringo333"],
-    "createDate": "2019-04-23",
-    "lastModifyDate": "2019-04-23"
+    "createDate": "2019-04-24",
+    "lastModifyDate": "2019-04-24"
   },
   "links": {
     "manual": [

--- a/fixtures/robe/spot-160-xt.json
+++ b/fixtures/robe/spot-160-xt.json
@@ -22,13 +22,15 @@
   "physical": {
     "dimensions": [292, 415, 378],
     "weight": 10.5,
+    "power": 300,
     "DMXconnector": "3-pin",
     "bulb": {
+      "type": "Philips CDM-SA/T150W/942",
       "colorTemperature": 4200,
       "lumens": 14000
     },
     "lens": {
-      "degreesMinMax": [0, 19]
+      "degreesMinMax": [19, 19]
     },
     "focus": {
       "panMax": 530,

--- a/fixtures/robe/spot-160-xt.json
+++ b/fixtures/robe/spot-160-xt.json
@@ -11,11 +11,11 @@
     "manual": [
       "http://www.schellscenic.com/downloads/Spot%20160%20XT.pdf"
     ],
-    "productPage": [
-      "http://spares.robe.cz/category/78"
-    ],
     "video": [
       "https://www.youtube.com/watch?v=rchX19BOlV0"
+    ],
+    "other": [
+      "http://spares.robe.cz/category/78"
     ]
   },
   "physical": {

--- a/fixtures/robe/spot-160-xt.json
+++ b/fixtures/robe/spot-160-xt.json
@@ -37,18 +37,101 @@
       "tiltMax": 280
     }
   },
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Color",
+          "name": "Turquoise",
+          "colors": ["#00ffaa"]
+        },
+        {
+          "type": "Color",
+          "name": "Red",
+          "colors": ["#ff0000"]
+        },
+        {
+          "type": "Color",
+          "name": "Cyan",
+          "colors": ["#00ffff"]
+        },
+        {
+          "type": "Color",
+          "name": "Light green",
+          "colors": ["#aaffaa"]
+        },
+        {
+          "type": "Color",
+          "name": "Magenta",
+          "colors": ["#ff00ff"]
+        },
+        {
+          "type": "Color",
+          "name": "Light blue",
+          "colors": ["#00ccff"]
+        },
+        {
+          "type": "Color",
+          "name": "Yellow",
+          "colors": ["#ffff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Green",
+          "colors": ["#00ff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Pink",
+          "colors": ["#ffaacc"]
+        },
+        {
+          "type": "Color",
+          "name": "Blue",
+          "colors": ["#0000ff"]
+        },
+        {
+          "type": "Color",
+          "name": "Orange",
+          "colors": ["#ffaa00"]
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        }
+      ]
+    }
+  },
   "availableChannels": {
     "Pan": {
-      "capability": {
-        "type": "Pan",
-        "angleStart": "0deg",
-        "angleEnd": "530deg"
-      }
-    },
-    "Pan 2": {
-      "name": "Pan",
-      "fineChannelAliases": ["Pan 2 fine"],
-      "dmxValueResolution": "8bit",
+      "fineChannelAliases": ["Pan fine"],
       "capability": {
         "type": "Pan",
         "angleStart": "0deg",
@@ -57,23 +140,6 @@
     },
     "Tilt": {
       "fineChannelAliases": ["Tilt fine"],
-      "dmxValueResolution": "8bit",
-      "capability": {
-        "type": "Tilt",
-        "angleStart": "0deg",
-        "angleEnd": "280deg"
-      }
-    },
-    "Pan 3": {
-      "name": "Pan",
-      "capability": {
-        "type": "Pan",
-        "angleStart": "0deg",
-        "angleEnd": "530deg"
-      }
-    },
-    "Tilt 2": {
-      "name": "Tilt",
       "capability": {
         "type": "Tilt",
         "angleStart": "0deg",
@@ -81,79 +147,427 @@
       }
     },
     "Pan/Tilt Speed": {
-      "capability": {
-        "type": "PanTiltSpeed",
-        "speedStart": "fast",
-        "speedEnd": "fast"
-      }
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "PanTiltSpeed",
+          "speed": "fast"
+        },
+        {
+          "dmxRange": [1, 249],
+          "type": "PanTiltSpeed",
+          "speedStart": "fast",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [250, 252],
+          "type": "PanTiltSpeed",
+          "speed": "fast",
+          "comment": "Blackout on color/gobo change"
+        },
+        {
+          "dmxRange": [253, 255],
+          "type": "PanTiltSpeed",
+          "speed": "fast",
+          "comment": "Blackout on pan/tilt/color/gobo change"
+        }
+      ]
     },
-    "Color Presets": {
-      "capability": {
-        "type": "ColorPreset"
-      }
+    "Color Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [1, 9],
+          "type": "WheelSlot",
+          "slotNumberStart": 1,
+          "slotNumberEnd": 2
+        },
+        {
+          "dmxRange": [10, 10],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [11, 20],
+          "type": "WheelSlot",
+          "slotNumberStart": 2,
+          "slotNumberEnd": 3
+        },
+        {
+          "dmxRange": [21, 21],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [22, 31],
+          "type": "WheelSlot",
+          "slotNumberStart": 3,
+          "slotNumberEnd": 4
+        },
+        {
+          "dmxRange": [32, 32],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [33, 41],
+          "type": "WheelSlot",
+          "slotNumberStart": 4,
+          "slotNumberEnd": 5
+        },
+        {
+          "dmxRange": [42, 42],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [43, 52],
+          "type": "WheelSlot",
+          "slotNumberStart": 5,
+          "slotNumberEnd": 6
+        },
+        {
+          "dmxRange": [53, 53],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [54, 63],
+          "type": "WheelSlot",
+          "slotNumberStart": 6,
+          "slotNumberEnd": 7
+        },
+        {
+          "dmxRange": [64, 64],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [65, 73],
+          "type": "WheelSlot",
+          "slotNumberStart": 7,
+          "slotNumberEnd": 8
+        },
+        {
+          "dmxRange": [74, 74],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [75, 84],
+          "type": "WheelSlot",
+          "slotNumberStart": 8,
+          "slotNumberEnd": 9
+        },
+        {
+          "dmxRange": [85, 85],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [86, 95],
+          "type": "WheelSlot",
+          "slotNumberStart": 9,
+          "slotNumberEnd": 10
+        },
+        {
+          "dmxRange": [96, 96],
+          "type": "WheelSlot",
+          "slotNumber": 10
+        },
+        {
+          "dmxRange": [97, 105],
+          "type": "WheelSlot",
+          "slotNumberStart": 10,
+          "slotNumberEnd": 11
+        },
+        {
+          "dmxRange": [106, 106],
+          "type": "WheelSlot",
+          "slotNumber": 11
+        },
+        {
+          "dmxRange": [107, 116],
+          "type": "WheelSlot",
+          "slotNumberStart": 11,
+          "slotNumberEnd": 12
+        },
+        {
+          "dmxRange": [117, 117],
+          "type": "WheelSlot",
+          "slotNumber": 12
+        },
+        {
+          "dmxRange": [118, 127],
+          "type": "WheelSlot",
+          "slotNumberStart": 12,
+          "slotNumberEnd": 13
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "WheelRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        }
+      ]
     },
     "Gobo Wheel": {
-      "capability": {
-        "type": "WheelRotation",
-        "speedStart": "slow CW",
-        "speedEnd": "fast CW"
-      }
+      "capabilities": [
+        {
+          "dmxRange": [0, 11],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [12, 23],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [24, 35],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [36, 47],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [48, 59],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [60, 71],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [72, 83],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [84, 95],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [96, 115],
+          "type": "WheelShake",
+          "slotNumber": 2,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [116, 135],
+          "type": "WheelShake",
+          "slotNumber": 3,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [136, 155],
+          "type": "WheelShake",
+          "slotNumber": 4,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [156, 175],
+          "type": "WheelShake",
+          "slotNumber": 5,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [176, 195],
+          "type": "WheelShake",
+          "slotNumber": 6,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [196, 215],
+          "type": "WheelShake",
+          "slotNumber": 7,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [216, 235],
+          "type": "WheelShake",
+          "slotNumber": 8,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [236, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
     },
-    "Gobo Wheel Rotation": {
-      "capability": {
-        "type": "WheelRotation",
-        "speedStart": "slow CW",
-        "speedEnd": "fast CW"
-      }
+    "Gobo Rotation": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
+          "angleStart": "0deg",
+          "angleEnd": "360deg"
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        }
+      ]
     },
-    "Shutter / Strobe": {
-      "capability": {
-        "type": "ShutterStrobe",
-        "shutterEffect": "Open"
-      }
+    "Dimmer / Shutter / Reset": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [1, 63],
+          "type": "Intensity"
+        },
+        {
+          "dmxRange": [64, 95],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [96, 127],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "1Hz",
+          "speedEnd": "10Hz"
+        },
+        {
+          "dmxRange": [128, 139],
+          "type": "Maintenance",
+          "comment": "Reset, shutter closed"
+        },
+        {
+          "dmxRange": [140, 159],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [160, 175],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [176, 191],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse",
+          "speedStart": "fast",
+          "speedEnd": "slow"
+        },
+        {
+          "dmxRange": [192, 223],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
     }
   },
   "modes": [
     {
-      "name": "Pan",
+      "name": "1st",
       "channels": [
-        "Pan 3"
+        "Pan",
+        "Tilt",
+        "Pan fine",
+        "Tilt fine",
+        "Pan/Tilt Speed",
+        "Color Wheel",
+        "Gobo Wheel",
+        "Gobo Rotation",
+        "Dimmer / Shutter / Reset"
       ]
     },
     {
-      "name": "Tilt",
+      "name": "2nd",
       "channels": [
-        "Tilt 2"
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Pan/Tilt Speed",
+        "Color Wheel",
+        "Gobo Wheel",
+        "Gobo Rotation",
+        "Dimmer / Shutter / Reset"
       ]
     },
     {
-      "name": "Speed of PAN/TILT movement",
+      "name": "3rd",
       "channels": [
-        "Pan/Tilt Speed"
+        "Pan",
+        "Tilt",
+        "Pan/Tilt Speed",
+        "Color Wheel",
+        "Gobo Wheel",
+        "Gobo Rotation",
+        "Dimmer / Shutter / Reset"
       ]
     },
     {
-      "name": "Colours",
+      "name": "4th",
       "channels": [
-        "Color Presets"
-      ]
-    },
-    {
-      "name": "Rotating Gobos",
-      "channels": [
-        "Gobo Wheel"
-      ]
-    },
-    {
-      "name": "Rotating Gobo rotation",
-      "channels": [
-        "Gobo Wheel Rotation"
-      ]
-    },
-    {
-      "name": "Shutter,Strobe,Reset",
-      "channels": [
-        "Shutter / Strobe"
+        "Pan",
+        "Tilt",
+        "Color Wheel",
+        "Gobo Wheel",
+        "Gobo Rotation",
+        "Dimmer / Shutter / Reset"
       ]
     }
   ]

--- a/fixtures/robe/spot-160-xt.json
+++ b/fixtures/robe/spot-160-xt.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Spot 160XT",
+  "name": "Spot 160 XT",
   "categories": ["Moving Head"],
   "meta": {
     "authors": ["Ringo333"],

--- a/fixtures/robe/spot-160xt.json
+++ b/fixtures/robe/spot-160xt.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Spot 160XT",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Ringo333"],
+    "createDate": "2019-04-23",
+    "lastModifyDate": "2019-04-23"
+  },
+  "links": {
+    "manual": [
+      "http://www.schellscenic.com/downloads/Spot%20160%20XT.pdf"
+    ],
+    "productPage": [
+      "http://spares.robe.cz/category/78"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=rchX19BOlV0"
+    ]
+  },
+  "physical": {
+    "dimensions": [292, 415, 378],
+    "weight": 10.5,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "colorTemperature": 4200,
+      "lumens": 14000
+    },
+    "lens": {
+      "degreesMinMax": [0, 19]
+    },
+    "focus": {
+      "panMax": 530,
+      "tiltMax": 280
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "530deg"
+      }
+    },
+    "Pan 2": {
+      "name": "Pan",
+      "fineChannelAliases": ["Pan 2 fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "530deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "280deg"
+      }
+    },
+    "Pan 3": {
+      "name": "Pan",
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "530deg"
+      }
+    },
+    "Tilt 2": {
+      "name": "Tilt",
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "280deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "fast"
+      }
+    },
+    "Color Presets": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    },
+    "Gobo Wheel": {
+      "capability": {
+        "type": "WheelRotation",
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Gobo Wheel Rotation": {
+      "capability": {
+        "type": "WheelRotation",
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Pan",
+      "channels": [
+        "Pan 3"
+      ]
+    },
+    {
+      "name": "Tilt",
+      "channels": [
+        "Tilt 2"
+      ]
+    },
+    {
+      "name": "Speed of PAN/TILT movement",
+      "channels": [
+        "Pan/Tilt Speed"
+      ]
+    },
+    {
+      "name": "Colours",
+      "channels": [
+        "Color Presets"
+      ]
+    },
+    {
+      "name": "Rotating Gobos",
+      "channels": [
+        "Gobo Wheel"
+      ]
+    },
+    {
+      "name": "Rotating Gobo rotation",
+      "channels": [
+        "Gobo Wheel Rotation"
+      ]
+    },
+    {
+      "name": "Shutter,Strobe,Reset",
+      "channels": [
+        "Shutter / Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'robe/spot-160xt'

### Fixture warnings / errors

* robe/spot-160xt
  - :x: Capability 'Wheel rotation CW slow…fast' (0…255) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (0…255) in channel 'Gobo Wheel Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel Rotation' (through the channel name) does not exist.
  - :x: Category 'Moving Head' invalid since focus.type is not 'Head'.
  - :warning: Unused channel(s): pan, pan 2, pan 2 fine, tilt, tilt fine
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.
  - :warning: Category 'Scanner' suggested since focus.type is 'Mirror' or there's a Pan(Continuous) and a Tilt(Continuous) capability.


Thank you **Ringo333**!