### PR TITLE
Set fixture download HTTP status code to 200

### DIFF
--- a/main.js
+++ b/main.js
@@ -227,7 +227,7 @@ async function downloadFixtures(response, pluginKey, fixtures, zipName, errorDes
 
     if (files.length === 1) {
       response
-        .status(201)
+        .status(200)
         .attachment(files[0].name)
         .type(files[0].mimetype)
         .send(Buffer.from(files[0].content));
@@ -245,7 +245,7 @@ async function downloadFixtures(response, pluginKey, fixtures, zipName, errorDes
       type: `nodebuffer`,
       compression: `DEFLATE`
     });
-    response.status(201)
+    response.status(200)
       .attachment(`ofl_export_${zipName}.zip`)
       .type(`application/zip`)
       .send(zipBuffer);

--- a/tests/github/exports-valid.js
+++ b/tests/github/exports-valid.js
@@ -245,12 +245,12 @@ async function getTaskPromise(task) {
     testErrored = true;
   }
 
-  return [].concat(
+  return [
     `<details>`,
     `  <summary>${emoji} <strong>${task.manKey} / ${task.fixKey}:</strong> ${task.pluginKey} / ${task.testKey}</summary>`,
     `  <ul>`,
     ...detailListItems.map(listItem => `    <li>${listItem}</li>`),
     `  </ul>`,
     `</details>`
-  );
+  ];
 }

--- a/tests/github/exports-valid.js
+++ b/tests/github/exports-valid.js
@@ -20,6 +20,8 @@ const testFixtures = require(`../test-fixtures.json`).map(
   fixture => [fixture.man, fixture.key]
 );
 
+let testErrored = false;
+
 /**
  * @typedef {object} Task
  * @property {string} manKey
@@ -107,6 +109,11 @@ pullRequest.checkEnv()
       name: `Export files validity`,
       lines
     });
+  })
+  .then(() => {
+    if (testErrored) {
+      throw new Error(`Unable to export some fixtures.`);
+    }
   })
   .catch(error => {
     console.error(error);
@@ -209,34 +216,41 @@ function getTasksForFixtures(changedComponents) {
  * @param {Task} task The export valid task to fulfill.
  * @returns {Promise} A promise resolving with an array of message lines.
  */
-function getTaskPromise(task) {
+async function getTaskPromise(task) {
   const plugin = require(path.join(__dirname, `../../plugins/${task.pluginKey}/export.js`));
   const test = require(path.join(__dirname, `../../plugins/${task.pluginKey}/exportTests/${task.testKey}.js`));
-  let failed = false;
+  let emoji = `:heavy_check_mark:`;
+  const detailListItems = [];
 
-  return plugin.export([fixtureFromRepository(task.manKey, task.fixKey)], {
-    baseDir: path.join(__dirname, `../..`),
-    date: new Date()
-  })
-    .then(files => Promise.all(files.map(
-      file => test(file)
-        .then(() => `    <li>:heavy_check_mark: ${file.name}</li>`)
-        .catch(err => {
-          failed = true;
-          const errors = Array.isArray(err) ? err : [err];
-          return `    <li><details><summary>:x: ${file.name}</summary>${errors.join(`<br />\n`)}</details></li>`;
-        })
-    )))
-    .then(resultLines => {
-      const emoji = failed ? `:x:` : `:heavy_check_mark:`;
-
-      return [].concat(
-        `<details>`,
-        `  <summary>${emoji} <strong>${task.manKey} / ${task.fixKey}:</strong> ${task.pluginKey} / ${task.testKey}</summary>`,
-        `  <ul>`,
-        resultLines,
-        `  </ul>`,
-        `</details>`
-      );
+  try {
+    const files = await plugin.export([fixtureFromRepository(task.manKey, task.fixKey)], {
+      baseDir: path.join(__dirname, `../..`),
+      date: new Date()
     });
+
+    const resultListItems = await Promise.all(files.map(
+      file => test(file)
+        .then(() => `heavy_check_mark: ${file.name}`)
+        .catch(err => {
+          emoji = `:x:`;
+          const errors = Array.isArray(err) ? err : [err];
+          return `<details><summary>:x: ${file.name}</summary>${errors.join(`<br />\n`)}</details>`;
+        })
+    ));
+    detailListItems.push(...resultListItems);
+  }
+  catch (error) {
+    emoji = `:heavy_exclamation_mark:`;
+    detailListItems.push(`Unable to export fixture: ${error.message}`);
+    testErrored = true;
+  }
+
+  return [].concat(
+    `<details>`,
+    `  <summary>${emoji} <strong>${task.manKey} / ${task.fixKey}:</strong> ${task.pluginKey} / ${task.testKey}</summary>`,
+    `  <ul>`,
+    ...detailListItems.map(listItem => `    <li>${listItem}</li>`),
+    `  </ul>`,
+    `</details>`
+  );
 }

--- a/tests/http-status.js
+++ b/tests/http-status.js
@@ -47,7 +47,7 @@ const siteChecker = new blc.SiteChecker({
     `https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+label%3Atype-bug`,
     `https://www.heise.de/embetty`,
 
-    ...exportPluginKeys.map(pluginKey => `${BASE_URL}*${pluginKey}`)
+    ...exportPluginKeys.map(pluginKey => `${BASE_URL}*.${pluginKey}`)
   ]
 }, {
   html(tree, robots, response, pageUrl, customData) {

--- a/tests/http-status.js
+++ b/tests/http-status.js
@@ -74,6 +74,11 @@ const siteChecker = new blc.SiteChecker({
     }
   },
   page(error, pageUrl, customData) {
+    if (!(pageUrl in resolvedUrls)) {
+      resolvedUrls[pageUrl] = pageUrl;
+      foundLinks[pageUrl] = [];
+    }
+
     const resolvedUrl = resolvedUrls[pageUrl];
 
     if (error) {

--- a/tests/http-status.js
+++ b/tests/http-status.js
@@ -4,7 +4,12 @@ const path = require(`path`);
 const chalk = require(`chalk`);
 const childProcess = require(`child_process`);
 const blc = require(`broken-link-checker`);
+
 const pullRequest = require(`./github/pull-request.js`);
+
+const exportPluginKeys = require(`../plugins/plugins.json`).exportPlugins;
+
+const BASE_URL = `http://localhost:5000/`;
 
 // disable certificate errors
 // this is unsafe, but there apparently is no better alternative
@@ -40,7 +45,9 @@ const siteChecker = new blc.SiteChecker({
     // otherwise these would somehow be checked for every fixture, and we can
     // safely assume that these are correct and long-lasting links
     `https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+label%3Atype-bug`,
-    `https://www.heise.de/embetty`
+    `https://www.heise.de/embetty`,
+
+    ...exportPluginKeys.map(pluginKey => `${BASE_URL}*${pluginKey}`)
   ]
 }, {
   html(tree, robots, response, pageUrl, customData) {
@@ -153,5 +160,5 @@ function startLinkChecker(data) {
   console.log(`${data}\nStarting HTTP requests ...\n`);
 
   startTime = new Date();
-  siteChecker.enqueue(`http://localhost:5000/`);
+  siteChecker.enqueue(BASE_URL);
 }


### PR DESCRIPTION
Downloading fixtures did not work in some mobile browsers (AOSP 7.1.2, DuckDuckGo 5.22.1), probably as they use the system's DownloadManager, which doesn't like `201 Created` status code. 

![photo_2019-04-29_11-36-23](https://user-images.githubusercontent.com/7782229/56887907-0dfd5400-6a73-11e9-88ea-a8411c3b6c34.jpg)

> The common use case of this status code is as the result of a POST request. ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201))

So 201 actually wasn't quite correct here.

See also: http://www.digiblog.de/2011/04/android-and-the-download-file-headers/, section "GET, POST, REST  [UPDATE 20120208]"