### PR TITLE
Add fixture 'fun-generation/picowash-40-pixel-quad-led'

### DIFF
--- a/fixtures/fun-generation/picowash-40-pixel-quad-led.json
+++ b/fixtures/fun-generation/picowash-40-pixel-quad-led.json
@@ -4,8 +4,8 @@
   "categories": ["Moving Head", "Color Changer"],
   "meta": {
     "authors": ["Harm Aldick"],
-    "createDate": "2019-05-11",
-    "lastModifyDate": "2019-05-11",
+    "createDate": "2019-05-13",
+    "lastModifyDate": "2019-05-13",
     "importPlugin": {
       "plugin": "qlcplus_4.11.2",
       "date": "2019-05-11",

--- a/fixtures/fun-generation/picowash-40-pixel-quad-led.json
+++ b/fixtures/fun-generation/picowash-40-pixel-quad-led.json
@@ -40,46 +40,32 @@
   "matrix": {},
   "availableChannels": {
     "Pan": {
+      "fineChannelAliases": ["Pan fine"],
       "capability": {
         "type": "Pan",
-        "angleStart": "0%",
-        "angleEnd": "100%",
-        "comment": "Pan (0° - 540°)"
-      }
-    },
-    "Pan (fine)": {
-      "capability": {
-        "type": "Pan",
-        "angleStart": "0%",
-        "angleEnd": "100%"
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
       }
     },
     "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
       "capability": {
         "type": "Tilt",
-        "angleStart": "0%",
-        "angleEnd": "100%",
-        "comment": "Tilt (0° - 180°)"
+        "angleStart": "0deg",
+        "angleEnd": "180deg"
       }
     },
-    "Tilt (fine)": {
+    "Motor Speed": {
+      "defaultValue": 0,
       "capability": {
-        "type": "Tilt",
-        "angleStart": "0%",
-        "angleEnd": "100%"
-      }
-    },
-    "Motor speed": {
-      "capability": {
-        "type": "Speed",
+        "type": "PanTiltSpeed",
         "speedStart": "fast",
         "speedEnd": "slow"
       }
     },
-    "Master dimmer": {
+    "Master Dimmer": {
       "capability": {
-        "type": "Intensity",
-        "comment": "Master dimmer 0 - 100%"
+        "type": "Intensity"
       }
     },
     "Strobe": {
@@ -87,277 +73,343 @@
         {
           "dmxRange": [0, 9],
           "type": "ShutterStrobe",
-          "shutterEffect": "Strobe",
-          "comment": "No function (open)"
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [10, 255],
           "type": "ShutterStrobe",
           "shutterEffect": "Strobe",
           "speedStart": "1Hz",
-          "speedEnd": "25Hz",
-          "comment": "Strobe, slow to fast"
+          "speedEnd": "25Hz"
         }
       ]
     },
     "LED 1 Red": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Red",
-        "comment": "LED 1 - Red - Dimmer 0 - 100%"
+        "color": "Red"
       }
     },
     "LED 1 Green": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Green",
-        "comment": "LED 1 - Green - Dimmer 0 - 100%"
+        "color": "Green"
       }
     },
     "LED 1 Blue": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Blue",
-        "comment": "LED 1 - Blue - Dimmer 0 - 100%"
+        "color": "Blue"
       }
     },
     "LED 1 White": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "White",
-        "comment": "LED 1 - White - Dimmer 0 - 100%"
+        "color": "White"
       }
     },
     "LED 2 Red": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Red",
-        "comment": "LED 2 - Red - Dimmer 0 - 100%"
+        "color": "Red"
       }
     },
     "LED 2 Green": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Green",
-        "comment": "LED 2 - Green - Dimmer 0 - 100%"
+        "color": "Green"
       }
     },
     "LED 2 Blue": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Blue",
-        "comment": "LED 2 - Blue - Dimmer 0 - 100%"
+        "color": "Blue"
       }
     },
     "LED 2 White": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "White",
-        "comment": "LED 2 - White - Dimmer 0 - 100%"
+        "color": "White"
       }
     },
     "LED 3 Red": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Red",
-        "comment": "LED 3 - Red - Dimmer 0 - 100%"
+        "color": "Red"
       }
     },
     "LED 3 Green": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Green",
-        "comment": "LED 3 - Green - Dimmer 0 - 100%"
+        "color": "Green"
       }
     },
     "LED 3 Blue": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Blue",
-        "comment": "LED 3 - Blue - Dimmer 0 - 100%"
+        "color": "Blue"
       }
     },
     "LED 3 White": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "White",
-        "comment": "LED 3 - White - Dimmer 0 - 100%"
+        "color": "White"
       }
     },
     "LED 4 Red": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Red",
-        "comment": "LED 4 - Red - Dimmer 0 - 100%"
+        "color": "Red"
       }
     },
     "LED 4 Green": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Green",
-        "comment": "LED 4 - Green - Dimmer 0 - 100%"
+        "color": "Green"
       }
     },
     "LED 4 Blue": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Blue",
-        "comment": "LED 4 - Blue - Dimmer 0 - 100%"
+        "color": "Blue"
       }
     },
     "LED 4 White": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "White",
-        "comment": "LED 4 - White - Dimmer 0 - 100%"
+        "color": "White"
       }
     },
     "Function": {
+      "defaultValue": 0,
       "capabilities": [
         {
           "dmxRange": [0, 49],
-          "type": "NoFunction"
+          "type": "NoFunction",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [50, 59],
-          "type": "Effect",
-          "effectName": "Red"
+          "type": "ColorPreset",
+          "comment": "Red",
+          "colors": ["#ff0000"],
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [60, 69],
-          "type": "Effect",
-          "effectName": "Green"
+          "type": "ColorPreset",
+          "comment": "Green",
+          "colors": ["#00ff00"],
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [70, 79],
-          "type": "Effect",
-          "effectName": "Blue"
+          "type": "ColorPreset",
+          "comment": "Blue",
+          "colors": ["#0000ff"],
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [80, 89],
-          "type": "Effect",
-          "effectName": "White"
+          "type": "ColorPreset",
+          "comment": "White",
+          "colors": ["#ffffff"],
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [90, 99],
-          "type": "Effect",
-          "effectName": "Yellow"
+          "type": "ColorPreset",
+          "comment": "Yellow",
+          "colors": ["#ffff00"],
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [100, 109],
-          "type": "Effect",
-          "effectName": "Cyan"
+          "type": "ColorPreset",
+          "comment": "Cyan",
+          "colors": ["#00ffff"],
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [110, 119],
-          "type": "Effect",
-          "effectName": "Purple"
+          "type": "ColorPreset",
+          "comment": "Purple",
+          "colors": ["#ff00ff"],
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [120, 129],
-          "type": "Effect",
-          "effectName": "All White"
+          "type": "ColorPreset",
+          "comment": "All White",
+          "colors": ["#ffffff"],
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [130, 139],
-          "type": "NoFunction"
+          "type": "NoFunction",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [140, 149],
           "type": "Effect",
-          "effectName": "Programme 1"
+          "effectName": "Program 1",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [150, 159],
           "type": "Effect",
-          "effectName": "Programme 2"
+          "effectName": "Program 2",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [160, 169],
           "type": "Effect",
-          "effectName": "Programme 3"
+          "effectName": "Program 3",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [170, 179],
           "type": "Effect",
-          "effectName": "Programme 4"
+          "effectName": "Program 4",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [180, 189],
           "type": "Effect",
-          "effectName": "Programme 5"
+          "effectName": "Program 5",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [190, 199],
           "type": "Effect",
-          "effectName": "Programme 6"
+          "effectName": "Program 6",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [200, 209],
           "type": "Effect",
-          "effectName": "Programme 7"
+          "effectName": "Program 7",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [210, 219],
           "type": "Effect",
-          "effectName": "Programme 8"
+          "effectName": "Program 8",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [220, 229],
           "type": "Effect",
-          "effectName": "Programme 9"
+          "effectName": "Program 9",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [230, 233],
-          "type": "NoFunction"
+          "type": "NoFunction",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [234, 236],
-          "type": "Effect",
-          "effectName": "Reset"
+          "type": "Maintenance",
+          "comment": "Reset",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [237, 249],
-          "type": "NoFunction"
+          "type": "NoFunction",
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Program Speed"
+          }
         },
         {
           "dmxRange": [250, 255],
           "type": "Effect",
-          "effectName": "Sound-controlled mode"
+          "effectName": "Sound-controlled mode",
+          "soundControlled": true,
+          "switchChannels": {
+            "Program Speed / Sound Sensitivity": "Sound Sensitivity"
+          }
         }
       ]
     },
-    "Speed / Sensitivity": {
+    "Program Speed": {
       "capability": {
-        "type": "Speed"
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Sound Sensitivity": {
+      "capability": {
+        "type": "SoundSensitivity",
+        "soundSensitivityStart": "low",
+        "soundSensitivityEnd": "high"
       }
     },
     "Red": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Red",
-        "comment": "Red - Dimmer 0 - 100%"
+        "color": "Red"
       }
     },
     "Green": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Green",
-        "comment": "Green - Dimmer 0 - 100%"
+        "color": "Green"
       }
     },
     "Blue": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "Blue",
-        "comment": "Blue - Dimmer 0 - 100%"
+        "color": "Blue"
       }
     },
     "White": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "White",
-        "comment": "White - Dimmer 0 - 100%"
+        "color": "White"
       }
     }
   },
@@ -368,49 +420,49 @@
       "channels": [
         "Pan",
         "Tilt",
-        "Master dimmer"
+        "Master Dimmer"
       ]
     },
     {
       "name": "8 Channel",
       "channels": [
         "Pan",
-        "Pan (fine)",
+        "Pan fine",
         "Tilt",
-        "Tilt (fine)",
-        "Motor speed",
-        "Master dimmer",
+        "Tilt fine",
+        "Motor Speed",
+        "Master Dimmer",
         "Function",
-        "Speed / Sensitivity"
+        "Program Speed / Sound Sensitivity"
       ]
     },
     {
       "name": "13 Channel",
       "channels": [
         "Pan",
-        "Pan (fine)",
+        "Pan fine",
         "Tilt",
-        "Tilt (fine)",
-        "Motor speed",
-        "Master dimmer",
+        "Tilt fine",
+        "Motor Speed",
+        "Master Dimmer",
         "Strobe",
         "Red",
         "Green",
         "Blue",
         "White",
         "Function",
-        "Speed / Sensitivity"
+        "Program Speed / Sound Sensitivity"
       ]
     },
     {
       "name": "25 Channel",
       "channels": [
         "Pan",
-        "Pan (fine)",
+        "Pan fine",
         "Tilt",
-        "Tilt (fine)",
-        "Motor speed",
-        "Master dimmer",
+        "Tilt fine",
+        "Motor Speed",
+        "Master Dimmer",
         "Strobe",
         "LED 1 Red",
         "LED 1 Green",
@@ -429,7 +481,7 @@
         "LED 4 Blue",
         "LED 4 White",
         "Function",
-        "Speed / Sensitivity"
+        "Program Speed / Sound Sensitivity"
       ]
     }
   ]

--- a/fixtures/fun-generation/picowash-40-pixel-quad-led.json
+++ b/fixtures/fun-generation/picowash-40-pixel-quad-led.json
@@ -37,7 +37,17 @@
       "tiltMax": 180
     }
   },
-  "matrix": {},
+  "matrix": {
+    "pixelKeys": [
+      [
+        ["LED 1", "LED 2"],
+        ["LED 3", "LED 4"]
+      ]
+    ],
+    "pixelGroups": {
+      "Master": "all"
+    }
+  },
   "availableChannels": {
     "Pan": {
       "fineChannelAliases": ["Pan fine"],
@@ -83,102 +93,6 @@
           "speedEnd": "25Hz"
         }
       ]
-    },
-    "LED 1 Red": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Red"
-      }
-    },
-    "LED 1 Green": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Green"
-      }
-    },
-    "LED 1 Blue": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Blue"
-      }
-    },
-    "LED 1 White": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "White"
-      }
-    },
-    "LED 2 Red": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Red"
-      }
-    },
-    "LED 2 Green": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Green"
-      }
-    },
-    "LED 2 Blue": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Blue"
-      }
-    },
-    "LED 2 White": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "White"
-      }
-    },
-    "LED 3 Red": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Red"
-      }
-    },
-    "LED 3 Green": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Green"
-      }
-    },
-    "LED 3 Blue": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Blue"
-      }
-    },
-    "LED 3 White": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "White"
-      }
-    },
-    "LED 4 Red": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Red"
-      }
-    },
-    "LED 4 Green": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Green"
-      }
-    },
-    "LED 4 Blue": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Blue"
-      }
-    },
-    "LED 4 White": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "White"
-      }
     },
     "Function": {
       "defaultValue": 0,
@@ -387,33 +301,34 @@
         "soundSensitivityStart": "low",
         "soundSensitivityEnd": "high"
       }
-    },
-    "Red": {
+    }
+  },
+  "templateChannels": {
+    "Red $pixelKey": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Red"
       }
     },
-    "Green": {
+    "Green $pixelKey": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Green"
       }
     },
-    "Blue": {
+    "Blue $pixelKey": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Blue"
       }
     },
-    "White": {
+    "White $pixelKey": {
       "capability": {
         "type": "ColorIntensity",
         "color": "White"
       }
     }
   },
-  "templateChannels": {},
   "modes": [
     {
       "name": "3 Channel",
@@ -446,10 +361,10 @@
         "Motor Speed",
         "Master Dimmer",
         "Strobe",
-        "Red",
-        "Green",
-        "Blue",
-        "White",
+        "Red Master",
+        "Green Master",
+        "Blue Master",
+        "White Master",
         "Function",
         "Program Speed / Sound Sensitivity"
       ]
@@ -464,22 +379,22 @@
         "Motor Speed",
         "Master Dimmer",
         "Strobe",
-        "LED 1 Red",
-        "LED 1 Green",
-        "LED 1 Blue",
-        "LED 1 White",
-        "LED 2 Red",
-        "LED 2 Green",
-        "LED 2 Blue",
-        "LED 2 White",
-        "LED 3 Red",
-        "LED 3 Green",
-        "LED 3 Blue",
-        "LED 3 White",
-        "LED 4 Red",
-        "LED 4 Green",
-        "LED 4 Blue",
-        "LED 4 White",
+        "Red LED 1",
+        "Green LED 1",
+        "Blue LED 1",
+        "White LED 1",
+        "Red LED 2",
+        "Green LED 2",
+        "Blue LED 2",
+        "White LED 2",
+        "Red LED 3",
+        "Green LED 3",
+        "Blue LED 3",
+        "White LED 3",
+        "Red LED 4",
+        "Green LED 4",
+        "Blue LED 4",
+        "White LED 4",
         "Function",
         "Program Speed / Sound Sensitivity"
       ]

--- a/fixtures/fun-generation/picowash-40-pixel-quad-led.json
+++ b/fixtures/fun-generation/picowash-40-pixel-quad-led.json
@@ -331,7 +331,8 @@
   },
   "modes": [
     {
-      "name": "3 Channel",
+      "name": "3-channel",
+      "shortName": "3ch",
       "channels": [
         "Pan",
         "Tilt",
@@ -339,7 +340,8 @@
       ]
     },
     {
-      "name": "8 Channel",
+      "name": "8-channel",
+      "shortName": "8ch",
       "channels": [
         "Pan",
         "Pan fine",
@@ -352,7 +354,8 @@
       ]
     },
     {
-      "name": "13 Channel",
+      "name": "13-channel",
+      "shortName": "13ch",
       "channels": [
         "Pan",
         "Pan fine",
@@ -370,7 +373,8 @@
       ]
     },
     {
-      "name": "25 Channel",
+      "name": "25-channel",
+      "shortName": "25ch",
       "channels": [
         "Pan",
         "Pan fine",

--- a/fixtures/fun-generation/picowash-40-pixel-quad-led.json
+++ b/fixtures/fun-generation/picowash-40-pixel-quad-led.json
@@ -1,0 +1,429 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "PicoWash 40 Pixel Quad LED",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Harm Aldick"],
+    "createDate": "2019-05-11",
+    "lastModifyDate": "2019-05-11",
+    "importPlugin": {
+      "plugin": "qlcplus_4.11.2",
+      "date": "2019-05-11",
+      "comment": "created by Q Light Controller Plus (version 4.11.2 GIT)"
+    }
+  },
+  "physical": {
+    "dimensions": [162, 228, 174],
+    "weight": 2.8,
+    "power": 55,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "name": "Other",
+      "degreesMinMax": [28, 28]
+    },
+    "focus": {
+      "type": "Fixed",
+      "panMax": 540,
+      "tiltMax": 180
+    }
+  },
+  "matrix": {},
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0%",
+        "angleEnd": "100%",
+        "comment": "Pan (0° - 540°)"
+      }
+    },
+    "Pan (fine)": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0%",
+        "angleEnd": "100%"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0%",
+        "angleEnd": "100%",
+        "comment": "Tilt (0° - 180°)"
+      }
+    },
+    "Tilt (fine)": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0%",
+        "angleEnd": "100%"
+      }
+    },
+    "Motor speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Master dimmer": {
+      "capability": {
+        "type": "Intensity",
+        "comment": "Master dimmer 0 - 100%"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "No function (open)"
+        },
+        {
+          "dmxRange": [10, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "1Hz",
+          "speedEnd": "25Hz",
+          "comment": "Strobe, slow to fast"
+        }
+      ]
+    },
+    "LED 1 Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "comment": "LED 1 - Red - Dimmer 0 - 100%"
+      }
+    },
+    "LED 1 Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green",
+        "comment": "LED 1 - Green - Dimmer 0 - 100%"
+      }
+    },
+    "LED 1 Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue",
+        "comment": "LED 1 - Blue - Dimmer 0 - 100%"
+      }
+    },
+    "LED 1 White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White",
+        "comment": "LED 1 - White - Dimmer 0 - 100%"
+      }
+    },
+    "LED 2 Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "comment": "LED 2 - Red - Dimmer 0 - 100%"
+      }
+    },
+    "LED 2 Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green",
+        "comment": "LED 2 - Green - Dimmer 0 - 100%"
+      }
+    },
+    "LED 2 Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue",
+        "comment": "LED 2 - Blue - Dimmer 0 - 100%"
+      }
+    },
+    "LED 2 White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White",
+        "comment": "LED 2 - White - Dimmer 0 - 100%"
+      }
+    },
+    "LED 3 Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "comment": "LED 3 - Red - Dimmer 0 - 100%"
+      }
+    },
+    "LED 3 Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green",
+        "comment": "LED 3 - Green - Dimmer 0 - 100%"
+      }
+    },
+    "LED 3 Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue",
+        "comment": "LED 3 - Blue - Dimmer 0 - 100%"
+      }
+    },
+    "LED 3 White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White",
+        "comment": "LED 3 - White - Dimmer 0 - 100%"
+      }
+    },
+    "LED 4 Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "comment": "LED 4 - Red - Dimmer 0 - 100%"
+      }
+    },
+    "LED 4 Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green",
+        "comment": "LED 4 - Green - Dimmer 0 - 100%"
+      }
+    },
+    "LED 4 Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue",
+        "comment": "LED 4 - Blue - Dimmer 0 - 100%"
+      }
+    },
+    "LED 4 White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White",
+        "comment": "LED 4 - White - Dimmer 0 - 100%"
+      }
+    },
+    "Function": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 49],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [50, 59],
+          "type": "Effect",
+          "effectName": "Red"
+        },
+        {
+          "dmxRange": [60, 69],
+          "type": "Effect",
+          "effectName": "Green"
+        },
+        {
+          "dmxRange": [70, 79],
+          "type": "Effect",
+          "effectName": "Blue"
+        },
+        {
+          "dmxRange": [80, 89],
+          "type": "Effect",
+          "effectName": "White"
+        },
+        {
+          "dmxRange": [90, 99],
+          "type": "Effect",
+          "effectName": "Yellow"
+        },
+        {
+          "dmxRange": [100, 109],
+          "type": "Effect",
+          "effectName": "Cyan"
+        },
+        {
+          "dmxRange": [110, 119],
+          "type": "Effect",
+          "effectName": "Purple"
+        },
+        {
+          "dmxRange": [120, 129],
+          "type": "Effect",
+          "effectName": "All White"
+        },
+        {
+          "dmxRange": [130, 139],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [140, 149],
+          "type": "Effect",
+          "effectName": "Programme 1"
+        },
+        {
+          "dmxRange": [150, 159],
+          "type": "Effect",
+          "effectName": "Programme 2"
+        },
+        {
+          "dmxRange": [160, 169],
+          "type": "Effect",
+          "effectName": "Programme 3"
+        },
+        {
+          "dmxRange": [170, 179],
+          "type": "Effect",
+          "effectName": "Programme 4"
+        },
+        {
+          "dmxRange": [180, 189],
+          "type": "Effect",
+          "effectName": "Programme 5"
+        },
+        {
+          "dmxRange": [190, 199],
+          "type": "Effect",
+          "effectName": "Programme 6"
+        },
+        {
+          "dmxRange": [200, 209],
+          "type": "Effect",
+          "effectName": "Programme 7"
+        },
+        {
+          "dmxRange": [210, 219],
+          "type": "Effect",
+          "effectName": "Programme 8"
+        },
+        {
+          "dmxRange": [220, 229],
+          "type": "Effect",
+          "effectName": "Programme 9"
+        },
+        {
+          "dmxRange": [230, 233],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [234, 236],
+          "type": "Effect",
+          "effectName": "Reset"
+        },
+        {
+          "dmxRange": [237, 249],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "Effect",
+          "effectName": "Sound-controlled mode"
+        }
+      ]
+    },
+    "Speed / Sensitivity": {
+      "capability": {
+        "type": "Speed"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "comment": "Red - Dimmer 0 - 100%"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green",
+        "comment": "Green - Dimmer 0 - 100%"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue",
+        "comment": "Blue - Dimmer 0 - 100%"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White",
+        "comment": "White - Dimmer 0 - 100%"
+      }
+    }
+  },
+  "templateChannels": {},
+  "modes": [
+    {
+      "name": "3 Channel",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Master dimmer"
+      ]
+    },
+    {
+      "name": "8 Channel",
+      "channels": [
+        "Pan",
+        "Pan (fine)",
+        "Tilt",
+        "Tilt (fine)",
+        "Motor speed",
+        "Master dimmer",
+        "Function",
+        "Speed / Sensitivity"
+      ]
+    },
+    {
+      "name": "13 Channel",
+      "channels": [
+        "Pan",
+        "Pan (fine)",
+        "Tilt",
+        "Tilt (fine)",
+        "Motor speed",
+        "Master dimmer",
+        "Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Function",
+        "Speed / Sensitivity"
+      ]
+    },
+    {
+      "name": "25 Channel",
+      "channels": [
+        "Pan",
+        "Pan (fine)",
+        "Tilt",
+        "Tilt (fine)",
+        "Motor speed",
+        "Master dimmer",
+        "Strobe",
+        "LED 1 Red",
+        "LED 1 Green",
+        "LED 1 Blue",
+        "LED 1 White",
+        "LED 2 Red",
+        "LED 2 Green",
+        "LED 2 Blue",
+        "LED 2 White",
+        "LED 3 Red",
+        "LED 3 Green",
+        "LED 3 Blue",
+        "LED 3 White",
+        "LED 4 Red",
+        "LED 4 Green",
+        "LED 4 Blue",
+        "LED 4 White",
+        "Function",
+        "Speed / Sensitivity"
+      ]
+    }
+  ]
+}

--- a/fixtures/fun-generation/picowash-40-pixel-quad-led.json
+++ b/fixtures/fun-generation/picowash-40-pixel-quad-led.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "PicoWash 40 Pixel Quad LED",
-  "categories": ["Moving Head"],
+  "categories": ["Moving Head", "Color Changer"],
   "meta": {
     "authors": ["Harm Aldick"],
     "createDate": "2019-05-11",
@@ -12,20 +12,27 @@
       "comment": "created by Q Light Controller Plus (version 4.11.2 GIT)"
     }
   },
+  "links": {
+    "manual": [
+      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/372705_c_372705_v2_r1_en_online.pdf"
+    ],
+    "productPage": [
+      "https://www.thomann.de/intl/fun_generation_picowash_40_pixel_quad_led.htm"
+    ]
+  },
   "physical": {
     "dimensions": [162, 228, 174],
     "weight": 2.8,
     "power": 55,
     "DMXconnector": "3-pin",
     "bulb": {
-      "type": "LED"
+      "type": "4x 10W RGBW LEDs"
     },
     "lens": {
-      "name": "Other",
       "degreesMinMax": [28, 28]
     },
     "focus": {
-      "type": "Fixed",
+      "type": "Head",
       "panMax": 540,
       "tiltMax": 180
     }


### PR DESCRIPTION
* Add fixture 'fun-generation/picowash-40-pixel-quad-led'

### Fixture warnings / errors

* fun-generation/picowash-40-pixel-quad-led
  - :x: File does not match schema. [ { keyword: 'required',
    dataPath: '.matrix',
    schemaPath: '#/properties/matrix/oneOf/0/required',
    params: { missingProperty: '.pixelCount' },
    message: 'should have required property \'.pixelCount\'' },
  { keyword: 'required',
    dataPath: '.matrix',
    schemaPath: '#/properties/matrix/oneOf/1/required',
    params: { missingProperty: '.pixelKeys' },
    message: 'should have required property \'.pixelKeys\'' },
  { keyword: 'oneOf',
    dataPath: '.matrix',
    schemaPath: '#/properties/matrix/oneOf',
    params: { passingSchemas: null },
    message: 'should match exactly one schema in oneOf' },
  [length]: 3 ]
  - :warning: Please check if manufacturer is correct.
  - :warning: Please check 16bit channel 'Pan (fine)': The corresponding coarse channel could not be detected.
  - :warning: Please check 16bit channel 'Tilt (fine)': The corresponding coarse channel could not be detected.
  - :warning: Please add 25 Channel mode's Head #1 to the fixture's matrix. The included channels were LED 1 Red, LED 1 Green, LED 1 Blue, LED 1 White.
  - :warning: Please add 25 Channel mode's Head #2 to the fixture's matrix. The included channels were LED 2 Red, LED 2 Green, LED 2 Blue, LED 2 White.
  - :warning: Please add 25 Channel mode's Head #3 to the fixture's matrix. The included channels were LED 3 Red, LED 3 Green, LED 3 Blue, LED 3 White.
  - :warning: Please add 25 Channel mode's Head #4 to the fixture's matrix. The included channels were LED 4 Red, LED 4 Green, LED 4 Blue, LED 4 White.


### User comment

As delivered with QLC 4.11.2
Author info from their changelog

Thank you **Harm Aldick**!