### PR TITLE
Use "format" in JSON schemas

### DIFF
--- a/lib/schema-properties.mjs
+++ b/lib/schema-properties.mjs
@@ -10,7 +10,7 @@ const physicalProperties = fixtureProperties.physical.properties;
 
 const capabilityTypes = {};
 capabilitySchema.allOf.forEach(ifThenClause => {
-  const type = ifThenClause[`if`].properties.type.enum[0];
+  const type = ifThenClause[`if`].properties.type.const;
   capabilityTypes[type] = ifThenClause.then;
 });
 

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -53,6 +53,7 @@ async function getSchemas() {
 
   // allow changed schema property
   fixtureSchema.patternProperties[`^\\$schema$`].const = `${SCHEMA_BASE_URL}fixture.json`;
+  fixtureSchema.patternProperties[`^\\$schema$`].enum = undefined;
 
   // allow new colors from schema version 11.1.0
   // see https://github.com/OpenLightingProject/open-fixture-library/pull/763

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -18,7 +18,13 @@ const schemaPromises = getSchemas();
 **/
 module.exports = async function testSchemaConformity(exportFile) {
   const schemas = await schemaPromises;
-  const ajv = new Ajv({ schemas });
+  const ajv = new Ajv({
+    schemas,
+    format: `full`,
+    formats: {
+      'color-hex': ``
+    }
+  });
   const schemaValidate = ajv.getSchema(`https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json`);
 
   const schemaValid = schemaValidate(JSON.parse(exportFile.content));

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -52,7 +52,7 @@ async function getSchemas() {
   fixtureSchema.properties.oflURL = true;
 
   // allow changed schema property
-  fixtureSchema.patternProperties[`^\\$schema$`].enum[0] = `${SCHEMA_BASE_URL}fixture.json`;
+  fixtureSchema.patternProperties[`^\\$schema$`].const = `${SCHEMA_BASE_URL}fixture.json`;
 
   // allow new colors from schema version 11.1.0
   // see https://github.com/OpenLightingProject/open-fixture-library/pull/763

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -40,7 +40,7 @@
     },
     "ofl": {
       "name": "Open Fixture Library JSON",
-      "exportPluginVersion": "11.3.0",
+      "exportPluginVersion": "11.3.1",
       "exportTests": []
     },
     "op-z": {

--- a/schemas/capability.json
+++ b/schemas/capability.json
@@ -88,7 +88,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["NoFunction"] }
+          "type": { "const": "NoFunction" }
         }
       },
       "then": {
@@ -106,7 +106,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["ShutterStrobe"] }
+          "type": { "const": "ShutterStrobe" }
         }
       },
       "then": {
@@ -156,7 +156,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["StrobeSpeed"] }
+          "type": { "const": "StrobeSpeed" }
         }
       },
       "then": {
@@ -185,7 +185,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["StrobeDuration"] }
+          "type": { "const": "StrobeDuration" }
         }
       },
       "then": {
@@ -214,7 +214,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Intensity"] }
+          "type": { "const": "Intensity" }
         }
       },
       "then": {
@@ -240,7 +240,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["ColorIntensity"] }
+          "type": { "const": "ColorIntensity" }
         }
       },
       "then": {
@@ -284,7 +284,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["ColorPreset"] }
+          "type": { "const": "ColorPreset" }
         }
       },
       "then": {
@@ -332,7 +332,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["ColorTemperature"] }
+          "type": { "const": "ColorTemperature" }
         }
       },
       "then": {
@@ -361,7 +361,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Pan"] }
+          "type": { "const": "Pan" }
         }
       },
       "then": {
@@ -390,7 +390,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["PanContinuous"] }
+          "type": { "const": "PanContinuous" }
         }
       },
       "then": {
@@ -419,7 +419,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Tilt"] }
+          "type": { "const": "Tilt" }
         }
       },
       "then": {
@@ -448,7 +448,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["TiltContinuous"] }
+          "type": { "const": "TiltContinuous" }
         }
       },
       "then": {
@@ -477,7 +477,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["PanTiltSpeed"] }
+          "type": { "const": "PanTiltSpeed" }
         }
       },
       "then": {
@@ -513,7 +513,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["WheelSlot"] }
+          "type": { "const": "WheelSlot" }
         }
       },
       "then": {
@@ -543,7 +543,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["WheelShake"] }
+          "type": { "const": "WheelShake" }
         }
       },
       "then": {
@@ -618,7 +618,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["WheelSlotRotation"] }
+          "type": { "const": "WheelSlotRotation" }
         }
       },
       "then": {
@@ -690,7 +690,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["WheelRotation"] }
+          "type": { "const": "WheelRotation" }
         }
       },
       "then": {
@@ -737,7 +737,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Effect"] }
+          "type": { "const": "Effect" }
         }
       },
       "then": {
@@ -792,7 +792,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["EffectSpeed"] }
+          "type": { "const": "EffectSpeed" }
         }
       },
       "then": {
@@ -821,7 +821,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["EffectDuration"] }
+          "type": { "const": "EffectDuration" }
         }
       },
       "then": {
@@ -850,7 +850,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["EffectParameter"] }
+          "type": { "const": "EffectParameter" }
         }
       },
       "then": {
@@ -879,7 +879,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["SoundSensitivity"] }
+          "type": { "const": "SoundSensitivity" }
         }
       },
       "then": {
@@ -908,7 +908,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Focus"] }
+          "type": { "const": "Focus" }
         }
       },
       "then": {
@@ -937,7 +937,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Zoom"] }
+          "type": { "const": "Zoom" }
         }
       },
       "then": {
@@ -966,7 +966,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Iris"] }
+          "type": { "const": "Iris" }
         }
       },
       "then": {
@@ -995,7 +995,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["IrisEffect"] }
+          "type": { "const": "IrisEffect" }
         }
       },
       "then": {
@@ -1023,7 +1023,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Frost"] }
+          "type": { "const": "Frost" }
         }
       },
       "then": {
@@ -1052,7 +1052,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["FrostEffect"] }
+          "type": { "const": "FrostEffect" }
         }
       },
       "then": {
@@ -1080,7 +1080,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Prism"] }
+          "type": { "const": "Prism" }
         }
       },
       "then": {
@@ -1120,7 +1120,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["PrismRotation"] }
+          "type": { "const": "PrismRotation" }
         }
       },
       "then": {
@@ -1156,7 +1156,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["BladeInsertion"] }
+          "type": { "const": "BladeInsertion" }
         }
       },
       "then": {
@@ -1190,7 +1190,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["BladeRotation"] }
+          "type": { "const": "BladeRotation" }
         }
       },
       "then": {
@@ -1224,7 +1224,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["BladeSystemRotation"] }
+          "type": { "const": "BladeSystemRotation" }
         }
       },
       "then": {
@@ -1253,7 +1253,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Fog"] }
+          "type": { "const": "Fog" }
         }
       },
       "then": {
@@ -1280,7 +1280,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["FogOutput"] }
+          "type": { "const": "FogOutput" }
         }
       },
       "then": {
@@ -1309,7 +1309,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["FogType"] }
+          "type": { "const": "FogType" }
         }
       },
       "then": {
@@ -1329,7 +1329,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["BeamAngle"] }
+          "type": { "const": "BeamAngle" }
         }
       },
       "then": {
@@ -1358,7 +1358,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Rotation"] }
+          "type": { "const": "Rotation" }
         }
       },
       "then": {
@@ -1394,7 +1394,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Speed"] }
+          "type": { "const": "Speed" }
         }
       },
       "then": {
@@ -1423,7 +1423,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Time"] }
+          "type": { "const": "Time" }
         }
       },
       "then": {
@@ -1452,7 +1452,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Maintenance"] }
+          "type": { "const": "Maintenance" }
         }
       },
       "then": {
@@ -1479,7 +1479,7 @@
     {
       "if": {
         "properties": {
-          "type": { "enum": ["Generic"] }
+          "type": { "const": "Generic" }
         }
       },
       "then": {

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -28,7 +28,8 @@
   },
   "urlString": {
     "type": "string",
-    "pattern": "^(ftp|http|https)://[^ \"]+$"
+    "pattern": "^(ftp|http|https)://[^ \"]+$",
+    "format": "uri"
   },
   "urlArray": {
     "type": "array",
@@ -38,7 +39,8 @@
   },
   "isoDateString": {
     "type": "string",
-    "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+    "format": "date"
   },
   "colorString": {
     "type": "string",

--- a/schemas/fixture-redirect.json
+++ b/schemas/fixture-redirect.json
@@ -23,7 +23,7 @@
   },
   "patternProperties": {
     "^\\$schema$": {
-      "enum": ["https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture-redirect.json"]
+      "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture-redirect.json"
     }
   },
   "additionalProperties": false

--- a/schemas/fixture-redirect.json
+++ b/schemas/fixture-redirect.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture-redirect.json",
 
-  "version": "11.3.0",
+  "version": "11.3.1",
 
   "type": "object",
   "properties": {

--- a/schemas/fixture.json
+++ b/schemas/fixture.json
@@ -186,7 +186,7 @@
                   "type": "number",
                   "minimum": 0
                 },
-                { "enum": ["infinite"] }
+                { "const": "infinite" }
               ]
             },
             "tiltMax": {
@@ -196,7 +196,7 @@
                   "type": "number",
                   "minimum": 0
                 },
-                { "enum": ["infinite"] }
+                { "const": "infinite" }
               ]
             }
           },
@@ -283,7 +283,7 @@
                   "$comment": "matrix channel insert block",
                   "type": "object",
                   "properties": {
-                    "insert": { "enum": ["matrixChannels"] },
+                    "insert": { "const": "matrixChannels" },
                     "repeatFor": {
                       "oneOf": [
                         {
@@ -362,7 +362,7 @@
   ],
   "patternProperties": {
     "^\\$schema$": {
-      "enum": ["https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json"]
+      "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json"
     }
   },
   "additionalProperties": false

--- a/schemas/fixture.json
+++ b/schemas/fixture.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
 
-  "version": "11.3.0",
+  "version": "11.3.1",
 
   "type": "object",
   "properties": {

--- a/schemas/manufacturers.json
+++ b/schemas/manufacturers.json
@@ -37,7 +37,7 @@
   "required": ["$schema"],
   "patternProperties": {
     "^\\$schema$": {
-      "enum": ["https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/manufacturers.json"]
+      "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/manufacturers.json"
     }
   }
 }

--- a/schemas/manufacturers.json
+++ b/schemas/manufacturers.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/manufacturers.json",
 
-  "version": "11.3.0",
+  "version": "11.3.1",
 
   "type": "object",
   "propertyNames": {

--- a/schemas/matrix.json
+++ b/schemas/matrix.json
@@ -111,7 +111,8 @@
                 "items": {
                   "$comment": "pattern that pixel keys should match",
                   "type": "string",
-                  "minLength": 1
+                  "minLength": 1,
+                  "format": "regex"
                 }
               }
             }

--- a/schemas/plugin.json
+++ b/schemas/plugin.json
@@ -12,7 +12,8 @@
     },
     "urlString": {
       "type": "string",
-      "pattern": "^(ftp|http|https)://[^ \"]+$"
+      "pattern": "^(ftp|http|https)://[^ \"]+$",
+      "format": "uri"
     },
     "fileLocations": {
       "type": "object",

--- a/tests/fixture-valid.js
+++ b/tests/fixture-valid.js
@@ -17,8 +17,12 @@ const {
   SwitchingChannel
 } = require(`../lib/model.js`);
 
-const ajv = new Ajv();
-ajv.addFormat(`color-hex`, ``); // do not crash when `format: color-hex` is used; actual validation is done with an additional pattern, the format is only added for VSCode's color preview
+const ajv = new Ajv({
+  format: `full`,
+  formats: {
+    'color-hex': ``
+  }
+});
 const schemaValidate = ajv.compile(fixtureSchema);
 const redirectSchemaValidate = ajv.compile(fixtureRedirectSchema);
 

--- a/tests/fixture-valid.js
+++ b/tests/fixture-valid.js
@@ -251,13 +251,6 @@ function checkFixture(manKey, fixKey, fixtureJson, uniqueValues = null) {
     function checkPixelGroups() {
       const pixelGroupKeys = Object.keys(matrix.jsonObject.pixelGroups);
 
-      const constraintsCorrect = pixelGroupKeys.every(checkPixelKeyStringConstraints);
-
-      if (!constraintsCorrect) {
-        // don't let model fail
-        return;
-      }
-
       pixelGroupKeys.forEach(pixelGroupKey => {
         const usedMatrixChannels = new Set();
 
@@ -280,32 +273,6 @@ function checkFixture(manKey, fixKey, fixtureJson, uniqueValues = null) {
           usedMatrixChannels.add(pixelKey);
         }
       });
-
-
-      /**
-       * Checks the pixel group's string constraints.
-       * @param {string} pixelGroupKey The key of the pixel group to check.
-       * @returns {boolean} True if all constraints are valid RegExps, false otherwise.
-       */
-      function checkPixelKeyStringConstraints(pixelGroupKey) {
-        const group = matrix.jsonObject.pixelGroups[pixelGroupKey];
-
-        if (group === `all` || Array.isArray(group)) {
-          return true;
-        }
-
-        for (const pattern of (group.name || [])) {
-          try {
-            new RegExp(pattern);
-          }
-          catch (syntaxError) {
-            result.errors.push(`Pixel key constraint '${pattern}' in pixelGroup '${pixelGroupKey}' is not a valid RegExp pattern. ${syntaxError.message}`);
-            return false;
-          }
-        }
-
-        return true;
-      }
     }
   }
 

--- a/tests/http-status.js
+++ b/tests/http-status.js
@@ -42,6 +42,9 @@ const siteChecker = new blc.SiteChecker({
     // form targets are not meant to be called without parameters / with GET instead of POST
     `http://localhost:5000/ajax/*`,
 
+    // large fixtures shouldn't be tested twice
+    `*?loadAllModes`,
+
     // otherwise these would somehow be checked for every fixture, and we can
     // safely assume that these are correct and long-lasting links
     `https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+label%3Atype-bug`,


### PR DESCRIPTION
Advantages:

* Simplify fixture-valid test a bit
* More declarative (and possibly restrictive) checks

Other fixes:

* Use `"const": "x"` instead of `"enum": ["x"]`
* Fix large fixtures being tested twice in HTTP status test