### PR TITLE
Revert "Explicitly upgrade esm to version 3.2.25"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5064,9 +5064,9 @@
       "dev": true
     },
     "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+      "version": "3.2.22",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.22.tgz",
+      "integrity": "sha512-z8YG7U44L82j1XrdEJcqZOLUnjxco8pO453gKOlaMD1/md1n/5QrscAmYG+oKUspsmDLuBFZrpbxI6aQ67yRxA=="
     },
     "espree": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compression": "^1.7.3",
     "details-polyfill": "^1.1.0",
     "embetty-vue": "^0.5.0",
-    "esm": "^3.2.25",
+    "esm": "^3.2.0",
     "express": "^4.16.4",
     "json-schema-ref-parser": "^6.0.3",
     "jszip": "^3.1.5",


### PR DESCRIPTION
Reverts #906. That could be the reason why the deployment is currently failing.