### PR TITLE
Add fixture 'elation/proteus-hybrid'

### DIFF
--- a/fixtures/elation/proteus-hybrid.json
+++ b/fixtures/elation/proteus-hybrid.json
@@ -126,9 +126,6 @@
           "type": "Open"
         },
         {
-          "type": "Open"
-        },
-        {
           "type": "Gobo"
         },
         {
@@ -376,109 +373,108 @@
       "capabilities": [
         {
           "dmxRange": [0, 10],
-          "type": "WheelSlot",
-          "slotNumber": 1,
+          "type": "NoFunction",
           "comment": "Beam"
         },
         {
           "dmxRange": [11, 21],
           "type": "WheelSlot",
-          "slotNumber": 2,
+          "slotNumber": 1,
           "comment": "Spot"
         },
         {
           "dmxRange": [22, 31],
           "type": "WheelSlot",
-          "slotNumber": 3
+          "slotNumber": 2
         },
         {
           "dmxRange": [32, 41],
           "type": "WheelSlot",
-          "slotNumber": 4
+          "slotNumber": 3
         },
         {
           "dmxRange": [42, 51],
           "type": "WheelSlot",
-          "slotNumber": 5
+          "slotNumber": 4
         },
         {
           "dmxRange": [52, 61],
           "type": "WheelSlot",
-          "slotNumber": 6
+          "slotNumber": 5
         },
         {
           "dmxRange": [62, 71],
           "type": "WheelSlot",
-          "slotNumber": 7
+          "slotNumber": 6
         },
         {
           "dmxRange": [72, 81],
           "type": "WheelSlot",
-          "slotNumber": 8
+          "slotNumber": 7
         },
         {
           "dmxRange": [82, 91],
           "type": "WheelSlot",
-          "slotNumber": 9
+          "slotNumber": 8
         },
         {
           "dmxRange": [92, 101],
           "type": "WheelSlot",
-          "slotNumber": 10
+          "slotNumber": 9
         },
         {
           "dmxRange": [102, 112],
           "type": "WheelShake",
-          "slotNumber": 3,
+          "slotNumber": 2,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [113, 123],
           "type": "WheelShake",
-          "slotNumber": 4,
+          "slotNumber": 3,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [124, 134],
           "type": "WheelShake",
-          "slotNumber": 5,
+          "slotNumber": 4,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "slow"
         },
         {
           "dmxRange": [135, 145],
           "type": "WheelShake",
-          "slotNumber": 6,
+          "slotNumber": 5,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [146, 156],
           "type": "WheelShake",
-          "slotNumber": 7,
+          "slotNumber": 6,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [157, 167],
           "type": "WheelShake",
-          "slotNumber": 8,
+          "slotNumber": 7,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "slow"
         },
         {
           "dmxRange": [168, 178],
           "type": "WheelShake",
-          "slotNumber": 9,
+          "slotNumber": 8,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [179, 189],
           "type": "WheelShake",
-          "slotNumber": 10,
+          "slotNumber": 9,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },

--- a/fixtures/elation/proteus-hybrid.json
+++ b/fixtures/elation/proteus-hybrid.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "Proteus Hybrid",
-  "categories": ["Moving Head"],
+  "categories": ["Moving Head", "Color Changer"],
   "meta": {
     "authors": ["MeroChat"],
     "createDate": "2019-05-21",
@@ -13,10 +13,15 @@
     ],
     "productPage": [
       "https://www.elationlighting.com/proteus-hybrid"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=w_GtudSQ8BU",
+      "https://www.youtube.com/watch?v=TPU1p4mMNlo&t=20",
+      "https://www.youtube.com/watch?v=v8iZYjFaTDA"
     ]
   },
   "rdm": {
-    "modelId": 26
+    "modelId": 22
   },
   "physical": {
     "dimensions": [571, 31.7, 465],

--- a/fixtures/elation/proteus-hybrid.json
+++ b/fixtures/elation/proteus-hybrid.json
@@ -24,23 +24,22 @@
     "modelId": 22
   },
   "physical": {
-    "dimensions": [571, 31.7, 465],
-    "weight": 38,
+    "dimensions": [465, 650, 571],
+    "weight": 38.0,
     "power": 750,
     "DMXconnector": "5-pin XLR IP65",
     "bulb": {
-      "type": "phillips MSD Platinum",
+      "type": "Philips MSD Platinum 21R 470W",
       "colorTemperature": 8000,
       "lumens": 23000
     },
     "lens": {
-      "name": "Beam Wash",
       "degreesMinMax": [2, 40]
     },
     "focus": {
       "type": "Head",
-      "panMax": 680,
-      "tiltMax": 280
+      "panMax": 630,
+      "tiltMax": 270
     }
   },
   "wheels": {

--- a/fixtures/elation/proteus-hybrid.json
+++ b/fixtures/elation/proteus-hybrid.json
@@ -1,0 +1,1209 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Proteus Hybrid",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["MeroChat"],
+    "createDate": "2019-05-21",
+    "lastModifyDate": "2019-05-21"
+  },
+  "links": {
+    "manual": [
+      "http://cdb.s3.amazonaws.com/ItemRelatedFiles/10677/ELATION%20PROTEUS%20HYBRID%20-%20USER%20MANUAL.pdf"
+    ],
+    "productPage": [
+      "https://www.elationlighting.com/proteus-hybrid"
+    ]
+  },
+  "rdm": {
+    "modelId": 26
+  },
+  "physical": {
+    "dimensions": [571, 31.7, 465],
+    "weight": 38,
+    "power": 750,
+    "DMXconnector": "5-pin XLR IP65",
+    "bulb": {
+      "type": "phillips MSD Platinum",
+      "colorTemperature": 8000,
+      "lumens": 23000
+    },
+    "lens": {
+      "name": "Beam Wash",
+      "degreesMinMax": [2, 40]
+    },
+    "focus": {
+      "type": "Head",
+      "panMax": 680,
+      "tiltMax": 280
+    }
+  },
+  "wheels": {
+    "Rotating Gobos, Continuous Rotation(Gobo Wheel 1)": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rotating Gobo 1"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rotating Gobo 2"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rotating Gobo 3"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rotating Gobo 4"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rotating Gobo 5"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rotating Gobo 6"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rotating Gobo 7"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rotating Gobo 8"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 1 Shake Slow to Fast"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 2 Shake Slow to Fast"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 3 Shake Slow to Fast"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 4 Shake Slow to Fast"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 5 Shake Slow to Fast"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 6 Shake Slow to Fast"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 7 Shake Slow to Fast"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 8 Shake Slow to Fast"
+        }
+      ]
+    },
+    "Static/Fixed Gobos(Gobo Wheel 2)": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 1"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 2"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 3"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 4"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 5"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 6"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 7"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 8"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 9"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 10"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 11"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 12"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 13"
+        },
+        {
+          "type": "Gobo",
+          "name": "Static/Fixed Gobo 14"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 1"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 2"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 3"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 4"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 5"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 6"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 7"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 8"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 9"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 10"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 11"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 12"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 13"
+        },
+        {
+          "type": "Gobo",
+          "name": "Shake SLOW to FAST Static/Fixed Gobo 14"
+        },
+        {
+          "type": "Gobo",
+          "name": "Clockwise Gobo Rotation from FAST to SLOW"
+        },
+        {
+          "type": "Gobo",
+          "name": "No Rotation"
+        },
+        {
+          "type": "Gobo",
+          "name": "Counterclockwise Gobo Wheel Rotation from SLOW to FAST"
+        }
+      ]
+    },
+    "Rotating Prism, Prism/Gobo Macros": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Prism",
+          "facets": 8
+        },
+        {
+          "type": "Prism",
+          "name": "Line Prism"
+        },
+        {
+          "type": "Prism",
+          "name": "8 facet plus Line prisms",
+          "facets": 8
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo Macro 1"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 2"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 3"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 4"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 5"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 6"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 7"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 8"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 9"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 10"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 11"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 12"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 13"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 14"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 15"
+        },
+        {
+          "type": "Prism",
+          "name": "Gobo macro 16"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan Movement": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "1deg",
+        "angleEnd": "680deg"
+      }
+    },
+    "Pan Movement 2": {
+      "name": "Pan Movement",
+      "fineChannelAliases": ["Pan Movement 2 fine"],
+      "capability": {
+        "type": "PanContinuous",
+        "speed": "slow CCW"
+      }
+    },
+    "Pan Movement 3": {
+      "name": "Pan Movement",
+      "fineChannelAliases": ["Pan Movement 3 fine"],
+      "capability": {
+        "type": "PanContinuous",
+        "speed": "slow CCW"
+      }
+    },
+    "Pan Movement 16": {
+      "fineChannelAliases": ["Pan Movement 16 fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "PanContinuous",
+        "speed": "slow CCW"
+      }
+    },
+    "Tilt Movement": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "1deg",
+        "angleEnd": "300deg"
+      }
+    },
+    "Tilt Movement 16": {
+      "fineChannelAliases": ["Tilt Movement 16 fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "TiltContinuous",
+        "speed": "slow CCW"
+      }
+    },
+    "Cyan Color": {
+      "capability": {
+        "type": "ColorPreset",
+        "comment": "Cyan",
+        "colorTemperature": "default"
+      }
+    },
+    "Magenta Color": {
+      "capability": {
+        "type": "ColorPreset",
+        "comment": "Magenta",
+        "colorTemperature": "default"
+      }
+    },
+    "Yellow Color": {
+      "capability": {
+        "type": "ColorPreset",
+        "comment": "Yellow"
+      }
+    },
+    "CTO Color": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "CTO",
+        "colorTemperatureEnd": "CTO"
+      }
+    },
+    "Color Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "ColorPreset",
+          "comment": "Open/White"
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "ColorPreset",
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "ColorPreset",
+          "comment": "Blue"
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "ColorPreset",
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "ColorPreset",
+          "comment": "Yellow"
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "ColorPreset",
+          "comment": "Purple"
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "ColorPreset",
+          "comment": "Aqua"
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "ColorPreset",
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "ColorPreset",
+          "comment": "Light Pink"
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "ColorPreset",
+          "comment": "Lime Green"
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "ColorPreset",
+          "comment": "Light Yellow"
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "ColorPreset",
+          "comment": "Magenta"
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "ColorPreset",
+          "comment": "CTB"
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "ColorPreset",
+          "comment": "CTO"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "ColorPreset",
+          "comment": "UV"
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "Clockwise COLOR Rotation from FAST to SLOW"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "WheelRotation",
+          "speedStart": "stop",
+          "speedEnd": "stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        }
+      ]
+    },
+    "Rotating Gobos, Continuous Rotation(Gobo Wheel 1)": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [11, 21],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [22, 31],
+          "type": "WheelSlotRotation",
+          "slotNumber": 3,
+          "speed": "fast CW"
+        },
+        {
+          "dmxRange": [32, 41],
+          "type": "WheelSlotRotation",
+          "slotNumber": 4,
+          "speed": "fast CW"
+        },
+        {
+          "dmxRange": [42, 51],
+          "type": "WheelSlotRotation",
+          "slotNumber": 5,
+          "speed": "fast CW"
+        },
+        {
+          "dmxRange": [52, 61],
+          "type": "WheelSlotRotation",
+          "slotNumber": 6,
+          "speed": "fast CW"
+        },
+        {
+          "dmxRange": [62, 71],
+          "type": "WheelSlotRotation",
+          "slotNumber": 7,
+          "speed": "fast CW"
+        },
+        {
+          "dmxRange": [72, 81],
+          "type": "WheelSlotRotation",
+          "slotNumber": 8,
+          "speed": "fast CW"
+        },
+        {
+          "dmxRange": [82, 91],
+          "type": "WheelSlotRotation",
+          "slotNumber": 9,
+          "speed": "fast CW"
+        },
+        {
+          "dmxRange": [92, 101],
+          "type": "WheelSlotRotation",
+          "slotNumber": 10,
+          "speed": "fast CW"
+        },
+        {
+          "dmxRange": [102, 112],
+          "type": "WheelShake",
+          "slotNumber": 11,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [113, 123],
+          "type": "WheelShake",
+          "slotNumber": 12,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [124, 134],
+          "type": "WheelShake",
+          "slotNumber": 13,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "slow"
+        },
+        {
+          "dmxRange": [135, 145],
+          "type": "WheelShake",
+          "slotNumber": 14,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [146, 156],
+          "type": "WheelShake",
+          "slotNumber": 15,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [157, 167],
+          "type": "WheelShake",
+          "slotNumber": 16,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "slow"
+        },
+        {
+          "dmxRange": [168, 178],
+          "type": "WheelShake",
+          "slotNumber": 17,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [179, 189],
+          "type": "WheelShake",
+          "slotNumber": 18,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [190, 221],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [222, 223],
+          "type": "WheelRotation",
+          "speedStart": "stop",
+          "speedEnd": "stop"
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Rotating Gobos, Index Rotation(Gobo Wheel 1)": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "WheelRotation",
+          "speed": "slow CW",
+          "comment": "Gobo indexing"
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW",
+          "comment": "Clockwise Gobo Rotation from FAST to SLOW"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "WheelRotation",
+          "speed": "stop",
+          "comment": "No Rotation"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Static/Fixed Gobos(Gobo Wheel 2)": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [8, 14],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [15, 21],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [22, 28],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [29, 35],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [36, 42],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [43, 49],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [50, 56],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [57, 63],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [64, 70],
+          "type": "WheelSlot",
+          "slotNumber": 10
+        },
+        {
+          "dmxRange": [71, 77],
+          "type": "WheelSlot",
+          "slotNumber": 11
+        },
+        {
+          "dmxRange": [78, 84],
+          "type": "WheelSlot",
+          "slotNumber": 12
+        },
+        {
+          "dmxRange": [85, 91],
+          "type": "WheelSlot",
+          "slotNumber": 13
+        },
+        {
+          "dmxRange": [92, 98],
+          "type": "WheelSlot",
+          "slotNumber": 14
+        },
+        {
+          "dmxRange": [99, 105],
+          "type": "WheelSlot",
+          "slotNumber": 15
+        },
+        {
+          "dmxRange": [106, 111],
+          "type": "WheelShake",
+          "slotNumber": 16,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "slow",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [112, 117],
+          "type": "WheelShake",
+          "slotNumber": 17,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [118, 123],
+          "type": "WheelShake",
+          "slotNumber": 18,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [124, 129],
+          "type": "WheelShake",
+          "slotNumber": 19,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [130, 135],
+          "type": "WheelShake",
+          "slotNumber": 20,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [136, 141],
+          "type": "WheelShake",
+          "slotNumber": 21,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [142, 147],
+          "type": "WheelShake",
+          "slotNumber": 22,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [148, 153],
+          "type": "WheelShake",
+          "slotNumber": 23,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [154, 159],
+          "type": "WheelShake",
+          "slotNumber": 24,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [160, 165],
+          "type": "WheelShake",
+          "slotNumber": 25,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [166, 171],
+          "type": "WheelShake",
+          "slotNumber": 26,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [172, 177],
+          "type": "WheelShake",
+          "slotNumber": 27,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [178, 183],
+          "type": "WheelShake",
+          "slotNumber": 28,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [184, 189],
+          "type": "WheelShake",
+          "slotNumber": 29,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "shakeAngle": "narrow"
+        },
+        {
+          "dmxRange": [190, 221],
+          "type": "WheelSlotRotation",
+          "slotNumber": 30,
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [222, 223],
+          "type": "WheelSlotRotation",
+          "slotNumber": 31,
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "WheelSlotRotation",
+          "slotNumber": 32,
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Rotating Prism, Prism/Gobo Macros": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 31],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [32, 64],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "8 Facet Prism"
+        },
+        {
+          "dmxRange": [65, 94],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Line Prism"
+        },
+        {
+          "dmxRange": [95, 127],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "8 Facet plus Line Prisms"
+        },
+        {
+          "dmxRange": [128, 135],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [136, 143],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [144, 151],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [152, 159],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [160, 167],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [168, 175],
+          "type": "WheelSlot",
+          "slotNumber": 10
+        },
+        {
+          "dmxRange": [176, 183],
+          "type": "WheelSlot",
+          "slotNumber": 11
+        },
+        {
+          "dmxRange": [184, 191],
+          "type": "WheelSlot",
+          "slotNumber": 12
+        },
+        {
+          "dmxRange": [192, 199],
+          "type": "WheelSlot",
+          "slotNumber": 13
+        },
+        {
+          "dmxRange": [200, 207],
+          "type": "WheelSlot",
+          "slotNumber": 14
+        },
+        {
+          "dmxRange": [208, 215],
+          "type": "WheelSlot",
+          "slotNumber": 15
+        },
+        {
+          "dmxRange": [216, 223],
+          "type": "WheelSlot",
+          "slotNumber": 16
+        },
+        {
+          "dmxRange": [224, 231],
+          "type": "WheelSlot",
+          "slotNumber": 17
+        },
+        {
+          "dmxRange": [232, 239],
+          "type": "WheelSlot",
+          "slotNumber": 18
+        },
+        {
+          "dmxRange": [240, 247],
+          "type": "WheelSlot",
+          "slotNumber": 19
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "WheelSlot",
+          "slotNumber": 20
+        }
+      ]
+    },
+    "Rotatig Prism, Prism Index Rotation": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "PrismRotation",
+          "speedStart": "stop",
+          "speedEnd": "stop"
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "PrismRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW",
+          "comment": "Clockwise Prism Rotation from FAST to SLOW"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "PrismRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "PrismRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "Clockwise Prism Rotation from SLOW to FAST"
+        }
+      ]
+    },
+    "Focus": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Zoom": {
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "narrow",
+        "angleEnd": "wide"
+      }
+    },
+    "Autofocus": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 50],
+          "type": "Focus",
+          "distance": "near"
+        },
+        {
+          "dmxRange": [51, 150],
+          "type": "Focus",
+          "distance": "15m"
+        },
+        {
+          "dmxRange": [151, 255],
+          "type": "Focus",
+          "distance": "20m"
+        }
+      ]
+    },
+    "Autofocus f": {
+      "fineChannelAliases": ["Autofocus f fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Autofocus 2": {
+      "name": "Autofocus",
+      "fineChannelAliases": ["Autofocus 2 fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "AutoFocus": {
+      "fineChannelAliases": ["AutoFocus fine"],
+      "dmxValueResolution": "8bit",
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Shutter / Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 31],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [32, 63],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [64, 95],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUp",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [96, 127],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [128, 159],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse"
+        },
+        {
+          "dmxRange": [160, 191],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [192, 223],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUpDown",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Frost": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "Frost",
+          "frostIntensity": "off"
+        },
+        {
+          "dmxRange": [128, 255],
+          "type": "Frost",
+          "frostIntensityStart": "off",
+          "frostIntensityEnd": "high"
+        }
+      ]
+    },
+    "Animation Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "EffectParameter",
+          "parameter": "off"
+        },
+        {
+          "dmxRange": [8, 127],
+          "type": "EffectParameter",
+          "parameterStart": "fast",
+          "parameterEnd": "slow"
+        },
+        {
+          "dmxRange": [128, 135],
+          "type": "EffectParameter",
+          "parameter": "off"
+        },
+        {
+          "dmxRange": [136, 255],
+          "type": "EffectParameter",
+          "parameterStart": "slow",
+          "parameterEnd": "fast"
+        }
+      ]
+    },
+    "CMY Speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Standard",
+      "shortName": "Stand",
+      "channels": [
+        "Pan Movement",
+        "Pan Movement 16",
+        "Tilt Movement",
+        "Tilt Movement 16",
+        "Cyan Color",
+        "Magenta Color",
+        "Yellow Color",
+        "CTO Color",
+        "Color Wheel",
+        "Rotating Gobos, Continuous Rotation(Gobo Wheel 1)",
+        "Rotating Gobos, Index Rotation(Gobo Wheel 1)",
+        "Static/Fixed Gobos(Gobo Wheel 2)",
+        "Rotating Prism, Prism/Gobo Macros",
+        "Rotatig Prism, Prism Index Rotation",
+        "Focus",
+        "Zoom",
+        "AutoFocus",
+        "AutoFocus fine",
+        "Shutter / Strobe",
+        "Dimmer",
+        "Frost",
+        "Animation Wheel",
+        "CMY Speed"
+      ]
+    }
+  ]
+}

--- a/fixtures/elation/proteus-hybrid.json
+++ b/fixtures/elation/proteus-hybrid.json
@@ -246,24 +246,28 @@
       }
     },
     "Cyan": {
+      "fineChannelAliases": ["Cyan fine"],
       "capability": {
         "type": "ColorIntensity",
         "color": "Cyan"
       }
     },
     "Magenta": {
+      "fineChannelAliases": ["Magenta fine"],
       "capability": {
         "type": "ColorIntensity",
         "color": "Magenta"
       }
     },
     "Yellow": {
+      "fineChannelAliases": ["Yellow fine"],
       "capability": {
         "type": "ColorIntensity",
         "color": "Yellow"
       }
     },
     "CTO": {
+      "fineChannelAliases": ["CTO fine"],
       "capability": {
         "type": "ColorTemperature",
         "colorTemperatureStart": "default",
@@ -271,6 +275,8 @@
       }
     },
     "Color Wheel": {
+      "fineChannelAliases": ["Color Wheel fine"],
+      "dmxValueResolution": "8bit",
       "capabilities": [
         {
           "dmxRange": [0, 15],
@@ -496,6 +502,8 @@
       ]
     },
     "Gobo Rotation": {
+      "fineChannelAliases": ["Gobo Rotation fine"],
+      "dmxValueResolution": "8bit",
       "capabilities": [
         {
           "dmxRange": [0, 127],
@@ -528,6 +536,8 @@
       ]
     },
     "Static Gobo Wheel": {
+      "fineChannelAliases": ["Static Gobo Wheel fine"],
+      "dmxValueResolution": "8bit",
       "capabilities": [
         {
           "dmxRange": [0, 7],
@@ -825,6 +835,8 @@
       ]
     },
     "Prism Rotation": {
+      "fineChannelAliases": ["Prism Rotation fine"],
+      "dmxValueResolution": "8bit",
       "capabilities": [
         {
           "dmxRange": [0, 127],
@@ -853,6 +865,7 @@
       ]
     },
     "Focus": {
+      "fineChannelAliases": ["Focus fine"],
       "capability": {
         "type": "Focus",
         "distanceStart": "near",
@@ -860,6 +873,7 @@
       }
     },
     "Zoom": {
+      "fineChannelAliases": ["Zoom fine"],
       "capability": {
         "type": "Zoom",
         "angleStart": "narrow",
@@ -937,6 +951,7 @@
       ]
     },
     "Dimmer": {
+      "fineChannelAliases": ["Dimmer fine"],
       "capability": {
         "type": "Intensity"
       }
@@ -1288,8 +1303,38 @@
   },
   "modes": [
     {
+      "name": "Basic",
+      "shortName": "bas",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Cyan",
+        "Magenta",
+        "Yellow",
+        "CTO",
+        "Color Wheel",
+        "Rotating Gobo Wheel",
+        "Gobo Rotation",
+        "Static Gobo Wheel",
+        "Rotating Prism / Prism/Gobo Macros",
+        "Prism Rotation",
+        "Focus",
+        "Zoom",
+        "Auto Focus",
+        "Auto Focus fine",
+        "Shutter / Strobe",
+        "Dimmer",
+        "Frost",
+        "Animation Wheel",
+        "CMY Speed",
+        "CMY Macros",
+        "Pan / Tilt Speed",
+        "Maintenance / Programs"
+      ]
+    },
+    {
       "name": "Standard",
-      "shortName": "Stand",
+      "shortName": "std",
       "channels": [
         "Pan",
         "Pan fine",
@@ -1311,6 +1356,49 @@
         "Auto Focus fine",
         "Shutter / Strobe",
         "Dimmer",
+        "Frost",
+        "Animation Wheel",
+        "CMY Speed",
+        "CMY Macros",
+        "Pan / Tilt Speed",
+        "Maintenance / Programs"
+      ]
+    },
+    {
+      "name": "Extended",
+      "shortName": "ext",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Cyan",
+        "Cyan fine",
+        "Magenta",
+        "Magenta fine",
+        "Yellow",
+        "Yellow fine",
+        "CTO",
+        "CTO fine",
+        "Color Wheel",
+        "Color Wheel fine",
+        "Rotating Gobo Wheel",
+        "Gobo Rotation",
+        "Gobo Rotation fine",
+        "Static Gobo Wheel",
+        "Static Gobo Wheel fine",
+        "Rotating Prism / Prism/Gobo Macros",
+        "Prism Rotation",
+        "Prism Rotation fine",
+        "Focus",
+        "Focus fine",
+        "Zoom",
+        "Zoom fine",
+        "Auto Focus",
+        "Auto Focus fine",
+        "Shutter / Strobe",
+        "Dimmer",
+        "Dimmer fine",
         "Frost",
         "Animation Wheel",
         "CMY Speed",

--- a/fixtures/elation/proteus-hybrid.json
+++ b/fixtures/elation/proteus-hybrid.json
@@ -43,292 +43,187 @@
     }
   },
   "wheels": {
-    "Rotating Gobos, Continuous Rotation(Gobo Wheel 1)": {
+    "Color Wheel": {
       "slots": [
         {
           "type": "Open"
         },
         {
-          "type": "Open"
+          "type": "Color",
+          "name": "Red",
+          "colors": ["#ec252a"]
         },
         {
-          "type": "Gobo",
-          "name": "Rotating Gobo 1"
+          "type": "Color",
+          "name": "Blue",
+          "colors": ["#2d3691"]
         },
         {
-          "type": "Gobo",
-          "name": "Rotating Gobo 2"
+          "type": "Color",
+          "name": "Green",
+          "colors": ["#14a651"]
         },
         {
-          "type": "Gobo",
-          "name": "Rotating Gobo 3"
+          "type": "Color",
+          "name": "Yellow",
+          "colors": ["#f7ef22"]
         },
         {
-          "type": "Gobo",
-          "name": "Rotating Gobo 4"
+          "type": "Color",
+          "name": "Purple",
+          "colors": ["#8f298d"]
         },
         {
-          "type": "Gobo",
-          "name": "Rotating Gobo 5"
+          "type": "Color",
+          "name": "Aqua",
+          "colors": ["#1aa89c"]
         },
         {
-          "type": "Gobo",
-          "name": "Rotating Gobo 6"
+          "type": "Color",
+          "name": "Orange",
+          "colors": ["#f16726"]
         },
         {
-          "type": "Gobo",
-          "name": "Rotating Gobo 7"
+          "type": "Color",
+          "name": "Light pink",
+          "colors": ["#f5abcc"]
         },
         {
-          "type": "Gobo",
-          "name": "Rotating Gobo 8"
+          "type": "Color",
+          "name": "Lime green",
+          "colors": ["#6cbd47"]
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 1 Shake Slow to Fast"
+          "type": "Color",
+          "name": "Light yellow",
+          "colors": ["#f5ed33"]
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 2 Shake Slow to Fast"
+          "type": "Color",
+          "name": "Magenta",
+          "colors": ["#ea098d"]
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 3 Shake Slow to Fast"
+          "type": "Color",
+          "name": "CTB",
+          "colors": ["#b1d6f1"]
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 4 Shake Slow to Fast"
+          "type": "Color",
+          "name": "CTO",
+          "colors": ["#e7a45d"]
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 5 Shake Slow to Fast"
-        },
-        {
-          "type": "Gobo",
-          "name": "Gobo 6 Shake Slow to Fast"
-        },
-        {
-          "type": "Gobo",
-          "name": "Gobo 7 Shake Slow to Fast"
-        },
-        {
-          "type": "Gobo",
-          "name": "Gobo 8 Shake Slow to Fast"
+          "type": "Color",
+          "name": "UV",
+          "colors": ["#572e8a"]
         }
       ]
     },
-    "Static/Fixed Gobos(Gobo Wheel 2)": {
+    "Rotating Gobo Wheel": {
       "slots": [
         {
           "type": "Open"
         },
         {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 1"
+          "type": "Open"
         },
         {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 2"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 3"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 4"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 5"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 6"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 7"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 8"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 9"
-        },
-        {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 10"
-        },
-        {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 11"
-        },
-        {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 12"
-        },
-        {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 13"
-        },
-        {
-          "type": "Gobo",
-          "name": "Static/Fixed Gobo 14"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 1"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 2"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 3"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 4"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 5"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 6"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 7"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 8"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 9"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 10"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 11"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 12"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 13"
-        },
-        {
-          "type": "Gobo",
-          "name": "Shake SLOW to FAST Static/Fixed Gobo 14"
-        },
-        {
-          "type": "Gobo",
-          "name": "Clockwise Gobo Rotation from FAST to SLOW"
-        },
-        {
-          "type": "Gobo",
-          "name": "No Rotation"
-        },
-        {
-          "type": "Gobo",
-          "name": "Counterclockwise Gobo Wheel Rotation from SLOW to FAST"
+          "type": "Gobo"
         }
       ]
     },
-    "Rotating Prism, Prism/Gobo Macros": {
+    "Static Gobo Wheel": {
       "slots": [
         {
           "type": "Open"
         },
         {
-          "type": "Prism",
-          "facets": 8
+          "type": "Iris",
+          "openPercent": "10%"
         },
         {
-          "type": "Prism",
-          "name": "Line Prism"
+          "type": "Iris",
+          "openPercent": "25%"
         },
         {
-          "type": "Prism",
-          "name": "8 facet plus Line prisms",
-          "facets": 8
+          "type": "Iris",
+          "openPercent": "40%"
         },
         {
-          "type": "Prism",
-          "name": "Gobo Macro 1"
+          "type": "Iris",
+          "openPercent": "55%"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 2"
+          "type": "Gobo",
+          "name": "Gobo 5"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 3"
+          "type": "Gobo",
+          "name": "Gobo 6"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 4"
+          "type": "Gobo",
+          "name": "Gobo 7"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 5"
+          "type": "Gobo",
+          "name": "Gobo 8"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 6"
+          "type": "Gobo",
+          "name": "Gobo 9"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 7"
+          "type": "Gobo",
+          "name": "Gobo 10"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 8"
+          "type": "Gobo",
+          "name": "Gobo 11"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 9"
+          "type": "Gobo",
+          "name": "Gobo 12"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 10"
+          "type": "Gobo",
+          "name": "Gobo 13"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 11"
+          "type": "Gobo",
+          "name": "Gobo 14"
+        }
+      ]
+    },
+    "Animation Wheel": {
+      "slots": [
+        {
+          "type": "AnimationGoboStart"
         },
         {
-          "type": "Prism",
-          "name": "Gobo macro 12"
-        },
-        {
-          "type": "Prism",
-          "name": "Gobo macro 13"
-        },
-        {
-          "type": "Prism",
-          "name": "Gobo macro 14"
-        },
-        {
-          "type": "Prism",
-          "name": "Gobo macro 15"
-        },
-        {
-          "type": "Prism",
-          "name": "Gobo macro 16"
+          "type": "AnimationGoboEnd"
         }
       ]
     }
@@ -379,227 +274,218 @@
       "capabilities": [
         {
           "dmxRange": [0, 15],
-          "type": "ColorPreset",
-          "comment": "Open/White"
-        },
-        {
-          "dmxRange": [16, 23],
-          "type": "ColorPreset",
-          "comment": "Red"
-        },
-        {
-          "dmxRange": [24, 31],
-          "type": "ColorPreset",
-          "comment": "Blue"
-        },
-        {
-          "dmxRange": [32, 39],
-          "type": "ColorPreset",
-          "comment": "Green"
-        },
-        {
-          "dmxRange": [40, 47],
-          "type": "ColorPreset",
-          "comment": "Yellow"
-        },
-        {
-          "dmxRange": [48, 55],
-          "type": "ColorPreset",
-          "comment": "Purple"
-        },
-        {
-          "dmxRange": [56, 63],
-          "type": "ColorPreset",
-          "comment": "Aqua"
-        },
-        {
-          "dmxRange": [64, 71],
-          "type": "ColorPreset",
-          "comment": "Orange"
-        },
-        {
-          "dmxRange": [72, 79],
-          "type": "ColorPreset",
-          "comment": "Light Pink"
-        },
-        {
-          "dmxRange": [80, 87],
-          "type": "ColorPreset",
-          "comment": "Lime Green"
-        },
-        {
-          "dmxRange": [88, 95],
-          "type": "ColorPreset",
-          "comment": "Light Yellow"
-        },
-        {
-          "dmxRange": [96, 103],
-          "type": "ColorPreset",
-          "comment": "Magenta"
-        },
-        {
-          "dmxRange": [104, 111],
-          "type": "ColorPreset",
-          "comment": "CTB"
-        },
-        {
-          "dmxRange": [112, 119],
-          "type": "ColorPreset",
-          "comment": "CTO"
-        },
-        {
-          "dmxRange": [120, 127],
-          "type": "ColorPreset",
-          "comment": "UV"
-        },
-        {
-          "dmxRange": [128, 189],
-          "type": "WheelRotation",
-          "speedStart": "slow CW",
-          "speedEnd": "fast CW",
-          "comment": "Clockwise COLOR Rotation from FAST to SLOW"
-        },
-        {
-          "dmxRange": [190, 193],
-          "type": "WheelRotation",
-          "speedStart": "stop",
-          "speedEnd": "stop"
-        },
-        {
-          "dmxRange": [194, 255],
-          "type": "WheelRotation",
-          "speedStart": "fast CW",
-          "speedEnd": "slow CW"
-        }
-      ]
-    },
-    "Rotating Gobos, Continuous Rotation(Gobo Wheel 1)": {
-      "capabilities": [
-        {
-          "dmxRange": [0, 10],
           "type": "WheelSlot",
           "slotNumber": 1
         },
         {
-          "dmxRange": [11, 21],
+          "dmxRange": [16, 23],
           "type": "WheelSlot",
           "slotNumber": 2
         },
         {
+          "dmxRange": [24, 31],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "WheelSlot",
+          "slotNumber": 10
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "WheelSlot",
+          "slotNumber": 11
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "WheelSlot",
+          "slotNumber": 12
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "WheelSlot",
+          "slotNumber": 13
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "WheelSlot",
+          "slotNumber": 14
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelSlot",
+          "slotNumber": 15
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "WheelRotation",
+          "speedStart": "fast CCW",
+          "speedEnd": "slow CCW"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "WheelRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Rotating Gobo Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "Beam"
+        },
+        {
+          "dmxRange": [11, 21],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Spot"
+        },
+        {
           "dmxRange": [22, 31],
-          "type": "WheelSlotRotation",
-          "slotNumber": 3,
-          "speed": "fast CW"
+          "type": "WheelSlot",
+          "slotNumber": 3
         },
         {
           "dmxRange": [32, 41],
-          "type": "WheelSlotRotation",
-          "slotNumber": 4,
-          "speed": "fast CW"
+          "type": "WheelSlot",
+          "slotNumber": 4
         },
         {
           "dmxRange": [42, 51],
-          "type": "WheelSlotRotation",
-          "slotNumber": 5,
-          "speed": "fast CW"
+          "type": "WheelSlot",
+          "slotNumber": 5
         },
         {
           "dmxRange": [52, 61],
-          "type": "WheelSlotRotation",
-          "slotNumber": 6,
-          "speed": "fast CW"
+          "type": "WheelSlot",
+          "slotNumber": 6
         },
         {
           "dmxRange": [62, 71],
-          "type": "WheelSlotRotation",
-          "slotNumber": 7,
-          "speed": "fast CW"
+          "type": "WheelSlot",
+          "slotNumber": 7
         },
         {
           "dmxRange": [72, 81],
-          "type": "WheelSlotRotation",
-          "slotNumber": 8,
-          "speed": "fast CW"
+          "type": "WheelSlot",
+          "slotNumber": 8
         },
         {
           "dmxRange": [82, 91],
-          "type": "WheelSlotRotation",
-          "slotNumber": 9,
-          "speed": "fast CW"
+          "type": "WheelSlot",
+          "slotNumber": 9
         },
         {
           "dmxRange": [92, 101],
-          "type": "WheelSlotRotation",
-          "slotNumber": 10,
-          "speed": "fast CW"
+          "type": "WheelSlot",
+          "slotNumber": 10
         },
         {
           "dmxRange": [102, 112],
           "type": "WheelShake",
-          "slotNumber": 11,
+          "slotNumber": 3,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [113, 123],
           "type": "WheelShake",
-          "slotNumber": 12,
+          "slotNumber": 4,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [124, 134],
           "type": "WheelShake",
-          "slotNumber": 13,
+          "slotNumber": 5,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "slow"
         },
         {
           "dmxRange": [135, 145],
           "type": "WheelShake",
-          "slotNumber": 14,
+          "slotNumber": 6,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [146, 156],
           "type": "WheelShake",
-          "slotNumber": 15,
+          "slotNumber": 7,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [157, 167],
           "type": "WheelShake",
-          "slotNumber": 16,
+          "slotNumber": 8,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "slow"
         },
         {
           "dmxRange": [168, 178],
           "type": "WheelShake",
-          "slotNumber": 17,
+          "slotNumber": 9,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [179, 189],
           "type": "WheelShake",
-          "slotNumber": 18,
+          "slotNumber": 10,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [190, 221],
           "type": "WheelRotation",
-          "speedStart": "fast CW",
-          "speedEnd": "slow CW"
+          "speedStart": "fast CCW",
+          "speedEnd": "slow CCW"
         },
         {
           "dmxRange": [222, 223],
           "type": "WheelRotation",
-          "speedStart": "stop",
-          "speedEnd": "stop"
+          "speed": "stop"
         },
         {
           "dmxRange": [224, 255],
@@ -609,36 +495,39 @@
         }
       ]
     },
-    "Rotating Gobos, Index Rotation(Gobo Wheel 1)": {
+    "Gobo Rotation": {
       "capabilities": [
         {
           "dmxRange": [0, 127],
-          "type": "WheelRotation",
-          "speed": "slow CW",
-          "comment": "Gobo indexing"
+          "type": "WheelSlotRotation",
+          "wheel": "Rotating Gobo Wheel",
+          "angleStart": "0deg",
+          "angleEnd": "360deg",
+          "helpWanted": "Correct angle?"
         },
         {
           "dmxRange": [128, 189],
-          "type": "WheelRotation",
-          "speedStart": "fast CW",
-          "speedEnd": "slow CW",
-          "comment": "Clockwise Gobo Rotation from FAST to SLOW"
+          "type": "WheelSlotRotation",
+          "wheel": "Rotating Gobo Wheel",
+          "speedStart": "fast CCW",
+          "speedEnd": "slow CCW"
         },
         {
           "dmxRange": [190, 193],
-          "type": "WheelRotation",
-          "speed": "stop",
-          "comment": "No Rotation"
+          "type": "WheelSlotRotation",
+          "wheel": "Rotating Gobo Wheel",
+          "speed": "stop"
         },
         {
           "dmxRange": [194, 255],
-          "type": "WheelRotation",
+          "type": "WheelSlotRotation",
+          "wheel": "Rotating Gobo Wheel",
           "speedStart": "slow CW",
           "speedEnd": "fast CW"
         }
       ]
     },
-    "Static/Fixed Gobos(Gobo Wheel 2)": {
+    "Static Gobo Wheel": {
       "capabilities": [
         {
           "dmxRange": [0, 7],
@@ -718,240 +607,220 @@
         {
           "dmxRange": [106, 111],
           "type": "WheelShake",
-          "slotNumber": 16,
+          "slotNumber": 2,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "slow",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "slow"
         },
         {
           "dmxRange": [112, 117],
           "type": "WheelShake",
-          "slotNumber": 17,
+          "slotNumber": 3,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [118, 123],
           "type": "WheelShake",
-          "slotNumber": 18,
+          "slotNumber": 4,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [124, 129],
           "type": "WheelShake",
-          "slotNumber": 19,
+          "slotNumber": 5,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [130, 135],
           "type": "WheelShake",
-          "slotNumber": 20,
+          "slotNumber": 6,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [136, 141],
           "type": "WheelShake",
-          "slotNumber": 21,
+          "slotNumber": 7,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [142, 147],
           "type": "WheelShake",
-          "slotNumber": 22,
+          "slotNumber": 8,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [148, 153],
           "type": "WheelShake",
-          "slotNumber": 23,
+          "slotNumber": 9,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [154, 159],
           "type": "WheelShake",
-          "slotNumber": 24,
+          "slotNumber": 10,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [160, 165],
           "type": "WheelShake",
-          "slotNumber": 25,
+          "slotNumber": 11,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [166, 171],
           "type": "WheelShake",
-          "slotNumber": 26,
+          "slotNumber": 12,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [172, 177],
           "type": "WheelShake",
-          "slotNumber": 27,
+          "slotNumber": 13,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [178, 183],
           "type": "WheelShake",
-          "slotNumber": 28,
+          "slotNumber": 14,
           "shakeSpeedStart": "slow",
           "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [184, 189],
           "type": "WheelShake",
-          "slotNumber": 29,
+          "slotNumber": 15,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "shakeAngle": "narrow"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [190, 221],
-          "type": "WheelSlotRotation",
-          "slotNumber": 30,
-          "speedStart": "fast CW",
-          "speedEnd": "slow CW"
+          "type": "WheelRotation",
+          "speedStart": "fast CCW",
+          "speedEnd": "slow CCW"
         },
         {
           "dmxRange": [222, 223],
-          "type": "WheelSlotRotation",
-          "slotNumber": 31,
+          "type": "WheelRotation",
           "speed": "stop"
         },
         {
           "dmxRange": [224, 255],
-          "type": "WheelSlotRotation",
-          "slotNumber": 32,
+          "type": "WheelRotation",
           "speedStart": "slow CW",
           "speedEnd": "fast CW"
         }
       ]
     },
-    "Rotating Prism, Prism/Gobo Macros": {
+    "Rotating Prism / Prism/Gobo Macros": {
       "capabilities": [
         {
           "dmxRange": [0, 31],
-          "type": "WheelSlot",
-          "slotNumber": 1,
-          "comment": "Open"
+          "type": "NoFunction"
         },
         {
           "dmxRange": [32, 64],
-          "type": "WheelSlot",
-          "slotNumber": 2,
-          "comment": "8 Facet Prism"
+          "type": "Prism",
+          "comment": "8-facet prism"
         },
         {
           "dmxRange": [65, 94],
-          "type": "WheelSlot",
-          "slotNumber": 3,
-          "comment": "Line Prism"
+          "type": "Prism",
+          "comment": "4-facet linear prism"
         },
         {
           "dmxRange": [95, 127],
-          "type": "WheelSlot",
-          "slotNumber": 4,
-          "comment": "8 Facet plus Line Prisms"
+          "type": "Prism",
+          "comment": "8-facet + 4-facet prisms"
         },
         {
           "dmxRange": [128, 135],
-          "type": "WheelSlot",
-          "slotNumber": 5
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 1"
         },
         {
           "dmxRange": [136, 143],
-          "type": "WheelSlot",
-          "slotNumber": 6
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 2"
         },
         {
           "dmxRange": [144, 151],
-          "type": "WheelSlot",
-          "slotNumber": 7
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 3"
         },
         {
           "dmxRange": [152, 159],
-          "type": "WheelSlot",
-          "slotNumber": 8
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 4"
         },
         {
           "dmxRange": [160, 167],
-          "type": "WheelSlot",
-          "slotNumber": 9
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 5"
         },
         {
           "dmxRange": [168, 175],
-          "type": "WheelSlot",
-          "slotNumber": 10
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 6"
         },
         {
           "dmxRange": [176, 183],
-          "type": "WheelSlot",
-          "slotNumber": 11
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 7"
         },
         {
           "dmxRange": [184, 191],
-          "type": "WheelSlot",
-          "slotNumber": 12
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 8"
         },
         {
           "dmxRange": [192, 199],
-          "type": "WheelSlot",
-          "slotNumber": 13
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 9"
         },
         {
           "dmxRange": [200, 207],
-          "type": "WheelSlot",
-          "slotNumber": 14
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 10"
         },
         {
           "dmxRange": [208, 215],
-          "type": "WheelSlot",
-          "slotNumber": 15
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 11"
         },
         {
           "dmxRange": [216, 223],
-          "type": "WheelSlot",
-          "slotNumber": 16
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 12"
         },
         {
           "dmxRange": [224, 231],
-          "type": "WheelSlot",
-          "slotNumber": 17
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 13"
         },
         {
           "dmxRange": [232, 239],
-          "type": "WheelSlot",
-          "slotNumber": 18
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 14"
         },
         {
           "dmxRange": [240, 247],
-          "type": "WheelSlot",
-          "slotNumber": 19
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 15"
         },
         {
           "dmxRange": [248, 255],
-          "type": "WheelSlot",
-          "slotNumber": 20
+          "type": "Effect",
+          "effectName": "Prism/Gobo macro 16"
         }
       ]
     },
@@ -1090,25 +959,24 @@
       "capabilities": [
         {
           "dmxRange": [0, 7],
-          "type": "EffectParameter",
-          "parameter": "off"
+          "type": "NoFunction"
         },
         {
           "dmxRange": [8, 127],
-          "type": "EffectParameter",
-          "parameterStart": "fast",
-          "parameterEnd": "slow"
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
         },
         {
           "dmxRange": [128, 135],
-          "type": "EffectParameter",
-          "parameter": "off"
+          "type": "WheelRotation",
+          "speed": "stop"
         },
         {
           "dmxRange": [136, 255],
-          "type": "EffectParameter",
-          "parameterStart": "slow",
-          "parameterEnd": "fast"
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
         }
       ]
     },
@@ -1134,10 +1002,10 @@
         "Yellow",
         "CTO",
         "Color Wheel",
-        "Rotating Gobos, Continuous Rotation(Gobo Wheel 1)",
-        "Rotating Gobos, Index Rotation(Gobo Wheel 1)",
-        "Static/Fixed Gobos(Gobo Wheel 2)",
-        "Rotating Prism, Prism/Gobo Macros",
+        "Rotating Gobo Wheel",
+        "Gobo Rotation",
+        "Static Gobo Wheel",
+        "Rotating Prism / Prism/Gobo Macros",
         "Prism Rotation",
         "Focus",
         "Zoom",

--- a/fixtures/elation/proteus-hybrid.json
+++ b/fixtures/elation/proteus-hybrid.json
@@ -986,6 +986,304 @@
         "speedStart": "slow",
         "speedEnd": "fast"
       }
+    },
+    "CMY Macros": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 31],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "ColorPreset",
+          "comment": "Macro 1"
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "ColorPreset",
+          "comment": "Macro 2"
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "ColorPreset",
+          "comment": "Macro 3"
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "ColorPreset",
+          "comment": "Macro 4"
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "ColorPreset",
+          "comment": "Macro 5"
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "ColorPreset",
+          "comment": "Macro 6"
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "ColorPreset",
+          "comment": "Macro 7"
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "ColorPreset",
+          "comment": "Macro 8"
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "ColorPreset",
+          "comment": "Macro 9"
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "ColorPreset",
+          "comment": "Macro 10"
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "ColorPreset",
+          "comment": "Macro 11"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "ColorPreset",
+          "comment": "Macro 12"
+        },
+        {
+          "dmxRange": [128, 135],
+          "type": "ColorPreset",
+          "comment": "Macro 13"
+        },
+        {
+          "dmxRange": [136, 143],
+          "type": "ColorPreset",
+          "comment": "Macro 14"
+        },
+        {
+          "dmxRange": [144, 151],
+          "type": "ColorPreset",
+          "comment": "Macro 15"
+        },
+        {
+          "dmxRange": [152, 159],
+          "type": "ColorPreset",
+          "comment": "Macro 16"
+        },
+        {
+          "dmxRange": [160, 167],
+          "type": "ColorPreset",
+          "comment": "Macro 17"
+        },
+        {
+          "dmxRange": [168, 175],
+          "type": "ColorPreset",
+          "comment": "Macro 18"
+        },
+        {
+          "dmxRange": [176, 183],
+          "type": "ColorPreset",
+          "comment": "Macro 19"
+        },
+        {
+          "dmxRange": [184, 191],
+          "type": "ColorPreset",
+          "comment": "Macro 20"
+        },
+        {
+          "dmxRange": [192, 199],
+          "type": "ColorPreset",
+          "comment": "Macro 21"
+        },
+        {
+          "dmxRange": [200, 207],
+          "type": "ColorPreset",
+          "comment": "Macro 22"
+        },
+        {
+          "dmxRange": [208, 215],
+          "type": "ColorPreset",
+          "comment": "Macro 23"
+        },
+        {
+          "dmxRange": [216, 223],
+          "type": "ColorPreset",
+          "comment": "Macro 24"
+        },
+        {
+          "dmxRange": [224, 231],
+          "type": "ColorPreset",
+          "comment": "Macro 25"
+        },
+        {
+          "dmxRange": [232, 239],
+          "type": "ColorPreset",
+          "comment": "Macro 26"
+        },
+        {
+          "dmxRange": [240, 247],
+          "type": "ColorPreset",
+          "comment": "Macro 27"
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "ColorPreset",
+          "comment": "Random CMY"
+        }
+      ]
+    },
+    "Pan / Tilt Speed": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 225],
+          "type": "PanTiltSpeed",
+          "speedStart": "fast",
+          "speedEnd": "slow"
+        },
+        {
+          "dmxRange": [226, 235],
+          "type": "Maintenance",
+          "comment": "Blackout at movement"
+        },
+        {
+          "dmxRange": [236, 245],
+          "type": "Maintenance",
+          "comment": "Blackout at all wheel movement"
+        },
+        {
+          "dmxRange": [246, 255],
+          "type": "NoFunction"
+        }
+      ]
+    },
+    "Maintenance / Programs": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 19],
+          "type": "Maintenance",
+          "comment": "Color wheel change normal"
+        },
+        {
+          "dmxRange": [20, 29],
+          "type": "Maintenance",
+          "comment": "Color wheel change to any position"
+        },
+        {
+          "dmxRange": [30, 39],
+          "type": "Maintenance",
+          "comment": "Color / Fixed gobo wheel change to any position"
+        },
+        {
+          "dmxRange": [40, 59],
+          "type": "Maintenance",
+          "comment": "Lamp on"
+        },
+        {
+          "dmxRange": [60, 79],
+          "type": "Maintenance",
+          "comment": "Lamp off"
+        },
+        {
+          "dmxRange": [80, 84],
+          "type": "Maintenance",
+          "comment": "All motors reset"
+        },
+        {
+          "dmxRange": [85, 87],
+          "type": "Maintenance",
+          "comment": "Scan motor reset"
+        },
+        {
+          "dmxRange": [88, 90],
+          "type": "Maintenance",
+          "comment": "Color wheel motor reset"
+        },
+        {
+          "dmxRange": [91, 93],
+          "type": "Maintenance",
+          "comment": "Gobo wheel motor reset"
+        },
+        {
+          "dmxRange": [94, 96],
+          "type": "Maintenance",
+          "comment": "Shutter/dimmer motor reset"
+        },
+        {
+          "dmxRange": [97, 99],
+          "type": "Maintenance",
+          "comment": "Other motors reset"
+        },
+        {
+          "dmxRange": [100, 119],
+          "type": "Effect",
+          "effectName": "Internal Program 1"
+        },
+        {
+          "dmxRange": [120, 139],
+          "type": "Effect",
+          "effectName": "Internal Program 2"
+        },
+        {
+          "dmxRange": [140, 159],
+          "type": "Effect",
+          "effectName": "Internal Program 3"
+        },
+        {
+          "dmxRange": [160, 179],
+          "type": "Effect",
+          "effectName": "Internal Program 4"
+        },
+        {
+          "dmxRange": [180, 199],
+          "type": "Effect",
+          "effectName": "Internal Program 5"
+        },
+        {
+          "dmxRange": [200, 219],
+          "type": "Effect",
+          "effectName": "Internal Program 6"
+        },
+        {
+          "dmxRange": [220, 239],
+          "type": "Effect",
+          "effectName": "Internal Program 7"
+        },
+        {
+          "dmxRange": [240, 241],
+          "type": "Maintenance",
+          "comment": "Dimmer curce standard"
+        },
+        {
+          "dmxRange": [242, 243],
+          "type": "Maintenance",
+          "comment": "Dimmer curce linear"
+        },
+        {
+          "dmxRange": [244, 245],
+          "type": "Maintenance",
+          "comment": "Dimmer curce square"
+        },
+        {
+          "dmxRange": [246, 247],
+          "type": "Maintenance",
+          "comment": "Dimmer curce inverse square"
+        },
+        {
+          "dmxRange": [248, 249],
+          "type": "Maintenance",
+          "comment": "Dimmer curce s-curve"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "NoFunction",
+          "comment": "Reserved"
+        }
+      ]
     }
   },
   "modes": [
@@ -1015,7 +1313,10 @@
         "Dimmer",
         "Frost",
         "Animation Wheel",
-        "CMY Speed"
+        "CMY Speed",
+        "CMY Macros",
+        "Pan / Tilt Speed",
+        "Maintenance / Programs"
       ]
     }
   ]

--- a/fixtures/elation/proteus-hybrid.json
+++ b/fixtures/elation/proteus-hybrid.json
@@ -334,76 +334,44 @@
     }
   },
   "availableChannels": {
-    "Pan Movement": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
       "capability": {
         "type": "Pan",
-        "angleStart": "1deg",
-        "angleEnd": "680deg"
+        "angleStart": "0deg",
+        "angleEnd": "630deg"
       }
     },
-    "Pan Movement 2": {
-      "name": "Pan Movement",
-      "fineChannelAliases": ["Pan Movement 2 fine"],
-      "capability": {
-        "type": "PanContinuous",
-        "speed": "slow CCW"
-      }
-    },
-    "Pan Movement 3": {
-      "name": "Pan Movement",
-      "fineChannelAliases": ["Pan Movement 3 fine"],
-      "capability": {
-        "type": "PanContinuous",
-        "speed": "slow CCW"
-      }
-    },
-    "Pan Movement 16": {
-      "fineChannelAliases": ["Pan Movement 16 fine"],
-      "dmxValueResolution": "8bit",
-      "capability": {
-        "type": "PanContinuous",
-        "speed": "slow CCW"
-      }
-    },
-    "Tilt Movement": {
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
       "capability": {
         "type": "Tilt",
-        "angleStart": "1deg",
-        "angleEnd": "300deg"
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
       }
     },
-    "Tilt Movement 16": {
-      "fineChannelAliases": ["Tilt Movement 16 fine"],
-      "dmxValueResolution": "8bit",
+    "Cyan": {
       "capability": {
-        "type": "TiltContinuous",
-        "speed": "slow CCW"
+        "type": "ColorIntensity",
+        "color": "Cyan"
       }
     },
-    "Cyan Color": {
+    "Magenta": {
       "capability": {
-        "type": "ColorPreset",
-        "comment": "Cyan",
-        "colorTemperature": "default"
+        "type": "ColorIntensity",
+        "color": "Magenta"
       }
     },
-    "Magenta Color": {
+    "Yellow": {
       "capability": {
-        "type": "ColorPreset",
-        "comment": "Magenta",
-        "colorTemperature": "default"
+        "type": "ColorIntensity",
+        "color": "Yellow"
       }
     },
-    "Yellow Color": {
-      "capability": {
-        "type": "ColorPreset",
-        "comment": "Yellow"
-      }
-    },
-    "CTO Color": {
+    "CTO": {
       "capability": {
         "type": "ColorTemperature",
-        "colorTemperatureStart": "CTO",
+        "colorTemperatureStart": "default",
         "colorTemperatureEnd": "CTO"
       }
     },
@@ -987,20 +955,20 @@
         }
       ]
     },
-    "Rotatig Prism, Prism Index Rotation": {
+    "Prism Rotation": {
       "capabilities": [
         {
           "dmxRange": [0, 127],
           "type": "PrismRotation",
-          "speedStart": "stop",
-          "speedEnd": "stop"
+          "angleStart": "0deg",
+          "angleEnd": "360deg",
+          "helpWanted": "Correct angle?"
         },
         {
           "dmxRange": [128, 189],
           "type": "PrismRotation",
           "speedStart": "fast CW",
-          "speedEnd": "slow CW",
-          "comment": "Clockwise Prism Rotation from FAST to SLOW"
+          "speedEnd": "slow CW"
         },
         {
           "dmxRange": [190, 193],
@@ -1011,8 +979,7 @@
           "dmxRange": [194, 255],
           "type": "PrismRotation",
           "speedStart": "slow CW",
-          "speedEnd": "fast CW",
-          "comment": "Clockwise Prism Rotation from SLOW to FAST"
+          "speedEnd": "fast CW"
         }
       ]
     },
@@ -1030,12 +997,14 @@
         "angleEnd": "wide"
       }
     },
-    "Autofocus": {
+    "Auto Focus": {
+      "fineChannelAliases": ["Auto Focus fine"],
+      "dmxValueResolution": "8bit",
       "capabilities": [
         {
           "dmxRange": [0, 50],
-          "type": "Focus",
-          "distance": "near"
+          "type": "NoFunction",
+          "comment": "Off"
         },
         {
           "dmxRange": [51, 150],
@@ -1048,34 +1017,6 @@
           "distance": "20m"
         }
       ]
-    },
-    "Autofocus f": {
-      "fineChannelAliases": ["Autofocus f fine"],
-      "dmxValueResolution": "8bit",
-      "capability": {
-        "type": "Focus",
-        "distanceStart": "near",
-        "distanceEnd": "far"
-      }
-    },
-    "Autofocus 2": {
-      "name": "Autofocus",
-      "fineChannelAliases": ["Autofocus 2 fine"],
-      "dmxValueResolution": "8bit",
-      "capability": {
-        "type": "Focus",
-        "distanceStart": "near",
-        "distanceEnd": "far"
-      }
-    },
-    "AutoFocus": {
-      "fineChannelAliases": ["AutoFocus fine"],
-      "dmxValueResolution": "8bit",
-      "capability": {
-        "type": "Focus",
-        "distanceStart": "near",
-        "distanceEnd": "far"
-      }
     },
     "Shutter / Strobe": {
       "capabilities": [
@@ -1092,7 +1033,7 @@
         {
           "dmxRange": [64, 95],
           "type": "ShutterStrobe",
-          "shutterEffect": "RampUp",
+          "shutterEffect": "Strobe",
           "speedStart": "slow",
           "speedEnd": "fast"
         },
@@ -1114,9 +1055,10 @@
         {
           "dmxRange": [192, 223],
           "type": "ShutterStrobe",
-          "shutterEffect": "RampUpDown",
+          "shutterEffect": "Strobe",
           "speedStart": "slow",
-          "speedEnd": "fast"
+          "speedEnd": "fast",
+          "randomTiming": true
         },
         {
           "dmxRange": [224, 255],
@@ -1140,8 +1082,7 @@
         {
           "dmxRange": [128, 255],
           "type": "Frost",
-          "frostIntensityStart": "off",
-          "frostIntensityEnd": "high"
+          "frostIntensity": "high"
         }
       ]
     },
@@ -1184,24 +1125,24 @@
       "name": "Standard",
       "shortName": "Stand",
       "channels": [
-        "Pan Movement",
-        "Pan Movement 16",
-        "Tilt Movement",
-        "Tilt Movement 16",
-        "Cyan Color",
-        "Magenta Color",
-        "Yellow Color",
-        "CTO Color",
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Cyan",
+        "Magenta",
+        "Yellow",
+        "CTO",
         "Color Wheel",
         "Rotating Gobos, Continuous Rotation(Gobo Wheel 1)",
         "Rotating Gobos, Index Rotation(Gobo Wheel 1)",
         "Static/Fixed Gobos(Gobo Wheel 2)",
         "Rotating Prism, Prism/Gobo Macros",
-        "Rotatig Prism, Prism Index Rotation",
+        "Prism Rotation",
         "Focus",
         "Zoom",
-        "AutoFocus",
-        "AutoFocus fine",
+        "Auto Focus",
+        "Auto Focus fine",
         "Shutter / Strobe",
         "Dimmer",
         "Frost",


### PR DESCRIPTION
* Add fixture 'elation/proteus-hybrid'

### Fixture warnings / errors

* elation/proteus-hybrid
  - :x: Capability 'Pan slow CCW' (0…65535) in channel 'Pan Movement 2' defines continuous pan but focus.panMax in the fixture's physical data is not "infinite".
  - :x: Capability 'Pan slow CCW' (0…65535) in channel 'Pan Movement 3' defines continuous pan but focus.panMax in the fixture's physical data is not "infinite".
  - :x: Capability 'Pan slow CCW' (0…255) in channel 'Pan Movement 16' defines continuous pan but focus.panMax in the fixture's physical data is not "infinite".
  - :x: Capability 'Tilt 1…300°' (0…255) in channel 'Tilt Movement' uses an angle range that is greater than focus.tiltMax in the fixture's physical data.
  - :x: Capability 'Tilt slow CCW' (0…255) in channel 'Tilt Movement 16' defines continuous tilt but focus.tiltMax in the fixture's physical data is not "infinite".
  - :x: Capability 'Wheel rotation CW slow…fast (Clockwise COLOR Rotation from FAST to SLOW)' (128…189) in channel 'Color Wheel' does not explicitly reference any wheel, but the default wheel 'Color Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation stop' (190…193) in channel 'Color Wheel' does not explicitly reference any wheel, but the default wheel 'Color Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW fast…slow' (194…255) in channel 'Color Wheel' does not explicitly reference any wheel, but the default wheel 'Color Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation slow CW (Gobo indexing)' (0…127) in channel 'Rotating Gobos, Index Rotation(Gobo Wheel 1)' does not explicitly reference any wheel, but the default wheel 'Rotating Gobos, Index Rotation(Gobo Wheel 1)' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW fast…slow (Clockwise Gobo Rotation from FAST to SLOW)' (128…189) in channel 'Rotating Gobos, Index Rotation(Gobo Wheel 1)' does not explicitly reference any wheel, but the default wheel 'Rotating Gobos, Index Rotation(Gobo Wheel 1)' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation stop (No Rotation)' (190…193) in channel 'Rotating Gobos, Index Rotation(Gobo Wheel 1)' does not explicitly reference any wheel, but the default wheel 'Rotating Gobos, Index Rotation(Gobo Wheel 1)' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (194…255) in channel 'Rotating Gobos, Index Rotation(Gobo Wheel 1)' does not explicitly reference any wheel, but the default wheel 'Rotating Gobos, Index Rotation(Gobo Wheel 1)' (through the channel name) does not exist.
  - :x: Channel key 'AutoFocus' is already defined (maybe in another letter case).
  - :warning: Name of wheel 'Rotating Prism, Prism/Gobo Macros' does not contain the word 'wheel' or 'disk', which could lead to confusing capability names.
  - :warning: Unused channel(s): pan movement 2, pan movement 2 fine, pan movement 3, pan movement 3 fine, pan movement 16 fine, tilt movement 16 fine, autofocus f, autofocus f fine, autofocus 2, autofocus 2 fine
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **MeroChat**!