### PR TITLE
Restrict min/max percent DMX values in editor

### DIFF
--- a/ui/components/editor-channel-dialog.vue
+++ b/ui/components/editor-channel-dialog.vue
@@ -127,7 +127,8 @@
           <app-property-input-entity
             v-model="channel.defaultValue"
             :schema-property="properties.channel.defaultValue"
-            :max-number="dmxMax"
+            :min-number="0"
+            :max-number="(typeof channel.defaultValue) === `string` ? 100 : dmxMax"
             class="wide"
             name="defaultValue" />
         </app-labeled-input>
@@ -187,7 +188,8 @@
           <app-property-input-entity
             v-model="channel.highlightValue"
             :schema-property="properties.channel.highlightValue"
-            :max-number="dmxMax"
+            :min-number="0"
+            :max-number="(typeof channel.highlightValue) === `string` ? 100 : dmxMax"
             class="wide"
             name="highlightValue" />
         </app-labeled-input>

--- a/ui/components/property-input-entity.vue
+++ b/ui/components/property-input-entity.vue
@@ -7,7 +7,8 @@
         v-model="selectedNumber"
         :schema-property="units[selectedUnit].numberSchema"
         :required="true"
-        :maximum="selectedUnitIsNumber && maxNumber !== null ? maxNumber : `invalid`"
+        :minimum="minNumber !== null ? minNumber : `invalid`"
+        :maximum="maxNumber !== null ? maxNumber : `invalid`"
         :name="name ? `${name}-number` : null"
         @focus.native="onFocus"
         @blur.native="onBlur($event)" />
@@ -110,6 +111,11 @@ export default {
       required: false,
       default: ``
     },
+    minNumber: {
+      type: Number,
+      required: false,
+      default: null
+    },
     maxNumber: {
       type: Number,
       required: false,
@@ -188,10 +194,6 @@ export default {
     },
     hasNumber() {
       return hasNumber(this.selectedUnit, this.enumValues);
-    },
-    selectedUnitIsNumber() {
-      const selectedUnitObj = this.properties.units[this.selectedUnit];
-      return selectedUnitObj && !(`pattern` in selectedUnitObj);
     },
     selectedNumber: {
       get() {


### PR DESCRIPTION
Until now, the `max-number` property did not affect percentaged default/highlight values. That's why the newly created fixture #936 could have a default value of 255% (which should be forbidden).