### PR TITLE
Add fixture 'generic/drgbwspx'

### DIFF
--- a/fixtures/generic/drgbwspx.json
+++ b/fixtures/generic/drgbwspx.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "DRGBWSPx",
+  "categories": ["Dimmer", "Color Changer", "Strobe"],
+  "meta": {
+    "authors": ["GVC"],
+    "createDate": "2019-07-04",
+    "lastModifyDate": "2019-07-04"
+  },
+  "comment": "GVCcustom",
+  "links": {
+    "manual": [
+      "https://open-fixture-library.org/fixture-editor"
+    ]
+  },
+  "wheels": {
+    "Reserved": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe Speed": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "0Hz",
+        "speedEnd": "255Hz"
+      }
+    },
+    "Reserved": {
+      "capability": {
+        "type": "WheelSlot",
+        "slotNumber": 1
+      }
+    },
+    "No function": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Reserved 2": {
+      "name": "Reserved",
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Reserved 3": {
+      "name": "Reserved",
+      "capability": {
+        "type": "NoFunction"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "GVC",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe Speed",
+        "Reserved 3",
+        "No function"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'generic/drgbwspx'

### Fixture warnings / errors

* generic/drgbwspx
  - :warning: Name of wheel 'Reserved' does not contain the word 'wheel' or 'disk', which could lead to confusing capability names.
  - :warning: Unused channel(s): reserved, reserved 2
  - :warning: Unused wheel slot(s): Reserved (slot 2), Reserved (slot 3), Reserved (slot 4), Reserved (slot 5), Reserved (slot 6), Reserved (slot 7), Reserved (slot 8), Reserved (slot 9), Reserved (slot 10), Reserved (slot 11), Reserved (slot 12), Reserved (slot 13), Reserved (slot 14), Reserved (slot 15)


Thank you **GVC**!