### PR TITLE
Fix missing `await` in create GitHub PR function

### DIFF
--- a/lib/create-github-pr.js
+++ b/lib/create-github-pr.js
@@ -213,7 +213,7 @@ module.exports = async function createPullRequest(out) {
     const appendToCommitMessage = excludeFromCi ? `\n\n[skip ci]` : ``;
 
     try {
-      const result = githubClient.repos.getContents({
+      const result = await githubClient.repos.getContents({
         owner: `OpenLightingProject`,
         repo: repository,
         path: filename


### PR DESCRIPTION
Missed that one in #943 :disappointed: 

This caused the file creation error in #960.