### PR TITLE
Add fixture 'chauvet/intimidator-spot-260'

### DIFF
--- a/fixtures/chauvet-dj/intimidator-spot-260.json
+++ b/fixtures/chauvet-dj/intimidator-spot-260.json
@@ -39,9 +39,7 @@
     "Color Wheel": {
       "slots": [
         {
-          "type": "Color",
-          "name": "White",
-          "colors": ["#ffffff"]
+          "type": "Open"
         },
         {
           "type": "Color",
@@ -82,11 +80,6 @@
           "type": "Color",
           "name": "Dark Blue",
           "colors": ["#0000ff"]
-        },
-        {
-          "type": "Color",
-          "name": "White",
-          "colors": ["#ffffff"]
         }
       ]
     },
@@ -96,52 +89,40 @@
           "type": "Open"
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 1"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 2"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 3"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 4"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 5"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 6"
+          "type": "Gobo"
         },
         {
-          "type": "Gobo",
-          "name": "Gobo 7"
-        },
-        {
-          "type": "Open"
+          "type": "Gobo"
         }
       ]
     }
   },
   "availableChannels": {
-    "Pan Coarse": {
-      "fineChannelAliases": ["Pan Fine"],
-      "defaultValue": 0,
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
       "capability": {
         "type": "Pan",
         "angleStart": "0deg",
         "angleEnd": "540deg"
       }
     },
-    "Tilt Coarse": {
-      "fineChannelAliases": ["Tilt Fine"],
-      "defaultValue": 0,
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
       "capability": {
         "type": "Tilt",
         "angleStart": "0deg",
@@ -162,90 +143,76 @@
         {
           "dmxRange": [0, 6],
           "type": "WheelSlot",
-          "slotNumber": 1,
-          "comment": "White"
+          "slotNumber": 1
         },
         {
           "dmxRange": [7, 13],
           "type": "WheelSlot",
-          "slotNumber": 2,
-          "comment": "Orange"
+          "slotNumber": 2
         },
         {
           "dmxRange": [14, 20],
           "type": "WheelSlot",
-          "slotNumber": 3,
-          "comment": "Lime Green"
+          "slotNumber": 3
         },
         {
           "dmxRange": [21, 27],
           "type": "WheelSlot",
-          "slotNumber": 4,
-          "comment": "Cyan"
+          "slotNumber": 4
         },
         {
           "dmxRange": [28, 34],
           "type": "WheelSlot",
-          "slotNumber": 5,
-          "comment": "Red"
+          "slotNumber": 5
         },
         {
           "dmxRange": [35, 41],
           "type": "WheelSlot",
-          "slotNumber": 6,
-          "comment": "Green"
+          "slotNumber": 6
         },
         {
           "dmxRange": [42, 48],
           "type": "WheelSlot",
-          "slotNumber": 7,
-          "comment": "Magenta"
+          "slotNumber": 7
         },
         {
           "dmxRange": [49, 55],
           "type": "WheelSlot",
-          "slotNumber": 8,
-          "comment": "Yellow"
+          "slotNumber": 8
         },
         {
           "dmxRange": [56, 62],
           "type": "WheelSlot",
-          "slotNumber": 9,
-          "comment": "Dark Blue"
+          "slotNumber": 9
         },
         {
           "dmxRange": [63, 64],
           "type": "WheelSlot",
-          "slotNumber": 10,
-          "comment": "White"
+          "slotNumber": 1
         },
         {
           "dmxRange": [65, 189],
           "type": "WheelRotation",
           "angleStart": "0deg",
           "angleEnd": "360deg",
-          "helpWanted": "Are these the correct angles?",
-          "comment": "Color indexing"
+          "helpWanted": "Are these the correct angles?"
         },
         {
           "dmxRange": [190, 221],
           "type": "WheelRotation",
           "speedStart": "fast CW",
-          "speedEnd": "slow CW",
-          "comment": "Color cycling rainbow, fast to slow"
+          "speedEnd": "slow CW"
         },
         {
           "dmxRange": [222, 223],
           "type": "WheelRotation",
-          "speed": "stop",
-          "comment": "Stop"
+          "speed": "stop"
         },
         {
           "dmxRange": [224, 255],
           "type": "WheelRotation",
           "speedStart": "slow CCW",
-          "speedEnd": "fast CCW",
-          "comment": "Reverse color cycling rainbow, slow to fast"
+          "speedEnd": "fast CCW"
         }
       ]
     },
@@ -255,132 +222,113 @@
         {
           "dmxRange": [0, 7],
           "type": "WheelSlot",
-          "slotNumber": 1,
-          "comment": "Open"
+          "slotNumber": 1
         },
         {
           "dmxRange": [8, 15],
           "type": "WheelSlot",
-          "slotNumber": 2,
-          "comment": "Gobo 1"
+          "slotNumber": 2
         },
         {
           "dmxRange": [16, 23],
           "type": "WheelSlot",
-          "slotNumber": 3,
-          "comment": "Gobo 2"
+          "slotNumber": 3
         },
         {
           "dmxRange": [24, 31],
           "type": "WheelSlot",
-          "slotNumber": 4,
-          "comment": "Gobo 3"
+          "slotNumber": 4
         },
         {
           "dmxRange": [32, 39],
           "type": "WheelSlot",
-          "slotNumber": 5,
-          "comment": "Gobo 4"
+          "slotNumber": 5
         },
         {
           "dmxRange": [40, 47],
           "type": "WheelSlot",
-          "slotNumber": 6,
-          "comment": "Gobo 5"
+          "slotNumber": 6
         },
         {
           "dmxRange": [48, 55],
           "type": "WheelSlot",
-          "slotNumber": 7,
-          "comment": "Gobo 6"
+          "slotNumber": 7
         },
         {
           "dmxRange": [56, 63],
           "type": "WheelSlot",
-          "slotNumber": 8,
-          "comment": "Gobo 7"
+          "slotNumber": 8
         },
         {
           "dmxRange": [64, 71],
           "type": "WheelShake",
-          "slotNumber": 9,
+          "slotNumber": 8,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "comment": "Gobo 7 shake, slow to fast"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [72, 79],
           "type": "WheelShake",
-          "slotNumber": 10,
+          "slotNumber": 7,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "comment": "Gobo 6 shake, slow to fast"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [80, 87],
           "type": "WheelShake",
-          "slotNumber": 11,
+          "slotNumber": 6,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "comment": "Gobo 5 shake, slow to fast"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [88, 95],
           "type": "WheelShake",
-          "slotNumber": 12,
+          "slotNumber": 5,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "comment": "Gobo 4 shake, slow to fast"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [96, 103],
           "type": "WheelShake",
-          "slotNumber": 13,
+          "slotNumber": 4,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "comment": "Gobo 3 shake, slow to fast"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [104, 111],
           "type": "WheelShake",
-          "slotNumber": 14,
+          "slotNumber": 3,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "comment": "Gobo 2 shake, slow to fast"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [112, 119],
           "type": "WheelShake",
-          "slotNumber": 15,
+          "slotNumber": 2,
           "shakeSpeedStart": "slow",
-          "shakeSpeedEnd": "fast",
-          "comment": "Gobo 1 shake, slow to fast"
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [120, 127],
           "type": "WheelSlot",
-          "slotNumber": 16,
-          "comment": "Open"
+          "slotNumber": 1
         },
         {
           "dmxRange": [128, 189],
           "type": "WheelRotation",
           "speedStart": "slow CW",
-          "speedEnd": "fast CW",
-          "comment": "Cycle effect, slow to fast"
+          "speedEnd": "fast CW"
         },
         {
           "dmxRange": [190, 193],
           "type": "WheelRotation",
-          "speed": "stop",
-          "comment": "Stop"
+          "speed": "stop"
         },
         {
           "dmxRange": [194, 255],
           "type": "WheelRotation",
           "speedStart": "slow CCW",
-          "speedEnd": "fast CCW",
-          "comment": "Reverse cycle effect, slow to fast"
+          "speedEnd": "fast CCW"
         }
       ]
     },
@@ -389,66 +337,57 @@
       "capabilities": [
         {
           "dmxRange": [0, 7],
-          "type": "WheelSlotRotation",
-          "wheel": "",
-          "speed": "stop",
-          "comment": "No function"
+          "type": "NoFunction"
         },
         {
           "dmxRange": [8, 119],
           "type": "WheelSlotRotation",
-          "wheel": "",
+          "wheel": "Gobo Wheel",
           "speedStart": "slow CW",
-          "speedEnd": "fast CW",
-          "comment": "Gobo rotation, slow to fast"
+          "speedEnd": "fast CW"
         },
         {
           "dmxRange": [120, 231],
           "type": "WheelSlotRotation",
-          "wheel": "",
+          "wheel": "Gobo Wheel",
           "speedStart": "slow CCW",
-          "speedEnd": "fast CCW",
-          "comment": "Reverse gobo rotation, slow to fast"
+          "speedEnd": "fast CCW"
         },
         {
           "dmxRange": [232, 255],
-          "type": "Speed",
-          "speedStart": "fast",
-          "speedEnd": "slow",
-          "comment": "Gobo bounce, short to long"
+          "type": "Effect",
+          "effectName": "Gobo bounce",
+          "durationStart": "short",
+          "durationEnd": "long"
         }
       ]
     },
     "Strobe": {
-      "defaultValue": 0,
+      "defaultValue": 4,
       "capabilities": [
         {
           "dmxRange": [0, 3],
           "type": "ShutterStrobe",
-          "shutterEffect": "Closed",
-          "comment": "Off"
+          "shutterEffect": "Closed"
         },
         {
           "dmxRange": [4, 7],
           "type": "ShutterStrobe",
-          "shutterEffect": "Open",
-          "comment": "On"
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [8, 76],
           "type": "ShutterStrobe",
           "shutterEffect": "Strobe",
-          "speedStart": "slow",
-          "speedEnd": "fast",
-          "comment": "Strobe, slow to fast"
+          "speedStart": "0Hz",
+          "speedEnd": "20.6Hz"
         },
         {
           "dmxRange": [77, 145],
           "type": "ShutterStrobe",
           "shutterEffect": "Pulse",
           "speedStart": "slow",
-          "speedEnd": "fast",
-          "comment": "Pulse strobe, slow to fast"
+          "speedEnd": "fast"
         },
         {
           "dmxRange": [146, 215],
@@ -456,14 +395,12 @@
           "shutterEffect": "Strobe",
           "speedStart": "slow",
           "speedEnd": "fast",
-          "randomTiming": true,
-          "comment": "Random strobe, slow to fast"
+          "randomTiming": true
         },
         {
           "dmxRange": [216, 255],
           "type": "ShutterStrobe",
-          "shutterEffect": "Open",
-          "comment": "On"
+          "shutterEffect": "Open"
         }
       ]
     },
@@ -511,7 +448,7 @@
           "comment": "Blackout on pan/tilt/color/gobo wheel movement"
         },
         {
-          "dmxRange": [59, 95],
+          "dmxRange": [56, 95],
           "type": "NoFunction"
         },
         {
@@ -609,49 +546,49 @@
         {
           "dmxRange": [136, 151],
           "type": "Effect",
-          "effectName": "Sound-Active movement macro 1",
+          "effectName": "Sound-active movement macro 1",
           "soundControlled": true
         },
         {
           "dmxRange": [152, 167],
           "type": "Effect",
-          "effectName": "Sound-Active movement macro 2",
+          "effectName": "Sound-active movement macro 2",
           "soundControlled": true
         },
         {
           "dmxRange": [168, 183],
           "type": "Effect",
-          "effectName": "Sound-Active movement macro 3",
+          "effectName": "Sound-active movement macro 3",
           "soundControlled": true
         },
         {
           "dmxRange": [184, 199],
           "type": "Effect",
-          "effectName": "Sound-Active movement macro 4",
+          "effectName": "Sound-active movement macro 4",
           "soundControlled": true
         },
         {
           "dmxRange": [200, 215],
           "type": "Effect",
-          "effectName": "Sound-Active movement macro 5",
+          "effectName": "Sound-active movement macro 5",
           "soundControlled": true
         },
         {
           "dmxRange": [216, 231],
           "type": "Effect",
-          "effectName": "Sound-Active movement macro 6",
+          "effectName": "Sound-active movement macro 6",
           "soundControlled": true
         },
         {
           "dmxRange": [232, 247],
           "type": "Effect",
-          "effectName": "Sound-Active movement macro 7",
+          "effectName": "Sound-active movement macro 7",
           "soundControlled": true
         },
         {
           "dmxRange": [248, 255],
           "type": "Effect",
-          "effectName": "Sound-Active movement macro 8",
+          "effectName": "Sound-active movement macro 8",
           "soundControlled": true
         }
       ]
@@ -661,39 +598,39 @@
       "capabilities": [
         {
           "dmxRange": [0, 15],
-          "type": "NoFunction",
-          "comment": "No function"
+          "type": "NoFunction"
         },
         {
           "dmxRange": [16, 255],
           "type": "Prism",
-          "comment": "3-facet prism"
+          "comment": "3-facet"
         }
       ]
     },
-    "Focus": {
+    "Zoom": {
       "defaultValue": 0,
       "capability": {
         "type": "Zoom",
-        "angleStart": "wide",
-        "angleEnd": "narrow"
+        "angleStart": "17deg",
+        "angleEnd": "12deg"
       }
     }
   },
   "modes": [
     {
-      "name": "Advanced",
+      "name": "14-channel",
+      "shortName": "14ch",
       "channels": [
-        "Pan Coarse",
-        "Pan Fine",
-        "Tilt Coarse",
-        "Tilt Fine",
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
         "Pan/Tilt Speed",
-        "Color",
-        "Gobo",
+        "Color Wheel",
+        "Gobo Wheel",
         "Gobo Rotation",
         "Prism",
-        "Focus",
+        "Zoom",
         "Dimmer",
         "Strobe",
         "Function",
@@ -701,15 +638,16 @@
       ]
     },
     {
-      "name": "Basic",
+      "name": "8-channel",
+      "shortName": "8ch",
       "channels": [
-        "Pan Coarse",
-        "Tilt Coarse",
-        "Color",
-        "Gobo",
+        "Pan",
+        "Tilt",
+        "Color Wheel",
+        "Gobo Wheel",
         "Gobo Rotation",
         "Prism",
-        "Focus",
+        "Zoom",
         "Strobe"
       ]
     }

--- a/fixtures/chauvet-dj/intimidator-spot-260.json
+++ b/fixtures/chauvet-dj/intimidator-spot-260.json
@@ -1,27 +1,37 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "Intimidator Spot 260",
-  "categories": ["Moving Head"],
+  "categories": ["Moving Head", "Color Changer"],
   "meta": {
     "authors": ["Peter Chave", "Felix Edelmann"],
-    "createDate": "2019-08-09",
-    "lastModifyDate": "2019-08-09",
+    "createDate": "2019-08-22",
+    "lastModifyDate": "2019-08-22",
     "importPlugin": {
       "plugin": "qlcplus_4.12.1",
-      "date": "2019-08-09",
+      "date": "2019-08-22",
       "comment": "created by Q Light Controller Plus (version 4.12.2 GIT)"
     }
   },
+  "links": {
+    "manual": [
+      "https://www.chauvetdj.com/wp-content/uploads/2018/08/Intimidator_Spot_260_UM_Rev3.pdf"
+    ],
+    "productPage": [
+      "https://www.chauvetdj.com/products/intimidator-spot-260/"
+    ],
+    "video": [
+      "https://youtu.be/PW1Yz53xUyk"
+    ]
+  },
   "physical": {
-    "dimensions": [232, 163, 351],
+    "dimensions": [232, 351, 163],
     "weight": 5.6,
     "power": 107,
     "DMXconnector": "3-pin",
     "bulb": {
-      "type": "LED 75W"
+      "type": "White 75W LED"
     },
     "lens": {
-      "name": "Other",
       "degreesMinMax": [12, 17]
     }
   },

--- a/fixtures/chauvet-dj/intimidator-spot-260.json
+++ b/fixtures/chauvet-dj/intimidator-spot-260.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Intimidator Spot LED 260",
+  "name": "Intimidator Spot 260",
   "categories": ["Moving Head"],
   "meta": {
     "authors": ["Peter Chave", "Felix Edelmann"],

--- a/fixtures/chauvet/intimidator-spot-led-260.json
+++ b/fixtures/chauvet/intimidator-spot-led-260.json
@@ -1,0 +1,707 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Intimidator Spot LED 260",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Peter Chave", "Felix Edelmann"],
+    "createDate": "2019-08-09",
+    "lastModifyDate": "2019-08-09",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2019-08-09",
+      "comment": "created by Q Light Controller Plus (version 4.12.2 GIT)"
+    }
+  },
+  "physical": {
+    "dimensions": [232, 163, 351],
+    "weight": 5.6,
+    "power": 107,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED 75W"
+    },
+    "lens": {
+      "name": "Other",
+      "degreesMinMax": [12, 17]
+    }
+  },
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        {
+          "type": "Color",
+          "name": "White",
+          "colors": ["#ffffff"]
+        },
+        {
+          "type": "Color",
+          "name": "Orange",
+          "colors": ["#fd8008"]
+        },
+        {
+          "type": "Color",
+          "name": "Lime Green",
+          "colors": ["#ccff66"]
+        },
+        {
+          "type": "Color",
+          "name": "Cyan",
+          "colors": ["#20ffff"]
+        },
+        {
+          "type": "Color",
+          "name": "Red",
+          "colors": ["#ff0000"]
+        },
+        {
+          "type": "Color",
+          "name": "Green",
+          "colors": ["#21ff06"]
+        },
+        {
+          "type": "Color",
+          "name": "Magenta",
+          "colors": ["#fc02ff"]
+        },
+        {
+          "type": "Color",
+          "name": "Yellow",
+          "colors": ["#ffff0a"]
+        },
+        {
+          "type": "Color",
+          "name": "Dark Blue",
+          "colors": ["#0000ff"]
+        },
+        {
+          "type": "Color",
+          "name": "White",
+          "colors": ["#ffffff"]
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 1"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 2"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 3"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 4"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 5"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 6"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 7"
+        },
+        {
+          "type": "Open"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan Coarse": {
+      "fineChannelAliases": ["Pan Fine"],
+      "defaultValue": 0,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt Coarse": {
+      "fineChannelAliases": ["Tilt Fine"],
+      "defaultValue": 0,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Color Wheel": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 6],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "White"
+        },
+        {
+          "dmxRange": [7, 13],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [14, 20],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Lime Green"
+        },
+        {
+          "dmxRange": [21, 27],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Cyan"
+        },
+        {
+          "dmxRange": [28, 34],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [35, 41],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [42, 48],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "Magenta"
+        },
+        {
+          "dmxRange": [49, 55],
+          "type": "WheelSlot",
+          "slotNumber": 8,
+          "comment": "Yellow"
+        },
+        {
+          "dmxRange": [56, 62],
+          "type": "WheelSlot",
+          "slotNumber": 9,
+          "comment": "Dark Blue"
+        },
+        {
+          "dmxRange": [63, 64],
+          "type": "WheelSlot",
+          "slotNumber": 10,
+          "comment": "White"
+        },
+        {
+          "dmxRange": [65, 189],
+          "type": "WheelRotation",
+          "angleStart": "0deg",
+          "angleEnd": "360deg",
+          "helpWanted": "Are these the correct angles?",
+          "comment": "Color indexing"
+        },
+        {
+          "dmxRange": [190, 221],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW",
+          "comment": "Color cycling rainbow, fast to slow"
+        },
+        {
+          "dmxRange": [222, 223],
+          "type": "WheelRotation",
+          "speed": "stop",
+          "comment": "Stop"
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW",
+          "comment": "Reverse color cycling rainbow, slow to fast"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Gobo 1"
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Gobo 2"
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Gobo 3"
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "Gobo 4"
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "Gobo 5"
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "Gobo 6"
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 8,
+          "comment": "Gobo 7"
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "WheelShake",
+          "slotNumber": 9,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 7 shake, slow to fast"
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "WheelShake",
+          "slotNumber": 10,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 6 shake, slow to fast"
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "WheelShake",
+          "slotNumber": 11,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 5 shake, slow to fast"
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "WheelShake",
+          "slotNumber": 12,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 4 shake, slow to fast"
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "WheelShake",
+          "slotNumber": 13,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 3 shake, slow to fast"
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "WheelShake",
+          "slotNumber": 14,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 2 shake, slow to fast"
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "WheelShake",
+          "slotNumber": 15,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast",
+          "comment": "Gobo 1 shake, slow to fast"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelSlot",
+          "slotNumber": 16,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "Cycle effect, slow to fast"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "WheelRotation",
+          "speed": "stop",
+          "comment": "Stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW",
+          "comment": "Reverse cycle effect, slow to fast"
+        }
+      ]
+    },
+    "Gobo Rotation": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlotRotation",
+          "wheel": "",
+          "speed": "stop",
+          "comment": "No function"
+        },
+        {
+          "dmxRange": [8, 119],
+          "type": "WheelSlotRotation",
+          "wheel": "",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "Gobo rotation, slow to fast"
+        },
+        {
+          "dmxRange": [120, 231],
+          "type": "WheelSlotRotation",
+          "wheel": "",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW",
+          "comment": "Reverse gobo rotation, slow to fast"
+        },
+        {
+          "dmxRange": [232, 255],
+          "type": "Speed",
+          "speedStart": "fast",
+          "speedEnd": "slow",
+          "comment": "Gobo bounce, short to long"
+        }
+      ]
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 3],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed",
+          "comment": "Off"
+        },
+        {
+          "dmxRange": [4, 7],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open",
+          "comment": "On"
+        },
+        {
+          "dmxRange": [8, 76],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Strobe, slow to fast"
+        },
+        {
+          "dmxRange": [77, 145],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Pulse strobe, slow to fast"
+        },
+        {
+          "dmxRange": [146, 215],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "randomTiming": true,
+          "comment": "Random strobe, slow to fast"
+        },
+        {
+          "dmxRange": [216, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open",
+          "comment": "On"
+        }
+      ]
+    },
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Function": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "Maintenance",
+          "comment": "Blackout on pan/tilt movement"
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "Maintenance",
+          "comment": "Blackout on color wheel movement"
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "Maintenance",
+          "comment": "Blackout on gobo wheel movement"
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "Maintenance",
+          "comment": "Blackout on pan/tilt/color wheel movement"
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "Maintenance",
+          "comment": "Blackout on pan/tilt/gobo wheel movement"
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "Maintenance",
+          "comment": "Blackout on pan/tilt/color/gobo wheel movement"
+        },
+        {
+          "dmxRange": [59, 95],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "Maintenance",
+          "comment": "Pan reset"
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "Maintenance",
+          "comment": "Tilt reset"
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "Maintenance",
+          "comment": "Color wheel reset"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "Maintenance",
+          "comment": "Gobo wheel reset"
+        },
+        {
+          "dmxRange": [128, 135],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [136, 143],
+          "type": "Maintenance",
+          "comment": "Prism reset"
+        },
+        {
+          "dmxRange": [144, 151],
+          "type": "Maintenance",
+          "comment": "Focus reset"
+        },
+        {
+          "dmxRange": [152, 159],
+          "type": "Maintenance",
+          "comment": "Reset all"
+        },
+        {
+          "dmxRange": [160, 255],
+          "type": "NoFunction"
+        }
+      ]
+    },
+    "Movement Macro": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [8, 23],
+          "type": "Effect",
+          "effectName": "Movement macro 1"
+        },
+        {
+          "dmxRange": [24, 39],
+          "type": "Effect",
+          "effectName": "Movement macro 2"
+        },
+        {
+          "dmxRange": [40, 55],
+          "type": "Effect",
+          "effectName": "Movement macro 3"
+        },
+        {
+          "dmxRange": [56, 71],
+          "type": "Effect",
+          "effectName": "Movement macro 4"
+        },
+        {
+          "dmxRange": [72, 87],
+          "type": "Effect",
+          "effectName": "Movement macro 5"
+        },
+        {
+          "dmxRange": [88, 103],
+          "type": "Effect",
+          "effectName": "Movement macro 6"
+        },
+        {
+          "dmxRange": [104, 119],
+          "type": "Effect",
+          "effectName": "Movement macro 7"
+        },
+        {
+          "dmxRange": [120, 135],
+          "type": "Effect",
+          "effectName": "Movement macro 8"
+        },
+        {
+          "dmxRange": [136, 151],
+          "type": "Effect",
+          "effectName": "Sound-Active movement macro 1",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [152, 167],
+          "type": "Effect",
+          "effectName": "Sound-Active movement macro 2",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [168, 183],
+          "type": "Effect",
+          "effectName": "Sound-Active movement macro 3",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [184, 199],
+          "type": "Effect",
+          "effectName": "Sound-Active movement macro 4",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [200, 215],
+          "type": "Effect",
+          "effectName": "Sound-Active movement macro 5",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [216, 231],
+          "type": "Effect",
+          "effectName": "Sound-Active movement macro 6",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [232, 247],
+          "type": "Effect",
+          "effectName": "Sound-Active movement macro 7",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "Effect",
+          "effectName": "Sound-Active movement macro 8",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Prism": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "NoFunction",
+          "comment": "No function"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "Prism",
+          "comment": "3-facet prism"
+        }
+      ]
+    },
+    "Focus": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "wide",
+        "angleEnd": "narrow"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Advanced",
+      "channels": [
+        "Pan Coarse",
+        "Pan Fine",
+        "Tilt Coarse",
+        "Tilt Fine",
+        "Pan/Tilt Speed",
+        "Color",
+        "Gobo",
+        "Gobo Rotation",
+        "Prism",
+        "Focus",
+        "Dimmer",
+        "Strobe",
+        "Function",
+        "Movement Macro"
+      ]
+    },
+    {
+      "name": "Basic",
+      "channels": [
+        "Pan Coarse",
+        "Tilt Coarse",
+        "Color",
+        "Gobo",
+        "Gobo Rotation",
+        "Prism",
+        "Focus",
+        "Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'chauvet/intimidator-spot-led-260'

### Fixture warnings / errors

* chauvet/intimidator-spot-led-260
  - :x: File does not match schema. [ { keyword: 'pattern',
    dataPath:
     '.availableChannels[\'Gobo Rotation\'].capabilities[0].wheel',
    schemaPath:
     '#/properties/availableChannels/additionalProperties/properties/capabilities/items/allOf/0/allOf/15/then/else/properties/wheel/oneOf/0/pattern',
    params: { pattern: '^[^\n]+$' },
    message: 'should match pattern "^[^\n]+$"' },
  { keyword: 'type',
    dataPath:
     '.availableChannels[\'Gobo Rotation\'].capabilities[0].wheel',
    schemaPath:
     '#/properties/availableChannels/additionalProperties/properties/capabilities/items/allOf/0/allOf/15/then/else/properties/wheel/oneOf/1/type',
    params: { type: 'array' },
    message: 'should be array' },
  { keyword: 'oneOf',
    dataPath:
     '.availableChannels[\'Gobo Rotation\'].capabilities[0].wheel',
    schemaPath:
     '#/properties/availableChannels/additionalProperties/properties/capabilities/items/allOf/0/allOf/15/then/else/properties/wheel/oneOf',
    params: { passingSchemas: null },
    message: 'should match exactly one schema in oneOf' },
  [length]: 3 ]
  - :warning: Please check if manufacturer is correct.


### User comment

This is the first fixture to be imported using the QLC+ 4.12.1 import plugin!

Thank you @Fxedel!