### PR TITLE
Disable pm2 cluster mode

### DIFF
--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -25,8 +25,6 @@ module.exports = {
       script: `main.js`,
       cwd: `/home/flo/open-fixture-library`,
       'log_date_format': `YYYY-MM-DD HH:mm:ss Z`,
-      instances: 2,
-      'exec_mode': `cluster`,
       env: envVariablesOfl
     },
     {


### PR DESCRIPTION
We are heaving severe issues in the last time with pm2's cluster mode, which lead to one outdated OFL server instance running besides an up-to-date instance. We should disable pm2 cluster mode until we can fix the issue with the outdated instance.