### PR TITLE
Pin vuedraggable dependency to version 2.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14339,11 +14339,11 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
     "vuedraggable": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.20.0.tgz",
-      "integrity": "sha512-mrSWGkzY40nkgLDuuoxrs6/0u+A7VwXtQRruLQYOVjwd8HcT3BZatRvzw4qVCwJczsAYPbaMubkGOEtzDOzhsQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.22.0.tgz",
+      "integrity": "sha512-5AxSCsmdptB8Gpy/8yDdW3FjnQI5unx+FkBKipZwfXyxvlxhZE6XPLD6SE8Ti5b+0uYqeKoYVpB2fcjgUY6gGw==",
       "requires": {
-        "sortablejs": "^1.8.4"
+        "sortablejs": "^1.9.0"
       }
     },
     "vuex": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "svg-inline-loader": "^0.8.0",
     "uuid": "^3.3.2",
     "vue-form": "^4.10.1",
-    "vuedraggable": "^2.20.0",
+    "vuedraggable": "2.22.0",
     "xml2js": "^0.4.19",
     "xmlbuilder": "^13.0.0"
   },


### PR DESCRIPTION
Closes #1044.

v2.23.1 was released to fix the regression introduced in v2.23.0, but it actually didn't. As soon as a new version is released, we will be notified by Greenkeeper.