### PR TITLE
Add fixture 'briteq/bt-stagepar-6in1'

### DIFF
--- a/fixtures/briteq/bt-stagepar-6in1.json
+++ b/fixtures/briteq/bt-stagepar-6in1.json
@@ -32,31 +32,31 @@
     }
   },
   "availableChannels": {
-    "Rojo": {
+    "Red": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Red"
       }
     },
-    "Verde": {
+    "Green": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Green"
       }
     },
-    "Azul": {
+    "Blue": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Blue"
       }
     },
-    "Blanco": {
+    "White": {
       "capability": {
         "type": "ColorIntensity",
         "color": "White"
       }
     },
-    "Ambar": {
+    "Amber": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Amber"
@@ -73,27 +73,28 @@
         "type": "Intensity"
       }
     },
-    "Estrobo": {
+    "Strobe": {
       "capabilities": [
         {
           "dmxRange": [0, 0],
           "type": "ShutterStrobe",
-          "shutterEffect": "Closed"
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [1, 5],
           "type": "ShutterStrobe",
-          "shutterEffect": "Spikes",
+          "shutterEffect": "Strobe",
           "soundControlled": true
         },
         {
           "dmxRange": [6, 10],
           "type": "ShutterStrobe",
-          "shutterEffect": "Closed"
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [11, 255],
-          "type": "StrobeSpeed",
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
           "speedStart": "slow",
           "speedEnd": "fast"
         }
@@ -102,17 +103,17 @@
   },
   "modes": [
     {
-      "name": "8 channel",
-      "shortName": "8channel",
+      "name": "8-channel",
+      "shortName": "8ch",
       "channels": [
-        "Rojo",
-        "Verde",
-        "Azul",
-        "Blanco",
-        "Ambar",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
         "UV",
         "Dimmer",
-        "Estrobo"
+        "Strobe"
       ]
     }
   ]

--- a/fixtures/briteq/bt-stagepar-6in1.json
+++ b/fixtures/briteq/bt-stagepar-6in1.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "BT-STAGEPAR 6in1",
+  "shortName": "BT-STAGEPAR6in1",
+  "categories": ["Other"],
+  "meta": {
+    "authors": ["josequioss"],
+    "createDate": "2019-10-01",
+    "lastModifyDate": "2019-10-01"
+  },
+  "links": {
+    "manual": [
+      "https://briteq-lighting.com/fr/fileuploader/download/download/?d=0&file=custom%2Fupload%2FFile-1517492038.pdf"
+    ],
+    "productPage": [
+      "https://briteq-lighting.com/fr/bt-stagepar-6in1"
+    ]
+  },
+  "physical": {
+    "dimensions": [300, 275, 300],
+    "weight": 2.5,
+    "power": 120,
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "Rojo": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Verde": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Azul": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Blanco": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Ambar": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "UV": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Estrobo": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [1, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Spikes",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [6, 10],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "8 channel",
+      "shortName": "8channel",
+      "channels": [
+        "Rojo",
+        "Verde",
+        "Azul",
+        "Blanco",
+        "Ambar",
+        "UV",
+        "Dimmer",
+        "Estrobo"
+      ]
+    }
+  ]
+}

--- a/fixtures/briteq/bt-stagepar-6in1.json
+++ b/fixtures/briteq/bt-stagepar-6in1.json
@@ -4,9 +4,9 @@
   "shortName": "BT-STAGEPAR6in1",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["josequioss"],
-    "createDate": "2019-10-01",
-    "lastModifyDate": "2019-10-01"
+    "authors": ["josequioss", "Flo Edelmann"],
+    "createDate": "2019-10-13",
+    "lastModifyDate": "2019-10-13"
   },
   "links": {
     "manual": [

--- a/fixtures/briteq/bt-stagepar-6in1.json
+++ b/fixtures/briteq/bt-stagepar-6in1.json
@@ -88,6 +88,7 @@
       }
     },
     "Simple Strobe": {
+      "name": "Strobe",
       "capability": {
         "type": "ShutterStrobe",
         "shutterEffect": "Strobe",
@@ -150,6 +151,7 @@
       ]
     },
     "Extended Strobe": {
+      "name": "Strobe",
       "capabilities": [
         {
           "dmxRange": [0, 7],

--- a/fixtures/briteq/bt-stagepar-6in1.json
+++ b/fixtures/briteq/bt-stagepar-6in1.json
@@ -32,6 +32,13 @@
     }
   },
   "availableChannels": {
+    "All Colors": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White",
+        "comment": "R+G+B+W+A"
+      }
+    },
     "Red": {
       "capability": {
         "type": "ColorIntensity",
@@ -73,6 +80,48 @@
         "type": "Intensity"
       }
     },
+    "Color Temperature": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "3200K",
+        "colorTemperatureEnd": "10000K"
+      }
+    },
+    "Simple Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX values is strobe disabled?"
+      }
+    },
+    "Dimmer / Chase / Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 190],
+          "type": "Intensity"
+        },
+        {
+          "dmxRange": [191, 200],
+          "type": "Effect",
+          "effectPreset": "ColorJump",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [201, 247],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "Intensity",
+          "brightness": "100%"
+        }
+      ]
+    },
     "Strobe": {
       "capabilities": [
         {
@@ -99,9 +148,114 @@
           "speedEnd": "fast"
         }
       ]
+    },
+    "Extended Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [8, 37],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true
+        },
+        {
+          "dmxRange": [38, 67],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [68, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Programs": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [8, 247],
+          "type": "Effect",
+          "effectPreset": "ColorFade",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "Effect",
+          "effectPreset": "ColorJump",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Color Presets": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [8, 255],
+          "type": "ColorPreset",
+          "helpWanted": "Which color can be selected at which DMX values?"
+        }
+      ]
     }
   },
   "modes": [
+    {
+      "name": "1-channel",
+      "shortName": "1ch",
+      "channels": [
+        "All Colors"
+      ]
+    },
+    {
+      "name": "2-channel",
+      "shortName": "2ch",
+      "channels": [
+        "All Colors",
+        "UV"
+      ]
+    },
+    {
+      "name": "3-channel",
+      "shortName": "3ch",
+      "channels": [
+        "All Colors",
+        "UV",
+        "Simple Strobe"
+      ]
+    },
+    {
+      "name": "3-channel+",
+      "shortName": "3ch+",
+      "channels": [
+        "Dimmer",
+        "Color Temperature",
+        "UV"
+      ]
+    },
+    {
+      "name": "4-channel",
+      "shortName": "4ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Dimmer / Chase / Strobe"
+      ]
+    },
     {
       "name": "8-channel",
       "shortName": "8ch",
@@ -114,6 +268,36 @@
         "UV",
         "Dimmer",
         "Strobe"
+      ]
+    },
+    {
+      "name": "9-channel",
+      "shortName": "9ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV",
+        "Dimmer",
+        "Strobe",
+        "Color Presets"
+      ]
+    },
+    {
+      "name": "9-channel+",
+      "shortName": "9ch+",
+      "channels": [
+        "Dimmer",
+        "Extended Strobe",
+        "Programs",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV"
       ]
     }
   ]

--- a/fixtures/briteq/bt-stagepar-6in1.json
+++ b/fixtures/briteq/bt-stagepar-6in1.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "BT-STAGEPAR 6in1",
   "shortName": "BT-STAGEPAR6in1",
-  "categories": ["Other"],
+  "categories": ["Color Changer"],
   "meta": {
     "authors": ["josequioss"],
     "createDate": "2019-10-01",
@@ -10,17 +10,26 @@
   },
   "links": {
     "manual": [
-      "https://briteq-lighting.com/fr/fileuploader/download/download/?d=0&file=custom%2Fupload%2FFile-1517492038.pdf"
+      "https://briteq-lighting.com/fileuploader/download/download/?d=0&file=custom%2Fupload%2FFile-1517492038.pdf"
     ],
     "productPage": [
-      "https://briteq-lighting.com/fr/bt-stagepar-6in1"
+      "https://briteq-lighting.com/bt-stagepar-6in1"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=dZgixI0Cq5Q"
     ]
   },
   "physical": {
     "dimensions": [300, 275, 300],
-    "weight": 2.5,
+    "weight": 3.5,
     "power": 120,
-    "DMXconnector": "3-pin"
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "12× 12W 6in1 LEDs (Red, Green, Blue, White, Amber, UV)"
+    },
+    "lens": {
+      "degreesMinMax": [25, 25]
+    }
   },
   "availableChannels": {
     "Rojo": {


### PR DESCRIPTION
* Add fixture 'briteq/bt-stagepar-6in1'

### Fixture warnings / errors

* briteq/bt-stagepar-6in1
  - :warning: Mode '8 channel' should have shortName '8ch' instead of '8channel'.
  - :warning: Mode '8 channel' should have shortName '8ch' instead of '8channel'.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **josequioss**!