### PR TITLE
 Use eslint-plugin-jsdoc (closes #1050) 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -169,27 +169,13 @@
   "settings": {
     "jsdoc": {
       "tagNamePreference": {
-        "arg": "param",
-        "argument": "param",
         "augments": "extends",
         "class": "constructor",
-        "const": "constant",
-        "defaultvalue": "default",
-        "desc": "description",
-        "exception": "throws",
         "file": "fileoverview",
         "fires": "emits",
-        "func": "function",
-        "host": "external",
         "linkcode": "link",
         "linkplain": "link",
-        "method": "function",
-        "overview": "fileoverview",
-        "prop": "property",
-        "return": "returns",
-        "var": "member",
-        "virtual": "abstract",
-        "yield": "yields"
+        "overview": "fileoverview"
       },
       "preferredTypes": {
         "array": "Array",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -184,7 +184,7 @@
         "object": "Object",
         "string": "String",
         "<>": ".<>",
-        "[]": "Array"
+        "[]": "Array.<>"
       }
     }
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
     "ecmaVersion": 2017
   },
   "plugins": [
+    "jsdoc",
     "json",
     "markdown",
     "promise",
@@ -15,6 +16,7 @@
   ],
   "extends": [
     "eslint:recommended",
+    "plugin:jsdoc/recommended",
     "plugin:promise/recommended",
     "plugin:security/recommended",
     "plugin:vue/recommended"
@@ -48,6 +50,35 @@
     "getter-return": "error",
     "guard-for-in": "error",
     "indent": ["error", 2, { "SwitchCase": 1 }],
+    "jsdoc/check-alignment": "error",
+    "jsdoc/check-indentation": "error",
+    "jsdoc/check-param-names": "error",
+    "jsdoc/check-syntax": "error",
+    "jsdoc/check-tag-names": "error",
+    "jsdoc/check-types": "error",
+    "jsdoc/implements-on-classes": "error",
+    "jsdoc/newline-after-description": "off",
+    "jsdoc/no-undefined-types": "off",
+    "jsdoc/require-description": "off",
+    "jsdoc/require-description-complete-sentence": "off",
+    "jsdoc/require-jsdoc": ["warn", {
+      "require": {
+        "FunctionDeclaration": true,
+        "MethodDefinition": true,
+        "ClassDeclaration": true,
+        "ArrowFunctionExpression": false,
+        "FunctionExpression": false
+      }
+    }],
+    "jsdoc/require-param": "error",
+    "jsdoc/require-param-description": "error",
+    "jsdoc/require-param-name": "error",
+    "jsdoc/require-param-type": "error",
+    "jsdoc/require-returns": "error",
+    "jsdoc/require-returns-check": "error",
+    "jsdoc/require-returns-description": "error",
+    "jsdoc/require-returns-type": "error",
+    "jsdoc/valid-types": "error",
     "key-spacing": "error",
     "vue/key-spacing": "error",
     "keyword-spacing": "error",
@@ -76,15 +107,6 @@
     "prefer-rest-params": "error",
     "prefer-template": "error",
     "quotes": ["error", "backtick", { "allowTemplateLiterals": true }],
-    "require-jsdoc": ["warn", {
-      "require": {
-        "FunctionDeclaration": true,
-        "MethodDefinition": true,
-        "ClassDeclaration": true,
-        "ArrowFunctionExpression": false,
-        "FunctionExpression": false
-      }
-    }],
     "security/detect-child-process": "off",
     "security/detect-non-literal-fs-filename": "off",
     "security/detect-non-literal-require": "off",
@@ -101,39 +123,6 @@
     "vue/space-infix-ops": "error",
     "spaced-comment": ["error", "always"],
     "template-curly-spacing": "error",
-    "valid-jsdoc": ["error", {
-      "requireReturn": false,
-      "prefer": {
-        "arg": "param",
-        "argument": "param",
-        "augments": "extends",
-        "class": "constructor",
-        "const": "constant",
-        "defaultvalue": "default",
-        "desc": "description",
-        "exception": "throws",
-        "file": "fileoverview",
-        "fires": "emits",
-        "func": "function",
-        "host": "external",
-        "linkcode": "link",
-        "linkplain": "link",
-        "method": "function",
-        "overview": "fileoverview",
-        "prop": "property",
-        "return": "returns",
-        "var": "member",
-        "virtual": "abstract",
-        "yield": "yields"
-      },
-      "preferType": {
-        "array": "Array",
-        "boolean": "Boolean",
-        "number": "Number",
-        "object": "Object",
-        "string": "String"
-      }
-    }],
     "promise/always-return": "off",
     "promise/prefer-await-to-then": "error",
     "promise/no-nesting": "off",
@@ -176,6 +165,42 @@
     "vue/prop-name-casing": "error",
     "vue/require-direct-export": "error",
     "vue/v-on-function-call": "error"
+  },
+  "settings": {
+    "jsdoc": {
+      "tagNamePreference": {
+        "arg": "param",
+        "argument": "param",
+        "augments": "extends",
+        "class": "constructor",
+        "const": "constant",
+        "defaultvalue": "default",
+        "desc": "description",
+        "exception": "throws",
+        "file": "fileoverview",
+        "fires": "emits",
+        "func": "function",
+        "host": "external",
+        "linkcode": "link",
+        "linkplain": "link",
+        "method": "function",
+        "overview": "fileoverview",
+        "prop": "property",
+        "return": "returns",
+        "var": "member",
+        "virtual": "abstract",
+        "yield": "yields"
+      },
+      "preferredTypes": {
+        "array": "Array",
+        "boolean": "Boolean",
+        "number": "Number",
+        "object": "Object",
+        "string": "String",
+        "<>": ".<>",
+        "[]": "Array"
+      }
+    }
   },
   "overrides": [{
     "files": ["**/*.md"],

--- a/docs/fixture-model.md
+++ b/docs/fixture-model.md
@@ -27,6 +27,7 @@ Model properties are always implemented using getters and setters. To store data
 
 Avoid returning `undefined` by returning smart default values if necessary. If the default value is not `null`, also provide a `hasXY` boolean getter function. Properties that need further computation or create other objects should be cached in an internal `_cache` object.
 
+<!-- eslint-disable jsdoc/require-jsdoc -->
 ```js
 export default class Fixture {
   set jsonObject(jsonObject) {

--- a/docs/model-api.md
+++ b/docs/model-api.md
@@ -993,7 +993,7 @@ A physical DMX device.
     * [new Fixture(man, key, jsonObject)](#new_Fixture_new)
     * [.manufacturer](#Fixture+manufacturer)
     * [.manufacturer](#Fixture+manufacturer) ⇒ [<code>Manufacturer</code>](#Manufacturer)
-    * [.key](#Fixture+key)
+    * [.key](#Fixture+key) ⇒ <code>String</code>
     * [.jsonObject](#Fixture+jsonObject)
     * [.jsonObject](#Fixture+jsonObject) ⇒ <code>Object</code>
     * [.url](#Fixture+url) ⇒ <code>String</code>
@@ -1066,13 +1066,9 @@ Create a new Fixture instance.
 **Returns**: [<code>Manufacturer</code>](#Manufacturer) - The fixture's manufacturer.  
 <a name="Fixture+key"></a>
 
-### fixture.key
+### fixture.key ⇒ <code>String</code>
 **Kind**: instance property of [<code>Fixture</code>](#Fixture)  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| key | <code>String</code> | The fixture's unique key. Equals to filename without '.json'. |
-
+**Returns**: <code>String</code> - The fixture's unique key. Equals to filename without '.json'.  
 <a name="Fixture+jsonObject"></a>
 
 ### fixture.jsonObject

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -99,7 +99,7 @@ module.exports.version = `0.1.0`; // semantic versioning of import plugin
  * @param {String} fileName The imported file's name.
  * @param {String} authorName The importer's name.
  * @returns {Promise.<Object, Error>} A Promise that resolves to an out object (see above) or rejects with an error.
- **/
+ */
 module.exports.import = async function importPluginName(buffer, fileName, authorName) {
   const out = {
     manufacturers: {},
@@ -152,7 +152,7 @@ const promisify = require(`util`).promisify;
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
- **/
+ */
 module.exports = async function testValueCorrectness(exportFile) {
   const parser = new xml2js.Parser();
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -44,7 +44,7 @@ module.exports.version = `0.1.0`; // semantic versioning of export plugin
  * @param {Date} options.date The current time.
  * @param {String|undefined} options.displayedPluginVersion Replacement for module.exports.version if the plugin version is used in export.
  * @returns {Promise.<Array.<Object>, Error>} All generated files (see file schema above)
-*/
+ */
 module.exports.export = async function exportPluginName(fixtures, options) {
   const outfiles = [];
 
@@ -98,9 +98,8 @@ module.exports.version = `0.1.0`; // semantic versioning of import plugin
  * @param {Buffer} buffer The imported file.
  * @param {String} fileName The imported file's name.
  * @param {String} authorName The importer's name.
- * @returns {Promise.<Object, Error>} A Promise resolving to an out object
- *                                    (see above) or rejects with an error.
-**/
+ * @returns {Promise.<Object, Error>} A Promise that resolves to an out object (see above) or rejects with an error.
+ **/
 module.exports.import = async function importPluginName(buffer, fileName, authorName) {
   const out = {
     manufacturers: {},
@@ -153,7 +152,7 @@ const promisify = require(`util`).promisify;
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
-**/
+ **/
 module.exports = async function testValueCorrectness(exportFile) {
   const parser = new xml2js.Parser();
 

--- a/lib/create-github-pr.js
+++ b/lib/create-github-pr.js
@@ -6,8 +6,7 @@ require(`./load-env-file.js`);
 const Octokit = require(`@octokit/rest`);
 
 /**
- * @typedef importPluginReturn
- * @type {Object}
+ * @typedef {Object} importPluginReturn
  * @property {Object} manufacturers like in manufacturers.json
  * @property {Object} fixtures Object keys are of the form 'manufacturerKey/fixtureKey', the value is like in fixture JSON files.
  * @property {String|null} submitter GitHub user name of the fixture submitter.
@@ -230,7 +229,7 @@ module.exports = async function createPullRequest(out) {
   /**
    * @callback newContentFunction
    * @param {String|null} oldFileContent The text content of the old file, or null if it has not existed yet.
-   * @return {String} The new file text content.
+   * @returns {String} The new file text content.
    */
 
   /**

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -10,8 +10,7 @@ const mkdirp = promisify(require(`mkdirp`));
 const del = promisify(require(`node-delete`));
 
 /**
- * @typedef PluginDiffOutput
- * @type {Object}
+ * @typedef {Object} PluginDiffOutput
  * @property {Array.<String>} removedFiles Removed outputted files' paths.
  * @property {Array.<String>} addedFiles Added outputted files' paths.
  * @property {Object} changedFiles Changed outputted files' paths pointing to their diff.

--- a/lib/model/AbstractChannel.js
+++ b/lib/model/AbstractChannel.js
@@ -3,7 +3,7 @@
 /**
  * Base class for channels.
  * @abstract
-*/
+ */
 class AbstractChannel {
   /**
    * Create a new AbstractChannel instance. Call this from child classes as `super(key)`.

--- a/lib/model/Fixture.js
+++ b/lib/model/Fixture.js
@@ -73,7 +73,7 @@ class Fixture {
   }
 
   /**
-   * @param {String} key The fixture's unique key. Equals to filename without '.json'.
+   * @returns {String} key The fixture's unique key. Equals to filename without '.json'.
    */
   get key() {
     return this._key;

--- a/lib/model/Fixture.js
+++ b/lib/model/Fixture.js
@@ -73,7 +73,7 @@ class Fixture {
   }
 
   /**
-   * @returns {String} key The fixture's unique key. Equals to filename without '.json'.
+   * @returns {String} The fixture's unique key. Equals to filename without '.json'.
    */
   get key() {
     return this._key;

--- a/lib/model/Mode.js
+++ b/lib/model/Mode.js
@@ -229,7 +229,7 @@ class Mode {
    * @param {String|AbstractChannel} channel Either a channel key or a Channel object.
    * @param {SwitchingChannelBehavior} [switchingChannelBehavior='all'] Controls how switching channels are counted, see {@link SwitchingChannel#usesChannelKey} for possible values.
    * @returns {Number} The index of the given channel in this mode or -1 if not found.
-  */
+   */
   getChannelIndex(channel, switchingChannelBehavior = `all`) {
     const chKey = channel.key || channel;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4123,6 +4123,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
     },
+    "comment-parser": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.6.2.tgz",
+      "integrity": "sha512-Wdms0Q8d4vvb2Yk72OwZjwNWtMklbC5Re7lD9cjCP/AG1fhocmc0TrxGBBAXPLy8fZQPrfHGgyygwI0lA7pbzA==",
+      "dev": true
+    },
     "common-sequence": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-1.0.2.tgz",
@@ -5572,6 +5578,20 @@
           "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "15.9.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-15.9.5.tgz",
+      "integrity": "sha512-OQOUf8Li9PRzULQG8Wi7QOd10aCZVAp/RkqOw0FYPT2j0F9lcPB21jBb6BLlWgR4F7XjdzbUmgVvhHYZGOWCVg==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.6.2",
+        "debug": "^4.1.1",
+        "jsdoctypeparser": "5.0.1",
+        "lodash": "^4.17.15",
+        "object.entries-ponyfill": "^1.0.1",
+        "regextras": "^0.6.1"
       }
     },
     "eslint-plugin-json": {
@@ -8420,6 +8440,12 @@
         "walk-back": "^3.0.1"
       }
     },
+    "jsdoctypeparser": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-5.0.1.tgz",
+      "integrity": "sha512-dYwcK6TKzvq+ZKtbp4sbQSW9JMo6s+4YFfUs5D/K7bZsn3s1NhEhZ+jmIPzby0HbkbECBe+hNPEa6a+E21o94w==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -9860,6 +9886,12 @@
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
       }
+    },
+    "object.entries-ponyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+      "integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
+      "dev": true
     },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
@@ -11743,6 +11775,12 @@
         "unicode-match-property-ecmascript": "^1.0.4",
         "unicode-match-property-value-ecmascript": "^1.1.0"
       }
+    },
+    "regextras": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.6.1.tgz",
+      "integrity": "sha512-EzIHww9xV2Kpqx+corS/I7OBmf2rZ0pKKJPsw5Dc+l6Zq1TslDmtRIP9maVn3UH+72MIXmn8zzDgP07ihQogUA==",
+      "dev": true
     },
     "regjsgen": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dir-compare": "^1.7.1",
     "disparity": "^2.0.0",
     "eslint": "^6.1.0",
+    "eslint-plugin-jsdoc": "^15.9.5",
     "eslint-plugin-json": "^1.3.2",
     "eslint-plugin-markdown": "^1.0.0",
     "eslint-plugin-promise": "^4.2.1",

--- a/plugins/d-light/export.js
+++ b/plugins/d-light/export.js
@@ -18,7 +18,7 @@ module.exports.version = `0.2.0`;
  * @param {Date} options.date The current time.
  * @param {String|undefined} options.displayedPluginVersion Replacement for module.exports.version if the plugin version is used in export.
  * @returns {Promise.<Array.<Object>, Error>} The generated files.
-*/
+ */
 module.exports.export = async function exportDLight(fixtures, options) {
   const deviceFiles = [];
 

--- a/plugins/d-light/exportTests/attributes-correctness.js
+++ b/plugins/d-light/exportTests/attributes-correctness.js
@@ -9,7 +9,7 @@ const promisify = require(`util`).promisify;
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
- **/
+ */
 module.exports = async function testAttributesCorrectness(exportFile) {
   const parser = new xml2js.Parser();
 

--- a/plugins/d-light/exportTests/attributes-correctness.js
+++ b/plugins/d-light/exportTests/attributes-correctness.js
@@ -9,7 +9,7 @@ const promisify = require(`util`).promisify;
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
-**/
+ **/
 module.exports = async function testAttributesCorrectness(exportFile) {
   const parser = new xml2js.Parser();
 

--- a/plugins/ecue/export.js
+++ b/plugins/ecue/export.js
@@ -17,7 +17,7 @@ module.exports.version = `0.3.0`;
  * @param {Date} options.date The current time.
  * @param {String|undefined} options.displayedPluginVersion Replacement for module.exports.version if the plugin version is used in export.
  * @returns {Promise.<Array.<Object>, Error>} The generated files.
-*/
+ */
 module.exports.export = async function exportECue(fixtures, options) {
   const timestamp = dateToString(options.date);
 

--- a/plugins/ecue/import.js
+++ b/plugins/ecue/import.js
@@ -14,7 +14,7 @@ for (const hex of Object.keys(colorNames)) {
  * @param {String} filename The imported file's name.
  * @param {String} authorName The importer's name.
  * @returns {Promise.<Object, Error>} A Promise resolving to an out object
- **/
+ */
 module.exports.import = async function importECue(buffer, filename, authorName) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);

--- a/plugins/ecue/import.js
+++ b/plugins/ecue/import.js
@@ -14,7 +14,7 @@ for (const hex of Object.keys(colorNames)) {
  * @param {String} filename The imported file's name.
  * @param {String} authorName The importer's name.
  * @returns {Promise.<Object, Error>} A Promise resolving to an out object
-**/
+ **/
 module.exports.import = async function importECue(buffer, filename, authorName) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);

--- a/plugins/gdtf/gdtf-attributes.js
+++ b/plugins/gdtf/gdtf-attributes.js
@@ -86,7 +86,7 @@ const gdtfUnits = {
 /**
  * @param {Number} value1 The first physical value.
  * @param {Number|null} value2 The second physical value, or null.
- * @param {function} predicate A function returning a boolean.
+ * @param {Function} predicate A function returning a boolean.
  * @returns {Boolean} True if all provided values fulfill the condition predicate.
  */
 function physicalValuesFulfillCondition(value1, value2, predicate) {

--- a/plugins/gdtf/import.js
+++ b/plugins/gdtf/import.js
@@ -18,7 +18,7 @@ module.exports.version = `0.1.0`;
  * @param {String} filename The imported file's name.
  * @param {String} authorName The importer's name.
  * @returns {Promise.<Object, Error>} A Promise resolving to an out object
-**/
+ **/
 module.exports.import = async function importGdtf(buffer, filename, authorName) {
   const parser = new xml2js.Parser();
 
@@ -244,8 +244,7 @@ module.exports.import = async function importGdtf(buffer, filename, authorName) 
   }
 
   /**
-   * @typedef Relation
-   * @type Object
+   * @typedef {Object} Relation
    * @property {Number} modeIndex
    * @property {Object} masterGdtfChannel
    * @property {String} switchingChannelName
@@ -315,8 +314,7 @@ module.exports.import = async function importGdtf(buffer, filename, authorName) 
   }
 
   /**
-   * @typedef ChannelWrapper
-   * @type Object
+   * @typedef {Object} ChannelWrapper
    * @property {String} key The channel key.
    * @property {Object} channel The OFL channel object.
    * @property {Number} maxResolution The highest used resolution of this channel.
@@ -642,7 +640,7 @@ module.exports.import = async function importGdtf(buffer, filename, authorName) 
       }
 
       /**
-       * @param {function|null} hook The hook function, or a falsy value.
+       * @param {Function|null} hook The hook function, or a falsy value.
        * @param  {...*} args The arguments to pass to the hook.
        * @returns {*} The return value of the hook, or null if no hook was called.
        */
@@ -673,7 +671,7 @@ module.exports.import = async function importGdtf(buffer, filename, authorName) 
 
       /**
        * @param {Object} gdtfCapability The enhanced <ChannelSet> XML object.
-       * @returns {function} The function to turn a physical value into an entity string with the correct unit.
+       * @returns {Function} The function to turn a physical value into an entity string with the correct unit.
        */
       function getPhysicalUnit(gdtfCapability) {
         const gdtfAttribute = gdtfCapability._channelFunction._attribute;
@@ -805,9 +803,7 @@ module.exports.import = async function importGdtf(buffer, filename, authorName) 
   }
 
   /**
-   * @typedef DmxBreakWrapper
-   * @description Holds a list of OFL channel keys belonging to consecutive GDTF channels with the same DMXBreak attribute.
-   * @type Object
+   * @typedef {Object} DmxBreakWrapper Holds a list of OFL channel keys belonging to consecutive GDTF channels with the same DMXBreak attribute.
    * @property {String|undefined} dmxBreak The DMXBreak attribute of consecutive DMXChannel nodes.
    * @property {String} geometry The Geometry attribute of consecutive DMXChannel nodes.
    * @property {Array.<String>} channels The OFL channel keys in this DMX break.
@@ -823,7 +819,7 @@ module.exports.import = async function importGdtf(buffer, filename, authorName) 
     const matrixPixels = new Set();
 
     fixture.modes = gdtfFixture.DMXModes[0].DMXMode.map(gdtfMode => {
-      /** @type Array.<DmxBreakWrapper> */
+      /** @type {Array.<DmxBreakWrapper>} */
       const dmxBreakWrappers = [];
 
       gdtfMode.DMXChannels[0].DMXChannel.forEach(gdtfChannel => {

--- a/plugins/gdtf/import.js
+++ b/plugins/gdtf/import.js
@@ -18,7 +18,7 @@ module.exports.version = `0.1.0`;
  * @param {String} filename The imported file's name.
  * @param {String} authorName The importer's name.
  * @returns {Promise.<Object, Error>} A Promise resolving to an out object
- **/
+ */
 module.exports.import = async function importGdtf(buffer, filename, authorName) {
   const parser = new xml2js.Parser();
 

--- a/plugins/millumin/export.js
+++ b/plugins/millumin/export.js
@@ -15,7 +15,7 @@ module.exports.supportedOflVersion = `7.3.0`;
  * @param {Date} options.date The current time.
  * @param {String|undefined} options.displayedPluginVersion Replacement for module.exports.version if the plugin version is used in export.
  * @returns {Promise.<Array.<Object>, Error>} The generated files.
-*/
+ */
 module.exports.export = async function exportMillumin(fixtures, options) {
   // one JSON file for each fixture
   const outFiles = fixtures.map(fixture => {

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -15,7 +15,7 @@ const schemaPromises = getSchemas();
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
- **/
+ */
 module.exports = async function testSchemaConformity(exportFile) {
   const schemas = await schemaPromises;
   const ajv = new Ajv({

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -15,7 +15,7 @@ const schemaPromises = getSchemas();
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
-**/
+ **/
 module.exports = async function testSchemaConformity(exportFile) {
   const schemas = await schemaPromises;
   const ajv = new Ajv({

--- a/plugins/ofl/export.js
+++ b/plugins/ofl/export.js
@@ -13,7 +13,7 @@ module.exports.version = require(`../../schemas/fixture.json`).version;
  * @param {Date} options.date The current time.
  * @param {String|undefined} options.displayedPluginVersion Replacement for module.exports.version if the plugin version is used in export.
  * @returns {Promise.<Array.<Object>, Error>} The generated files.
-*/
+ */
 module.exports.export = async function exportOfl(fixtures, options) {
   const displayedPluginVersion = options.displayedPluginVersion || module.exports.version;
 

--- a/plugins/op-z/export.js
+++ b/plugins/op-z/export.js
@@ -17,7 +17,7 @@ const MAX_OPZ_FIXTURES = 16;
  * @param {Date} options.date The current time.
  * @param {String|undefined} options.displayedPluginVersion Replacement for module.exports.version if the plugin version is used in export.
  * @returns {Promise.<Array.<Object>, Error>} The generated files.
-*/
+ */
 module.exports.export = async function exportOpZ(fixtures, options) {
   const exportJson = {
     profiles: [],

--- a/plugins/qlcplus_4.11.2/export.js
+++ b/plugins/qlcplus_4.11.2/export.js
@@ -19,7 +19,7 @@ module.exports.version = `0.5.2`;
  * @param {Date} options.date The current time.
  * @param {String|undefined} options.displayedPluginVersion Replacement for module.exports.version if the plugin version is used in export.
  * @returns {Promise.<Array.<Object>, Error>} The generated files.
-*/
+ */
 module.exports.export = async function exportQlcPlus(fixtures, options) {
   const outFiles = fixtures.map(fixture => {
     const xml = xmlbuilder.begin()

--- a/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
+++ b/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
@@ -11,7 +11,7 @@ const SCHEMA_URL = `https://raw.githubusercontent.com/mcallegari/qlcplus/QLC+_4.
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
-**/
+ **/
 module.exports = async function testSchemaConformity(exportFile) {
   const schemaData = await new Promise((resolve, reject) => {
     https.get(SCHEMA_URL, res => {

--- a/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
+++ b/plugins/qlcplus_4.11.2/exportTests/xsd-schema-conformity.js
@@ -11,7 +11,7 @@ const SCHEMA_URL = `https://raw.githubusercontent.com/mcallegari/qlcplus/QLC+_4.
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
- **/
+ */
 module.exports = async function testSchemaConformity(exportFile) {
   const schemaData = await new Promise((resolve, reject) => {
     https.get(SCHEMA_URL, res => {

--- a/plugins/qlcplus_4.12.1/export.js
+++ b/plugins/qlcplus_4.12.1/export.js
@@ -21,7 +21,7 @@ module.exports.version = `1.2.0`;
  * @param {Date} options.date The current time.
  * @param {String|undefined} options.displayedPluginVersion Replacement for module.exports.version if the plugin version is used in export.
  * @returns {Promise.<Array.<Object>, Error>} The generated files.
-*/
+ */
 module.exports.export = async function exportQlcPlus(fixtures, options) {
   const outFiles = fixtures.map(fixture => {
     const xml = xmlbuilder.begin()

--- a/plugins/qlcplus_4.12.1/exportTests/fixture-tool-validation.js
+++ b/plugins/qlcplus_4.12.1/exportTests/fixture-tool-validation.js
@@ -23,7 +23,7 @@ const EXPORTED_FIXTURE_PATH = `resources/fixtures/manufacturer/fixture.qxf`;
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
-**/
+ **/
 module.exports = async function testFixtureToolValidation(exportFile) {
   // create a unique temporary directory to avoid race conditions when multiple running tests access the same files
   const directory = await mkdtemp(FIXTURE_TOOL_DIR_PREFIX);

--- a/plugins/qlcplus_4.12.1/exportTests/fixture-tool-validation.js
+++ b/plugins/qlcplus_4.12.1/exportTests/fixture-tool-validation.js
@@ -23,7 +23,7 @@ const EXPORTED_FIXTURE_PATH = `resources/fixtures/manufacturer/fixture.qxf`;
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
- **/
+ */
 module.exports = async function testFixtureToolValidation(exportFile) {
   // create a unique temporary directory to avoid race conditions when multiple running tests access the same files
   const directory = await mkdtemp(FIXTURE_TOOL_DIR_PREFIX);

--- a/plugins/qlcplus_4.12.1/exportTests/xsd-schema-conformity.js
+++ b/plugins/qlcplus_4.12.1/exportTests/xsd-schema-conformity.js
@@ -11,7 +11,7 @@ const SCHEMA_URL = `https://raw.githubusercontent.com/mcallegari/qlcplus/master/
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
- **/
+ */
 module.exports = async function testSchemaConformity(exportFile) {
   const schemaData = await new Promise((resolve, reject) => {
     https.get(SCHEMA_URL, res => {

--- a/plugins/qlcplus_4.12.1/exportTests/xsd-schema-conformity.js
+++ b/plugins/qlcplus_4.12.1/exportTests/xsd-schema-conformity.js
@@ -11,7 +11,7 @@ const SCHEMA_URL = `https://raw.githubusercontent.com/mcallegari/qlcplus/master/
  * @param {Array.<Fixture>|null} exportFile.fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
  * @param {String|null} exportFile.mode Mode's shortName if given file only describes a single mode.
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
-**/
+ **/
 module.exports = async function testSchemaConformity(exportFile) {
   const schemaData = await new Promise((resolve, reject) => {
     https.get(SCHEMA_URL, res => {

--- a/plugins/qlcplus_4.12.1/import.js
+++ b/plugins/qlcplus_4.12.1/import.js
@@ -15,7 +15,7 @@ module.exports.version = `0.5.0`;
  * @param {String} filename The imported file's name.
  * @param {String} authorName The importer's name.
  * @returns {Promise.<Object, Error>} A Promise resolving to an out object
- **/
+ */
 module.exports.import = async function importQlcPlus(buffer, filename, authorName) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);

--- a/plugins/qlcplus_4.12.1/import.js
+++ b/plugins/qlcplus_4.12.1/import.js
@@ -15,7 +15,7 @@ module.exports.version = `0.5.0`;
  * @param {String} filename The imported file's name.
  * @param {String} authorName The importer's name.
  * @returns {Promise.<Object, Error>} A Promise resolving to an out object
-**/
+ **/
 module.exports.import = async function importQlcPlus(buffer, filename, authorName) {
   const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);

--- a/plugins/qlcplus_4.12.1/presets.js
+++ b/plugins/qlcplus_4.12.1/presets.js
@@ -972,8 +972,7 @@ const capabilityPresets = {
 };
 
 /**
- * @typedef CapabilityPreset
- * @type {Object}
+ * @typedef {Object} CapabilityPreset
  * @property {String} presetName The name of the QLC+ capability preset.
  * @property {String|null} res1 A value for the QLC+ capability element's Res1 attribute, or null if the attribute should not be added.
  * @property {String|null} res2 A value for the QLC+ capability element's Res2 attribute, or null if the attribute should not be added.

--- a/tests/fixture-valid.js
+++ b/tests/fixture-valid.js
@@ -42,13 +42,12 @@ const redirectSchemaValidate = ajv.compile(fixtureRedirectSchema);
  */
 function checkFixture(manKey, fixKey, fixtureJson, uniqueValues = null) {
   /**
-   * @typedef ResultData
-   * @type {Object}
+   * @typedef {Object} ResultData
    * @property {Array.<String>} errors
    * @property {Array.<String>} warnings
    */
 
-  /** @type ResultData */
+  /** @type {ResultData} */
   const result = {
     errors: [],
     warnings: []
@@ -1050,7 +1049,7 @@ function checkFixture(manKey, fixKey, fixtureJson, uniqueValues = null) {
 
     /**
      * @returns {Boolean} Whether the 'Color Changer' category is suggested.
-    */
+     */
     function isColorChanger() {
       return hasCapabilityOfType(`ColorPreset`) || hasCapabilityOfType(`ColorIntensity`, 2) || fixture.wheels.some(
         wheel => wheel.slots.some(slot => slot.type === `Color`)

--- a/tests/fixtures-valid.js
+++ b/tests/fixtures-valid.js
@@ -9,8 +9,7 @@ const manufacturerSchema = require(`../schemas/dereferenced/manufacturers.json`)
 const { checkFixture, checkUniqueness, getErrorString } = require(`./fixture-valid.js`);
 
 /**
- * @typedef UniqueValues
- * @type {Object}
+ * @typedef {Object} UniqueValues
  * @property {Set.<String>} manNames All manufacturer names
  * @property {Object.<String, Set.<String>>} fixKeysInMan All fixture keys by manufacturer key
  * @property {Object.<String, Set.<String>>} fixNamesInMan All fixture names by manufacturer key

--- a/tests/github/export-diff.js
+++ b/tests/github/export-diff.js
@@ -246,8 +246,7 @@ async function performTask(task) {
 }
 
 /**
- * @typedef ChangeFlags
- * @type Object
+ * @typedef {Object} ChangeFlags
  * @property {Boolean} hasRemoved Whether any files were removed.
  * @property {Boolean} hasAdded Whether any files were added.
  * @property {Boolean} hasChanged Whether any files were changed.


### PR DESCRIPTION
Unfortunately, `jsdoc/require-jsdoc` has a fixer that simply inserts an empty JSDoc comment (i. e. when calling `./tests/lint.js --fix`). However, `get-out-object-from-editor-data.js` is our only script with undocumented functions, so the simplest (and best) fix to avoid the creation of these useless comments is to fully document that script (and until that, we need to revert changes made to that file after using lint's auto fix).