### PR TITLE
Add fixture 'stairville/led-par-64-cob-rgbw-60w'

### DIFF
--- a/fixtures/stairville/led-par-64-cob-rgbw-60w.json
+++ b/fixtures/stairville/led-par-64-cob-rgbw-60w.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED Par 64 COB RGBW 60W",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Nicolas Sanchez"],
+    "createDate": "2019-10-21",
+    "lastModifyDate": "2019-10-21"
+  },
+  "links": {
+    "manual": [
+      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/c_333906_334993_334994_334995_375066_375060_375059_375061_v2_r7_en_online.pdf"
+    ]
+  },
+  "physical": {
+    "dimensions": [280, 200, 500],
+    "weight": 2.93,
+    "power": 56,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [60, 60]
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "4 Channels",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'stairville/led-par-64-cob-rgbw-60w'

### Fixture warnings / errors

* stairville/led-par-64-cob-rgbw-60w
  - :warning: Mode '4 Channels' should have shortName '4ch' instead of '4 Channels'.
  - :warning: Mode '4 Channels' should have shortName '4ch' instead of '4 Channels'.


Thank you **Nicolas Sanchez**!