### PR TITLE
Fix external-links test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - env: TESTFILE=tests/external-links.js
       if: type in (api, cron)
 script:
-  - NODE_ENV=production node "$TESTFILE"
+  - NODE_ENV=production node --tls-min-v1.0 "$TESTFILE"
 cache:
   directories:
     - node_modules # cache NPM dependencies

--- a/tests/external-links.js
+++ b/tests/external-links.js
@@ -369,13 +369,12 @@ async function updateGithubIssue(urlResults) {
     ].concat(Object.entries(linkData).map(([url, statuses]) => {
       let line = `| ${url} |`;
       for (const status of statuses) {
-        const { failed, message, jobUrl } = status;
-        if (failed) {
-          line += ` <a href="${jobUrl}" title="${message}">:x:</a> |`;
-        }
-        else {
-          line += ` :heavy_check_mark: |`;
-        }
+        const { failed, jobUrl } = status;
+        const message = status.message.replace(`\n`, ` `).replace(`"`, `&quot;`);
+
+        line += ` `;
+        line += failed ? `<a href="${jobUrl}" title="${message}">:x:</a>` : `:heavy_check_mark:`;
+        line += ` |`;
       }
       return line;
     }));

--- a/tests/external-links.js
+++ b/tests/external-links.js
@@ -365,19 +365,23 @@ async function updateGithubIssue(urlResults) {
       `**Last updated:** ${(new Date()).toISOString()}`,
       ``,
       `| URL | today | -1d | -2d | -3d | -4d | -5d | -6d |`,
-      `|-----|-------|-----|-----|-----|-----|-----|-----|`
-    ].concat(Object.entries(linkData).map(([url, statuses]) => {
-      let line = `| ${url} |`;
-      for (const status of statuses) {
-        const { failed, jobUrl } = status;
-        const message = (status.message || ``).replace(`\n`, ` `).replace(`"`, `&quot;`);
+      `|-----|-------|-----|-----|-----|-----|-----|-----|`,
+      ...Object.entries(linkData).map(([url, statuses]) => {
+        const columns = [
+          url,
+          ...statuses.map(status => {
+            if (!status.failed) {
+              return `:heavy_check_mark:`;
+            }
 
-        line += ` `;
-        line += failed ? `<a href="${jobUrl}" title="${message}">:x:</a>` : `:heavy_check_mark:`;
-        line += ` |`;
-      }
-      return line;
-    }));
+            const message = status.message.replace(`\n`, ` `).replace(`"`, `&quot;`);
+            return `<a href="${status.jobUrl}" title="${message}">:x:</a>`;
+          })
+        ];
+
+        return `| ${columns.join(` | `)} |`;
+      })
+    ];
 
     return lines.join(`\n`);
   }

--- a/tests/external-links.js
+++ b/tests/external-links.js
@@ -370,7 +370,7 @@ async function updateGithubIssue(urlResults) {
       let line = `| ${url} |`;
       for (const status of statuses) {
         const { failed, jobUrl } = status;
-        const message = status.message.replace(`\n`, ` `).replace(`"`, `&quot;`);
+        const message = (status.message || ``).replace(`\n`, ` `).replace(`"`, `&quot;`);
 
         line += ` `;
         line += failed ? `<a href="${jobUrl}" title="${message}">:x:</a>` : `:heavy_check_mark:`;


### PR DESCRIPTION
Returned status messages can break the generated Markdown. This change sanitizes the message first.