### PR TITLE
Add fixture 'fractal-lights/par-led-7x10w'

### DIFF
--- a/fixtures/fractal-lights/par-led-7x10w.json
+++ b/fixtures/fractal-lights/par-led-7x10w.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "PAR LED 7x10W",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Marek Jędrzejewski"],
+    "createDate": "2020-01-09",
+    "lastModifyDate": "2020-01-09",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2020-01-09",
+      "comment": "created by Q Light Controller Plus (version 4.12.3 GIT)"
+    }
+  },
+  "physical": {
+    "dimensions": [180, 180, 110],
+    "weight": 2,
+    "power": 90,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "name": "Other",
+      "degreesMinMax": [25, 25]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Generic",
+        "helpWanted": "Unknown QLC+ channel preset IntensityRedFine."
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Generic",
+        "helpWanted": "Unknown QLC+ channel preset IntensityGreenFine."
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Generic",
+        "helpWanted": "Unknown QLC+ channel preset IntensityBlueFine."
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Generic",
+        "helpWanted": "Unknown QLC+ channel preset IntensityWhiteFine."
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX values is strobe disabled?"
+      }
+    },
+    "Function choice": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 50],
+          "type": "Effect",
+          "effectName": "DMX 8CH Control"
+        },
+        {
+          "dmxRange": [51, 100],
+          "type": "Effect",
+          "effectName": "Different Colors Output"
+        },
+        {
+          "dmxRange": [101, 150],
+          "type": "Effect",
+          "effectName": "Colors Jump Change"
+        },
+        {
+          "dmxRange": [151, 200],
+          "type": "Effect",
+          "effectName": "Colors Gradate"
+        },
+        {
+          "dmxRange": [201, 250],
+          "type": "Effect",
+          "effectName": "Colors Pulse Change"
+        },
+        {
+          "dmxRange": [251, 255],
+          "type": "Effect",
+          "effectName": "Sound-Active",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Function Speed": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Speed",
+        "comment": "Speed of chosen function"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8 channels",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe",
+        "Function choice",
+        "Function Speed"
+      ]
+    },
+    {
+      "name": "RGBW",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -349,14 +349,14 @@
     "website": "https://www.vari-lite.com/global",
     "comment": "Belongs to the Vari-Lite brand."
   },
+  "showpro": {
+    "name": "ShowPRO",
+    "website": "https://www.showtech.com.au/our-brands/showpro/"
+  },
   "showtec": {
     "name": "Showtec",
     "website": "https://www.highlite.com/",
     "rdmId": 10676
-  },
-  "showpro": {
-    "name": "ShowPRO",
-    "website": "https://www.showtech.com.au/our-brands/showpro/"
   },
   "showven": {
     "name": "Showven",


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'fractal-lights/par-led-7x10w'

### Fixture warnings / errors

* fractal-lights/par-led-7x10w
  - :x: File does not match schema. [
  {
    keyword: 'required',
    dataPath: ".availableChannels['Function Speed'].capability",
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capability/allOf/0/allOf/39/then/oneOf/0/required',
    params: { missingProperty: '.speed' },
    message: "should have required property '.speed'"
  },
  {
    keyword: 'required',
    dataPath: ".availableChannels['Function Speed'].capability",
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capability/allOf/0/allOf/39/then/oneOf/1/required',
    params: { missingProperty: '.speedStart' },
    message: "should have required property '.speedStart'"
  },
  {
    keyword: 'oneOf',
    dataPath: ".availableChannels['Function Speed'].capability",
    schemaPath: '#/properties/availableChannels/additionalProperties/properties/capability/allOf/0/allOf/39/then/oneOf',
    params: { passingSchemas: null },
    message: 'should match exactly one schema in oneOf'
  },
  [length]: 3
]
  - :warning: Please check if manufacturer is correct.
  - :warning: Please check 16bit channel 'Red': The corresponding coarse channel could not be detected.
  - :warning: Please check 16bit channel 'Green': The corresponding coarse channel could not be detected.
  - :warning: Please check 16bit channel 'Blue': The corresponding coarse channel could not be detected.
  - :warning: Please check 16bit channel 'White': The corresponding coarse channel could not be detected.


### User comment

The weight might not exactly be 2kg, but I can't find info about it and can't weight it myself.

Thank you @marekjedrzejewski!