### PR TITLE
Rename GitHub label `type-bug` → `bug`

### DIFF
--- a/ui/components/HelpWantedMessage.vue
+++ b/ui/components/HelpWantedMessage.vue
@@ -15,7 +15,7 @@
         <span>Send information</span>
       </a>
       <a
-        href="https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+label%3Atype-bug"
+        href="https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+label%3Abug"
         class="no-js"
         rel="nofollow">
         <OflSvg name="bug" class="left" />

--- a/ui/pages/_manufacturerKey/_fixtureKey.vue
+++ b/ui/pages/_manufacturerKey/_fixtureKey.vue
@@ -181,7 +181,7 @@
           })">
           <OflSvg name="comment-alert" class="left" /><span>Send information</span>
         </a>
-        <a href="https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+label%3Atype-bug" rel="nofollow" class="card slim">
+        <a href="https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+label%3Abug" rel="nofollow" class="card slim">
           <OflSvg name="bug" class="left" /><span>Create issue on GitHub</span>
         </a>
         <a :href="mailtoUrl" class="card slim">

--- a/ui/pages/index.vue
+++ b/ui/pages/index.vue
@@ -75,11 +75,11 @@
     </div>
 
     <div class="grid-3 centered">
-      <a href="https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+-label%3Atype-bug" rel="nofollow" class="card slim">
+      <a href="https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+-label%3Abug" rel="nofollow" class="card slim">
         <OflSvg name="lightbulb-on-outline" class="left" />
         <span>Request feature</span>
       </a>
-      <a href="https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+label%3Atype-bug" rel="nofollow" class="card slim">
+      <a href="https://github.com/OpenLightingProject/open-fixture-library/issues?q=is%3Aopen+is%3Aissue+label%3Abug" rel="nofollow" class="card slim">
         <OflSvg name="bug" class="left" />
         <span>Report problem</span>
       </a>


### PR DESCRIPTION
So we stick to GitHub's default naming convention and are enable *Refined GitHub* users to use the `bugs-tab` feature: https://github.com/sindresorhus/refined-github/pull/2750