### PR TITLE
Fix fixture editor backend

### DIFF
--- a/lib/create-github-pr.js
+++ b/lib/create-github-pr.js
@@ -37,7 +37,7 @@ module.exports = async function createPullRequest(out) {
 
   try {
     console.log(`get latest commit hash ...`);
-    const latestCommitHash = (await githubClient.gitdata.getRef({
+    const latestCommitHash = (await githubClient.git.getRef({
       owner: `OpenLightingProject`,
       repo: repository,
       ref: `heads/master`


### PR DESCRIPTION
See <https://octokit.github.io/rest.js/v17#git-create-ref>. Fixes the bug that caused #1227 and #1231 to fail.