### PR TITLE
Make schema errors more human-readable in Millumin export test, too

### DIFF
--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -29,7 +29,8 @@ module.exports = async function testSchemaConformity(exportFile, allExportFiles)
     format: `full`,
     formats: {
       'color-hex': ``
-    }
+    },
+    verbose: true
   });
   const schemaValidate = ajv.getSchema(`https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json`);
 

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -1,5 +1,6 @@
 const https = require(`https`);
 const Ajv = require(`ajv`);
+const getAjvErrorMessages = require(`../../../lib/get-ajv-error-messages.js`);
 
 const SUPPORTED_OFL_VERSION = require(`../export.js`).supportedOflVersion;
 const SCHEMA_BASE_URL = `https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/schema-${SUPPORTED_OFL_VERSION}/schemas/`;
@@ -34,7 +35,7 @@ module.exports = async function testSchemaConformity(exportFile, allExportFiles)
 
   const schemaValid = schemaValidate(JSON.parse(exportFile.content));
   if (!schemaValid) {
-    throw JSON.stringify(schemaValidate.errors, null, 2);
+    throw getAjvErrorMessages(schemaValidate.errors, `fixture`);
   }
 };
 


### PR DESCRIPTION
Use the function from #1243 that makes the AJV error messages more human-readable in the Millumin export test, too.