### PR TITLE
Fix SVG loader on Windows

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -36,7 +36,7 @@ module.exports = {
     extend(config, ctx) {
       // exclude /assets/icons from url-loader
       const urlLoader = config.module.rules.find(rule => `use` in rule && rule.use[0].loader === `url-loader`);
-      urlLoader.exclude = /assets\/icons/;
+      urlLoader.exclude = path.resolve(__dirname, `ui/assets/icons`);
 
       // include /assets/icons for svg-inline-loader
       config.module.rules.push({


### PR DESCRIPTION
References #1276.

For proper packing the SVGs in ui/assets/icons must not use the
standard url-loader and instead use the svg-inline-loader.
Previously this was achieved by an exclude for url-loader
containing a RegExp with a forward slash. However Windows uses
backwards slashes for paths, causing the RegExp to not work.

This commit changed the exclude to use the Node path module,
as suggested in https://webpack.js.org/configuration/#options