### PR TITLE
Revert dialog style changes from #1263

### DIFF
--- a/ui/components/A11yDialog.vue
+++ b/ui/components/A11yDialog.vue
@@ -100,7 +100,8 @@ dialog.card {
 
 @media (max-width: $phone) {
   /* make dialogs cover the whole screen */
-  dialog {
+  dialog,
+  dialog.wide {
     min-width: none;
     max-width: none;
     max-height: none;

--- a/ui/components/A11yDialog.vue
+++ b/ui/components/A11yDialog.vue
@@ -38,29 +38,16 @@
 <style lang="scss" scoped>
 .dialog-container {
   outline: none;
-  position: fixed;
-  z-index: 1000;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  box-sizing: border-box;
-  padding: 30px;
-  overflow: hidden;
-
-  /* fixes bug with hiding app bars on mobile */
-  /* (avoid 'width: 100vw' as this includes the scroll bar) */
-  height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .dialog-overlay {
+  z-index: 1000;
   background-color: rgba(0, 0, 0, 0.66);
-  position: absolute;
-  width: 100%;
-  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 .dialog-container[aria-hidden=true],
@@ -73,16 +60,20 @@ dialog {
   color: theme-color(text-primary);
   border: 0;
   z-index: 1010;
+  position: fixed;
+  top: 50%;
+  left: 50%;
   margin: 0;
+  transform: translate(-50%, -50%);
+  box-sizing: border-box;
   min-width: 20rem;
-  max-width: 650px;
-  max-height: 100%;
+  max-width: 90%;
+  max-height: 90%;
   overflow: auto;
   overscroll-behavior: contain;
 
   &.wide {
     width: 1000px;
-    max-width: 100%;
   }
 
   &::backdrop {
@@ -108,14 +99,13 @@ dialog.card {
 }
 
 @media (max-width: $phone) {
-  .dialog-container {
-    padding: 10px;
-  }
-
-  dialog,
-  dialog.wide {
-    min-width: 0;
-    width: auto;
+  /* make dialogs cover the whole screen */
+  dialog {
+    min-width: none;
+    max-width: none;
+    max-height: none;
+    width: 100%;
+    height: 100%;
   }
 }
 </style>


### PR DESCRIPTION
They broke the layout in Chromium:

![Screenshot_2020-05-31_00-34-37](https://user-images.githubusercontent.com/202916/83340305-bb761300-a2d6-11ea-8eea-fa9616c252a6.png)
