### PR TITLE
Add fixture 'xmlite/hotbeam280'

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -451,5 +451,9 @@
     "name": "Venue",
     "comment": "Venue by Proline",
     "website": "https://venuelightingeffects.com/"
+  },
+  "xmlite": {
+    "name": "XMlite",
+    "website": "http://www.movinghead.net/cn/"
   }
 }

--- a/fixtures/xmlite/hotbeam280.json
+++ b/fixtures/xmlite/hotbeam280.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "HotBeam280",
+  "shortName": "280",
+  "categories": ["Moving Head", "Color Changer", "Flower"],
+  "meta": {
+    "authors": ["zl"],
+    "createDate": "2020-07-03",
+    "lastModifyDate": "2020-07-03"
+  },
+  "links": {
+    "manual": [
+      "http://www.movinghead.net/cn/product/stagelighting/moving_head_light/show111.html"
+    ],
+    "productPage": [
+      "http://www.movinghead.net/cn/product/stagelighting/moving_head_light/show111.html"
+    ]
+  },
+  "rdm": {
+    "modelId": 1,
+    "softwareVersion": "1.1"
+  },
+  "physical": {
+    "weight": 16,
+    "power": 470,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "YODN MSD 280 R10",
+      "colorTemperature": 4000,
+      "lumens": 12000
+    }
+  },
+  "availableChannels": {
+    "Cyan": {
+      "fineChannelAliases": ["Cyan fine"],
+      "defaultValue": 12,
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "24",
+      "rdmPersonalityIndex": 1,
+      "channels": [
+        "Cyan",
+        "Cyan fine"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'xmlite/hotbeam280'

### Fixture warnings / errors

* xmlite/hotbeam280
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.
  - :x: Category 'Moving Head' invalid since there are not both pan and tilt channels.


Thank you **zl**!