### PR TITLE
Add fixture 'stairville/mh-x50'

### DIFF
--- a/fixtures/stairville/mh-x50.json
+++ b/fixtures/stairville/mh-x50.json
@@ -29,7 +29,7 @@
     }
   },
   "wheels": {
-    "Color": {
+    "Color Wheel": {
       "slots": [
         {
           "type": "Color",
@@ -75,63 +75,10 @@
           "type": "Color",
           "name": "Dark blue",
           "colors": ["#1e00ff"]
-        },
-        {
-          "type": "Color",
-          "name": "White + Yellow",
-          "colors": ["#ffffff", "#ffff00"]
-        },
-        {
-          "type": "Color",
-          "name": "Yellow + Pink",
-          "colors": ["#ffff00", "#ff00ff"]
-        },
-        {
-          "type": "Color",
-          "name": "Pink + Green",
-          "colors": ["#ff00ff", "#00ff00"]
-        },
-        {
-          "type": "Color",
-          "name": "Green + Peachblow",
-          "colors": ["#00ff00", "#d7735b"]
-        },
-        {
-          "type": "Color",
-          "name": "Peachblow + Blue",
-          "colors": ["#d7735b", "#00aeff"]
-        },
-        {
-          "type": "Color",
-          "name": "Blue + Kelly-Green",
-          "colors": ["#00aeff", "#4cbb17"]
-        },
-        {
-          "type": "Color",
-          "name": "Kelly-Green + Red",
-          "colors": ["#4cbb17", "#ff0000"]
-        },
-        {
-          "type": "Color",
-          "name": "Red + Dark blue",
-          "colors": ["#ff0000", "#0000ff"]
-        },
-        {
-          "type": "Color",
-          "name": "Dark blue + White",
-          "colors": ["#0000ff", "#ffffff"]
-        },
-        {
-          "type": "Color",
-          "name": "Rainbow CW"
-        },
-        {
-          "type": "Color",
-          "name": "Rainbow CCW"
         }
       ]
     },
-    "Gobo": {
+    "Gobo Wheel": {
       "slots": [
         {
           "type": "Open"
@@ -163,29 +110,6 @@
         {
           "type": "Gobo",
           "name": "Gobo 8"
-        },
-        {
-          "type": "Gobo",
-          "name": "Gobo 8 Shake"
-        },
-        {
-          "type": "Gobo",
-          "name": "Gobo 7 Shake"
-        },
-        {
-          "type": "Gobo",
-          "name": "Gobo 6 Shake"
-        },
-        {
-          "type": "Gobo",
-          "name": "Gobo 5 Shake"
-        },
-        {
-          "type": "Gobo",
-          "name": "Gobo 4 Shake"
-        },
-        {
-          "type": "Gobo"
         }
       ]
     }
@@ -195,7 +119,7 @@
       "capability": {
         "type": "Pan",
         "angleStart": "0deg",
-        "angleEnd": "0deg"
+        "angleEnd": "540deg"
       }
     },
     "Tilt": {
@@ -205,7 +129,7 @@
         "angleEnd": "270deg"
       }
     },
-    "Color": {
+    "Color Wheel": {
       "capabilities": [
         {
           "dmxRange": [0, 6],
@@ -255,47 +179,47 @@
         {
           "dmxRange": [64, 70],
           "type": "WheelSlot",
-          "slotNumber": 10
+          "slotNumber": 1.5
         },
         {
           "dmxRange": [71, 77],
           "type": "WheelSlot",
-          "slotNumber": 11
+          "slotNumber": 2.5
         },
         {
           "dmxRange": [78, 84],
           "type": "WheelSlot",
-          "slotNumber": 12
+          "slotNumber": 3.5
         },
         {
           "dmxRange": [85, 91],
           "type": "WheelSlot",
-          "slotNumber": 13
+          "slotNumber": 4.5
         },
         {
           "dmxRange": [92, 98],
           "type": "WheelSlot",
-          "slotNumber": 14
+          "slotNumber": 5.5
         },
         {
           "dmxRange": [99, 105],
           "type": "WheelSlot",
-          "slotNumber": 15
+          "slotNumber": 6.5
         },
         {
           "dmxRange": [106, 112],
           "type": "WheelSlot",
-          "slotNumber": 16
+          "slotNumber": 7.5
         },
         {
           "dmxRange": [113, 119],
           "type": "WheelSlot",
-          "slotNumber": 17
+          "slotNumber": 8.5
         },
         {
           "dmxRange": [120, 127],
           "type": "WheelSlot",
-          "slotNumber": 18
+          "slotNumber": 9.5
         },
         {
           "dmxRange": [128, 191],
@@ -337,7 +261,7 @@
         }
       ]
     },
-    "Gobo": {
+    "Gobo Wheel": {
       "capabilities": [
         {
           "dmxRange": [0, 7],
@@ -417,7 +341,9 @@
         {
           "dmxRange": [104, 111],
           "type": "WheelShake",
-          "slotNumber": 3
+          "slotNumber": 3,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
         },
         {
           "dmxRange": [112, 119],
@@ -450,25 +376,28 @@
         {
           "dmxRange": [0, 63],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
           "speed": "stop"
         },
         {
           "dmxRange": [64, 147],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
           "speedStart": "slow CW",
           "speedEnd": "fast CW"
         },
         {
           "dmxRange": [148, 231],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
           "speedStart": "slow CCW",
           "speedEnd": "fast CCW"
         },
         {
           "dmxRange": [232, 255],
-          "type": "WheelSlotRotation",
-          "speed": "100%",
-          "comment": "Gobo Jumping"
+          "type": "WheelShake",
+          "wheel": "Gobo Wheel",
+          "isShaking": "slot"
         }
       ]
     },
@@ -724,9 +653,9 @@
       "channels": [
         "Pan",
         "Tilt",
-        "Color",
+        "Color Wheel",
         "Shutter",
-        "Gobo",
+        "Gobo Wheel",
         "Gobo Rotation",
         "Prism",
         "Focus"
@@ -740,10 +669,10 @@
         "Pan 2 fine",
         "Tilt 2 fine",
         "Speed",
-        "Color",
+        "Color Wheel",
         "Shutter",
         "Dimmer",
-        "Gobo",
+        "Gobo Wheel",
         "Gobo Rotation",
         "Special Functions",
         "Built-in Programs",

--- a/fixtures/stairville/mh-x50.json
+++ b/fixtures/stairville/mh-x50.json
@@ -1,0 +1,755 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "MH-X50+",
+  "categories": ["Moving Head", "Color Changer"],
+  "meta": {
+    "authors": ["Hannes Rüger"],
+    "createDate": "2020-07-15",
+    "lastModifyDate": "2020-07-15"
+  },
+  "links": {
+    "manual": [
+      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/250558_c_250558_v3_de_online.pdf"
+    ],
+    "video": [
+      "https://video2.thomann.de//vidiot/02591c1c/video_i2514p10_yd59vqpa.mp4"
+    ]
+  },
+  "physical": {
+    "dimensions": [240, 370, 280],
+    "weight": 10.3,
+    "power": 135,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "lumens": 940
+    },
+    "lens": {
+      "degreesMinMax": [14, 14]
+    }
+  },
+  "wheels": {
+    "Color": {
+      "slots": [
+        {
+          "type": "Color",
+          "name": "White",
+          "colors": ["#ffffff"]
+        },
+        {
+          "type": "Color",
+          "name": "Yellow",
+          "colors": ["#ffff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Pink",
+          "colors": ["#ff00ff"]
+        },
+        {
+          "type": "Color",
+          "name": "Green",
+          "colors": ["#00ff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Peachblow",
+          "colors": ["#d7735b"]
+        },
+        {
+          "type": "Color",
+          "name": "Blue",
+          "colors": ["#00aeff"]
+        },
+        {
+          "type": "Color",
+          "name": "Kelly-Green",
+          "colors": ["#4cbb17"]
+        },
+        {
+          "type": "Color",
+          "name": "Dark Orange",
+          "colors": ["#ffb300"]
+        },
+        {
+          "type": "Color",
+          "name": "Dark blue",
+          "colors": ["#1e00ff"]
+        },
+        {
+          "type": "Color",
+          "name": "White + Yellow",
+          "colors": ["#ffffff", "#ffff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Yellow + Pink",
+          "colors": ["#ffff00", "#ff00ff"]
+        },
+        {
+          "type": "Color",
+          "name": "Pink + Green",
+          "colors": ["#ff00ff", "#00ff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Green + Peachblow",
+          "colors": ["#00ff00", "#d7735b"]
+        },
+        {
+          "type": "Color",
+          "name": "Peachblow + Blue",
+          "colors": ["#d7735b", "#00aeff"]
+        },
+        {
+          "type": "Color",
+          "name": "Blue + Kelly-Green",
+          "colors": ["#00aeff", "#4cbb17"]
+        },
+        {
+          "type": "Color",
+          "name": "Kelly-Green + Red",
+          "colors": ["#4cbb17", "#ff0000"]
+        },
+        {
+          "type": "Color",
+          "name": "Red + Dark blue",
+          "colors": ["#ff0000", "#0000ff"]
+        },
+        {
+          "type": "Color",
+          "name": "Dark blue + White",
+          "colors": ["#0000ff", "#ffffff"]
+        },
+        {
+          "type": "Color",
+          "name": "Rainbow CW"
+        },
+        {
+          "type": "Color",
+          "name": "Rainbow CCW"
+        }
+      ]
+    },
+    "Gobo": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 2"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 3"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 4"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 5"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 6"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 7"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 8"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 8 Shake"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 7 Shake"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 6 Shake"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 5 Shake"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 4 Shake"
+        },
+        {
+          "type": "Gobo"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "0deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Color": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 6],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [7, 13],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [14, 20],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [21, 27],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [28, 34],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [35, 41],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [42, 48],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [49, 55],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [64, 70],
+          "type": "WheelSlot",
+          "slotNumber": 10
+        },
+        {
+          "dmxRange": [71, 77],
+          "type": "WheelSlot",
+          "slotNumber": 11
+        },
+        {
+          "dmxRange": [78, 84],
+          "type": "WheelSlot",
+          "slotNumber": 12
+        },
+        {
+          "dmxRange": [85, 91],
+          "type": "WheelSlot",
+          "slotNumber": 13
+        },
+        {
+          "dmxRange": [92, 98],
+          "type": "WheelSlot",
+          "slotNumber": 14
+        },
+        {
+          "dmxRange": [99, 105],
+          "type": "WheelSlot",
+          "slotNumber": 15
+        },
+        {
+          "dmxRange": [106, 112],
+          "type": "WheelSlot",
+          "slotNumber": 16
+        },
+        {
+          "dmxRange": [113, 119],
+          "type": "WheelSlot",
+          "slotNumber": 17
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelSlot",
+          "slotNumber": 18
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        }
+      ]
+    },
+    "Shutter": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 3],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [4, 7],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [8, 215],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0Hz",
+          "speedEnd": "1Hz"
+        },
+        {
+          "dmxRange": [216, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Gobo": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "WheelShake",
+          "slotNumber": 8,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "WheelShake",
+          "slotNumber": 7,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "WheelShake",
+          "slotNumber": 6,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "WheelShake",
+          "slotNumber": 5,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "WheelShake",
+          "slotNumber": 4,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "WheelShake",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "WheelShake",
+          "slotNumber": 2,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        }
+      ]
+    },
+    "Gobo Rotation": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 63],
+          "type": "WheelSlotRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [64, 147],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [148, 231],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        },
+        {
+          "dmxRange": [232, 255],
+          "type": "WheelSlotRotation",
+          "speed": "100%",
+          "comment": "Gobo Jumping"
+        }
+      ]
+    },
+    "Prism": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [8, 247],
+          "type": "Prism",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "Prism",
+          "speed": "stop"
+        }
+      ]
+    },
+    "Focus": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Pan 2": {
+      "name": "Pan",
+      "fineChannelAliases": ["Pan 2 fine"],
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt 2": {
+      "name": "Tilt",
+      "fineChannelAliases": ["Tilt 2 fine"],
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Special Functions": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "Maintenance",
+          "comment": "Blackout while Pan and Tilt"
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "Maintenance",
+          "comment": "No blackout while Pan and Tilt"
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "Maintenance",
+          "comment": "Blackout while changing color"
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "Maintenance",
+          "comment": "No blackout while changing color"
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "Maintenance",
+          "comment": "Blackout while changing gobo"
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "Maintenance",
+          "comment": "No blackout while changing gobo"
+        },
+        {
+          "dmxRange": [56, 87],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "Maintenance",
+          "comment": "Blackout while moving"
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "Maintenance",
+          "comment": "Reset pan"
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "Maintenance",
+          "comment": "Reset tilt"
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "Maintenance",
+          "comment": "Reset color wheel"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "Maintenance",
+          "comment": "Reset gobo wheel"
+        },
+        {
+          "dmxRange": [128, 135],
+          "type": "Maintenance",
+          "comment": "Rset gobo rotation"
+        },
+        {
+          "dmxRange": [136, 143],
+          "type": "Maintenance",
+          "comment": "Reset prism"
+        },
+        {
+          "dmxRange": [144, 151],
+          "type": "Maintenance",
+          "comment": "Reset focus"
+        },
+        {
+          "dmxRange": [152, 159],
+          "type": "Maintenance",
+          "comment": "Reset all channels"
+        },
+        {
+          "dmxRange": [160, 255],
+          "type": "NoFunction"
+        }
+      ]
+    },
+    "Built-in Programs": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [8, 23],
+          "type": "Effect",
+          "effectName": "Program 1"
+        },
+        {
+          "dmxRange": [24, 39],
+          "type": "Effect",
+          "effectName": "Program 2"
+        },
+        {
+          "dmxRange": [40, 55],
+          "type": "Effect",
+          "effectName": "Program 3"
+        },
+        {
+          "dmxRange": [56, 71],
+          "type": "Effect",
+          "effectName": "Program 4"
+        },
+        {
+          "dmxRange": [72, 87],
+          "type": "Effect",
+          "effectName": "Program 5"
+        },
+        {
+          "dmxRange": [88, 103],
+          "type": "Effect",
+          "effectName": "Program 6"
+        },
+        {
+          "dmxRange": [104, 119],
+          "type": "Effect",
+          "effectName": "Program 7"
+        },
+        {
+          "dmxRange": [120, 135],
+          "type": "Effect",
+          "effectName": "Program 8"
+        },
+        {
+          "dmxRange": [136, 151],
+          "type": "Effect",
+          "effectName": "Music controlled 1",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [152, 167],
+          "type": "Effect",
+          "effectName": "Music controlled 2",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [168, 183],
+          "type": "Effect",
+          "effectName": "Music controlled 3",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [184, 199],
+          "type": "Effect",
+          "effectName": "Music controlled 4",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [200, 215],
+          "type": "Effect",
+          "effectName": "Music controlled 5",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [216, 231],
+          "type": "Effect",
+          "effectName": "Music controlled 6",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [232, 247],
+          "type": "Effect",
+          "effectName": "Music controlled 7",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "Effect",
+          "effectName": "Music controlled 8",
+          "soundControlled": true
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "8ch",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Color",
+        "Shutter",
+        "Gobo",
+        "Gobo Rotation",
+        "Prism",
+        "Focus"
+      ]
+    },
+    {
+      "name": "14ch",
+      "channels": [
+        "Pan 2",
+        "Tilt 2",
+        "Pan 2 fine",
+        "Tilt 2 fine",
+        "Speed",
+        "Color",
+        "Shutter",
+        "Dimmer",
+        "Gobo",
+        "Gobo Rotation",
+        "Special Functions",
+        "Built-in Programs",
+        "Prism",
+        "Focus"
+      ]
+    }
+  ]
+}

--- a/fixtures/stairville/mh-x50.json
+++ b/fixtures/stairville/mh-x50.json
@@ -4,8 +4,8 @@
   "categories": ["Moving Head", "Color Changer"],
   "meta": {
     "authors": ["Hannes Rüger"],
-    "createDate": "2020-07-15",
-    "lastModifyDate": "2020-07-15"
+    "createDate": "2020-07-16",
+    "lastModifyDate": "2020-07-16"
   },
   "links": {
     "manual": [

--- a/fixtures/stairville/mh-x50.json
+++ b/fixtures/stairville/mh-x50.json
@@ -119,6 +119,7 @@
   },
   "availableChannels": {
     "Pan": {
+      "fineChannelAliases": ["Pan fine"],
       "capability": {
         "type": "Pan",
         "angleStart": "0deg",
@@ -126,6 +127,7 @@
       }
     },
     "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
       "capability": {
         "type": "Tilt",
         "angleStart": "0deg",
@@ -255,7 +257,7 @@
           "type": "ShutterStrobe",
           "shutterEffect": "Strobe",
           "speedStart": "0Hz",
-          "speedEnd": "1Hz"
+          "speedEnd": "13Hz"
         },
         {
           "dmxRange": [216, 255],
@@ -426,40 +428,20 @@
     "Focus": {
       "capability": {
         "type": "Focus",
-        "distanceStart": "near",
-        "distanceEnd": "far"
-      }
-    },
-    "Pan 2": {
-      "name": "Pan",
-      "fineChannelAliases": ["Pan 2 fine"],
-      "capability": {
-        "type": "Pan",
-        "angleStart": "0deg",
-        "angleEnd": "540deg"
-      }
-    },
-    "Tilt 2": {
-      "name": "Tilt",
-      "fineChannelAliases": ["Tilt 2 fine"],
-      "capability": {
-        "type": "Tilt",
-        "angleStart": "0deg",
-        "angleEnd": "270deg"
+        "distanceStart": "far",
+        "distanceEnd": "near"
       }
     },
     "Speed": {
       "capability": {
         "type": "Speed",
-        "speedStart": "slow",
-        "speedEnd": "fast"
+        "speedStart": "fast",
+        "speedEnd": "slow"
       }
     },
     "Dimmer": {
       "capability": {
-        "type": "Intensity",
-        "brightnessStart": "0%",
-        "brightnessEnd": "100%"
+        "type": "Intensity"
       }
     },
     "Special Functions": {
@@ -667,10 +649,10 @@
     {
       "name": "14ch",
       "channels": [
-        "Pan 2",
-        "Tilt 2",
-        "Pan 2 fine",
-        "Tilt 2 fine",
+        "Pan",
+        "Tilt",
+        "Pan fine",
+        "Tilt fine",
         "Speed",
         "Color Wheel",
         "Shutter",

--- a/fixtures/stairville/mh-x50.json
+++ b/fixtures/stairville/mh-x50.json
@@ -9,7 +9,10 @@
   },
   "links": {
     "manual": [
-      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/250558_c_250558_v3_de_online.pdf"
+      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/250558_c_250558_v3_en_online.pdf"
+    ],
+    "productPage": [
+      "https://www.thomann.de/intl/stairville_mhx50_led_spot_moving_head.htm"
     ],
     "video": [
       "https://video2.thomann.de//vidiot/02591c1c/video_i2514p10_yd59vqpa.mp4"

--- a/fixtures/stairville/mh-x50.json
+++ b/fixtures/stairville/mh-x50.json
@@ -24,7 +24,7 @@
     "power": 135,
     "DMXconnector": "3-pin",
     "bulb": {
-      "type": "LED",
+      "type": "50W LED",
       "lumens": 940
     },
     "lens": {


### PR DESCRIPTION
* Add fixture 'stairville/mh-x50'

### Fixture warnings / errors

* stairville/mh-x50
  - :x: Capability 'Wheel slot rotation stop' (0…63) in channel 'Gobo Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation CW slow…fast' (64…147) in channel 'Gobo Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation CCW slow…fast' (148…231) in channel 'Gobo Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation speed 100% (Gobo Jumping)' (232…255) in channel 'Gobo Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Rotation' (through the channel name) does not exist.
  - :warning: Name of wheel 'Color' does not contain the word 'wheel' or 'disk', which could lead to confusing capability names.
  - :warning: Name of wheel 'Gobo' does not contain the word 'wheel' or 'disk', which could lead to confusing capability names.
  - :warning: Unused wheel slot(s): Color (slot 19), Color (slot 20), Gobo (slot 9), Gobo (slot 10), Gobo (slot 11), Gobo (slot 12), Gobo (slot 13), Gobo (slot 14)


Thank you @hrueger!