### PR TITLE
Revert "Bump @nuxtjs/axios from 5.12.0 to 5.12.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2939,28 +2939,21 @@
       }
     },
     "@nuxtjs/axios": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/axios/-/axios-5.12.1.tgz",
-      "integrity": "sha512-zRqCRN1Omp0aHZLbSlZTMH2i/2oafGJZbzBM1Aw0KzfwphofNJBIq0ue2k+fgbVXSX6fj53FNxL50sAwaGyAMA==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/axios/-/axios-5.12.0.tgz",
+      "integrity": "sha512-VQI9Nnf12jWknldrgCNGzCQxnWO3/CvMwrkWKNUr3WtGYuOKryUOd1XXxDbaJmopfX4SGjKvDL1G6qTkWLiPew==",
       "requires": {
-        "@nuxtjs/proxy": "^2.0.1",
+        "@nuxtjs/proxy": "^2.0.0",
         "axios": "^0.19.2",
         "axios-retry": "^3.1.8",
         "consola": "^2.14.0",
-        "defu": "^3.1.0"
-      },
-      "dependencies": {
-        "defu": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/defu/-/defu-3.1.0.tgz",
-          "integrity": "sha512-pc7vS4wbYFtsRL+OaLHKD72VcpOz9eYgzZeoLz9pCs+R8htyPdZnD1CxKP9ttZuT90CLPYFTSaTyc3/7v4gG9A=="
-        }
+        "defu": "^2.0.4"
       }
     },
     "@nuxtjs/proxy": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/proxy/-/proxy-2.0.1.tgz",
-      "integrity": "sha512-RVZ6iYeAuWteot9oer3vTDCOEiTwg37Mqf6yy8vPD0QQaw4z3ykgM++MzfUl85jM14+qNnODZj5EATRoCY009Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/proxy/-/proxy-2.0.0.tgz",
+      "integrity": "sha512-ewiOLAhfQlE/QWiQkHH0MQBYrtTRRSuz5SqDly1Zy/M3cN9bxqWd9d5Ty/GnU3nLtwsfW64TrRKuTw8/gT1nFQ==",
       "requires": {
         "consola": "^2.11.3",
         "http-proxy-middleware": "^1.0.4"
@@ -9064,6 +9057,11 @@
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
         },
         "micromatch": {
           "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.6",
     "@heise/embetty-server": "^2.0.3",
-    "@nuxtjs/axios": "^5.12.1",
+    "@nuxtjs/axios": "^5.12.0",
     "@octokit/rest": "~18.0.3",
     "a11y-dialog": "^5.3.2",
     "ajv": "^6.12.3",


### PR DESCRIPTION
Reverts #1402.

Due to https://github.com/nuxt-community/axios-module/issues/401 (which didn't appear in the GitHub Actions CI, curiously).