### PR TITLE
Fix AGLight plugin corrupting other export plugins

### DIFF
--- a/plugins/aglight/export.js
+++ b/plugins/aglight/export.js
@@ -68,7 +68,7 @@ function transformMatrixChannels(fixtureJson, fixture) {
 
   fixtureJson.availableChannels = Object.fromEntries(
     availableAndMatrixChannels.map(channel => {
-      let channelJsonObject = channel.jsonObject;
+      let channelJsonObject = JSON.parse(JSON.stringify(channel.jsonObject));
 
       if (channel.pixelKey) {
         channelJsonObject = Object.assign({}, channelJsonObject, {


### PR DESCRIPTION
After exporting with AGLight once, most other plugin exports (Colorsource, D::Light, e:cue, Millumin, QLC+ 4.12.2) failed with the following error (e.g. in [this Travis run](https://travis-ci.org/github/OpenLightingProject/open-fixture-library/builds/728378736) from #1453):

```
Exporting with current plugin script failed: TypeError: Cannot read property '0' of undefined
    at Capability.getDmxRangeWithResolution (/home/travis/build/OpenLightingProject/open-fixture-library/lib/model/Capability.js:318:34)
    at /home/travis/build/OpenLightingProject/open-fixture-library/plugins/colorsource/export.js:249:30
    at Array.map (<anonymous>)
    at addColorSourceChannelDetails (/home/travis/build/OpenLightingProject/open-fixture-library/plugins/colorsource/export.js:248:49)
    at /home/travis/build/OpenLightingProject/open-fixture-library/plugins/colorsource/export.js:207:7
    at Array.forEach (<anonymous>)
    at getColorSourceChannels (/home/travis/build/OpenLightingProject/open-fixture-library/plugins/colorsource/export.js:167:17)
    at /home/travis/build/OpenLightingProject/open-fixture-library/plugins/colorsource/export.js:46:26
    at Array.forEach (<anonymous>)
    at /home/travis/build/OpenLightingProject/open-fixture-library/plugins/colorsource/export.js:43:19
```

This was caused by modifying the cached JSON object, instead of correctly copying it first.