### PR TITLE
ETC S4 daylight and tungsten

### DIFF
--- a/fixtures/etc/source-four-led-series-2-daylight-hd.json
+++ b/fixtures/etc/source-four-led-series-2-daylight-hd.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Source Four LED Series 2 Lustr",
-  "shortName": "EtcSF2Lustr",
+  "name": "Source Four LED Series 2 Daylight HD",
+  "shortName": "EtcSF2DaylightHD",
   "categories": ["Dimmer", "Color Changer", "Strobe"],
   "meta": {
     "authors": ["Jeppe Cohrt", "Dyami Caliri"],
@@ -17,16 +17,17 @@
       "https://www.etcconnect.com/Products/Lighting-Fixtures/Source-Four-LED-Series-2/Features.aspx"
     ],
     "video": [
+      "https://www.youtube.com/watch?v=FXQDFq9jxI0",
       "https://www.youtube.com/watch?v=oEjG8XLzuvs"
     ]
   },
   "physical": {
     "dimensions": [338, 615, 631],
     "weight": 8.3,
-    "power": 171,
+    "power": 248,
     "DMXconnector": "5-pin",
     "bulb": {
-      "type": "Seven-color LED array"
+      "type": "Four-color LED array"
     }
   },
   "availableChannels": {
@@ -36,28 +37,10 @@
         "color": "Red"
       }
     },
-    "Lime": {
+    "Mint": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Lime"
-      }
-    },
-    "Amber": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Amber"
-      }
-    },
-    "Green": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Green"
-      }
-    },
-    "Cyan": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Cyan"
       }
     },
     "Blue": {
@@ -202,13 +185,21 @@
   },
   "modes": [
     {
+      "name": "Studio",
+      "channels": [
+        "Intensity",
+        "Color Point",
+        "Tint",
+        null,
+        "Strobe",
+        "Fan Control"
+      ]
+    },
+    {
       "name": "Direct",
       "channels": [
         "Red",
-        "Lime",
-        "Amber",
-        "Green",
-        "Cyan",
+        "Mint",
         "Blue",
         "Indigo",
         "Intensity",
@@ -251,17 +242,6 @@
       ]
     },
     {
-      "name": "Studio",
-      "channels": [
-        "Intensity",
-        "Color Point",
-        "Tint",
-        null,
-        "Strobe",
-        "Fan Control"
-      ]
-    },
-    {
       "name": "HSI Plus 7",
       "shortName": "HSI+7",
       "channels": [
@@ -274,12 +254,12 @@
         null,
         "Plus 7 Control",
         "Red",
-        "Lime",
-        "Amber",
-        "Green",
-        "Cyan",
+        null,
+        "Mint",
         "Blue",
-        "Indigo"
+        "Indigo",
+        null,
+        null
       ]
     },
     {
@@ -296,12 +276,12 @@
         null,
         "Plus 7 Control",
         "Red",
-        "Lime",
-        "Amber",
-        "Green",
-        "Cyan",
+        null,
+        "Mint",
         "Blue",
-        "Indigo"
+        "Indigo",
+        null,
+        null
       ]
     },
     {
@@ -317,12 +297,12 @@
         null,
         "Plus 7 Control",
         "Red",
-        "Lime",
-        "Amber",
-        "Green",
-        "Cyan",
+        null,
+        "Mint",
         "Blue",
-        "Indigo"
+        "Indigo",
+        null,
+        null
       ]
     }
   ]

--- a/fixtures/etc/source-four-led-series-2-daylight-hd.json
+++ b/fixtures/etc/source-four-led-series-2-daylight-hd.json
@@ -4,9 +4,9 @@
   "shortName": "EtcSF2DaylightHD",
   "categories": ["Dimmer", "Color Changer", "Strobe"],
   "meta": {
-    "authors": ["Jeppe Cohrt", "Dyami Caliri"],
+    "authors": ["Dyami Caliri"],
     "createDate": "2019-07-11",
-    "lastModifyDate": "2020-10-01"
+    "lastModifyDate": "2020-10-02"
   },
   "links": {
     "manual": [

--- a/fixtures/etc/source-four-led-series-2-daylight-hd.json
+++ b/fixtures/etc/source-four-led-series-2-daylight-hd.json
@@ -88,14 +88,10 @@
           "comment": "Fan auto"
         },
         {
-          "dmxRange": [1, 254],
-          "type": "Maintenance",
-          "comment": "Fan low to high"
-        },
-        {
-          "dmxRange": [255, 255],
-          "type": "Maintenance",
-          "comment": "Fan high"
+          "dmxRange": [1, 255],
+          "type": "Rotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
         }
       ]
     },

--- a/fixtures/etc/source-four-led-series-2-daylight-hd.json
+++ b/fixtures/etc/source-four-led-series-2-daylight-hd.json
@@ -27,7 +27,11 @@
     "power": 248,
     "DMXconnector": "5-pin",
     "bulb": {
-      "type": "Four-color LED array"
+      "type": "60× 4-color Lumileds LUXEON® Rebel LED",
+      "lumens": 13060
+    },
+    "lens": {
+      "degreesMinMax": [5, 90]
     }
   },
   "availableChannels": {

--- a/fixtures/etc/source-four-led-series-2-lustr.json
+++ b/fixtures/etc/source-four-led-series-2-lustr.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Jeppe Cohrt", "Dyami Caliri"],
     "createDate": "2019-07-11",
-    "lastModifyDate": "2020-10-01"
+    "lastModifyDate": "2020-10-02"
   },
   "links": {
     "manual": [

--- a/fixtures/etc/source-four-led-series-2-lustr.json
+++ b/fixtures/etc/source-four-led-series-2-lustr.json
@@ -105,14 +105,10 @@
           "comment": "Fan auto"
         },
         {
-          "dmxRange": [1, 254],
-          "type": "Maintenance",
-          "comment": "Fan low to high"
-        },
-        {
-          "dmxRange": [255, 255],
-          "type": "Maintenance",
-          "comment": "Fan high"
+          "dmxRange": [1, 255],
+          "type": "Rotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
         }
       ]
     },

--- a/fixtures/etc/source-four-led-series-2-lustr.json
+++ b/fixtures/etc/source-four-led-series-2-lustr.json
@@ -26,7 +26,11 @@
     "power": 171,
     "DMXconnector": "5-pin",
     "bulb": {
-      "type": "Seven-color LED array"
+      "type": "60× 7-color Lumileds LUXEON® Rebel LED",
+      "lumens": 8667
+    },
+    "lens": {
+      "degreesMinMax": [5, 90]
     }
   },
   "availableChannels": {

--- a/fixtures/etc/source-four-led-series-2-tungsten-hd.json
+++ b/fixtures/etc/source-four-led-series-2-tungsten-hd.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Source Four LED Series 2 Lustr",
-  "shortName": "EtcSF2Lustr",
+  "name": "Source Four LED Series 2 Tungsten HD",
+  "shortName": "EtcSF2TungstenHD",
   "categories": ["Dimmer", "Color Changer", "Strobe"],
   "meta": {
     "authors": ["Jeppe Cohrt", "Dyami Caliri"],
@@ -17,16 +17,17 @@
       "https://www.etcconnect.com/Products/Lighting-Fixtures/Source-Four-LED-Series-2/Features.aspx"
     ],
     "video": [
+      "https://www.youtube.com/watch?v=FXQDFq9jxI0",
       "https://www.youtube.com/watch?v=oEjG8XLzuvs"
     ]
   },
   "physical": {
     "dimensions": [338, 615, 631],
     "weight": 8.3,
-    "power": 171,
+    "power": 208,
     "DMXconnector": "5-pin",
     "bulb": {
-      "type": "Seven-color LED array"
+      "type": "Five-color LED array"
     }
   },
   "availableChannels": {
@@ -36,28 +37,16 @@
         "color": "Red"
       }
     },
-    "Lime": {
+    "Red Orange": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Mint": {
       "capability": {
         "type": "ColorIntensity",
         "color": "Lime"
-      }
-    },
-    "Amber": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Amber"
-      }
-    },
-    "Green": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Green"
-      }
-    },
-    "Cyan": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Cyan"
       }
     },
     "Blue": {
@@ -202,13 +191,22 @@
   },
   "modes": [
     {
+      "name": "Studio",
+      "channels": [
+        "Intensity",
+        "Color Point",
+        "Tint",
+        null,
+        "Strobe",
+        "Fan Control"
+      ]
+    },
+    {
       "name": "Direct",
       "channels": [
         "Red",
-        "Lime",
-        "Amber",
-        "Green",
-        "Cyan",
+        "Red Orange",
+        "Mint",
         "Blue",
         "Indigo",
         "Intensity",
@@ -251,17 +249,6 @@
       ]
     },
     {
-      "name": "Studio",
-      "channels": [
-        "Intensity",
-        "Color Point",
-        "Tint",
-        null,
-        "Strobe",
-        "Fan Control"
-      ]
-    },
-    {
       "name": "HSI Plus 7",
       "shortName": "HSI+7",
       "channels": [
@@ -274,12 +261,12 @@
         null,
         "Plus 7 Control",
         "Red",
-        "Lime",
-        "Amber",
-        "Green",
-        "Cyan",
+        "Red Orange",
+        "Mint",
         "Blue",
-        "Indigo"
+        "Indigo",
+        null,
+        null
       ]
     },
     {
@@ -296,12 +283,12 @@
         null,
         "Plus 7 Control",
         "Red",
-        "Lime",
-        "Amber",
-        "Green",
-        "Cyan",
+        "Red Orange",
+        "Mint",
         "Blue",
-        "Indigo"
+        "Indigo",
+        null,
+        null
       ]
     },
     {
@@ -317,12 +304,12 @@
         null,
         "Plus 7 Control",
         "Red",
-        "Lime",
-        "Amber",
-        "Green",
-        "Cyan",
+        null,
+        "Mint",
         "Blue",
-        "Indigo"
+        "Indigo",
+        null,
+        null
       ]
     }
   ]

--- a/fixtures/etc/source-four-led-series-2-tungsten-hd.json
+++ b/fixtures/etc/source-four-led-series-2-tungsten-hd.json
@@ -94,14 +94,10 @@
           "comment": "Fan auto"
         },
         {
-          "dmxRange": [1, 254],
-          "type": "Maintenance",
-          "comment": "Fan low to high"
-        },
-        {
-          "dmxRange": [255, 255],
-          "type": "Maintenance",
-          "comment": "Fan high"
+          "dmxRange": [1, 255],
+          "type": "Rotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
         }
       ]
     },

--- a/fixtures/etc/source-four-led-series-2-tungsten-hd.json
+++ b/fixtures/etc/source-four-led-series-2-tungsten-hd.json
@@ -27,7 +27,11 @@
     "power": 208,
     "DMXconnector": "5-pin",
     "bulb": {
-      "type": "Five-color LED array"
+      "type": "60× 5-color Lumileds LUXEON® Rebel LED",
+      "lumens": 11512
+    },
+    "lens": {
+      "degreesMinMax": [5, 90]
     }
   },
   "availableChannels": {

--- a/fixtures/etc/source-four-led-series-2-tungsten-hd.json
+++ b/fixtures/etc/source-four-led-series-2-tungsten-hd.json
@@ -4,9 +4,9 @@
   "shortName": "EtcSF2TungstenHD",
   "categories": ["Dimmer", "Color Changer", "Strobe"],
   "meta": {
-    "authors": ["Jeppe Cohrt", "Dyami Caliri"],
+    "authors": ["Dyami Caliri"],
     "createDate": "2019-07-11",
-    "lastModifyDate": "2020-10-01"
+    "lastModifyDate": "2020-10-02"
   },
   "links": {
     "manual": [


### PR DESCRIPTION
Added ETC source four series 2 Daylight HD and Tungsten HD fixtures, and filled in some missing info on Lustr.