### PR TITLE
Add missing ARRI Skypanel fixture variants

### DIFF
--- a/fixtures/arri/skypanel-s120c.json
+++ b/fixtures/arri/skypanel-s120c.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Skypanel S30C",
+  "name": "Skypanel S120C",
   "categories": ["Dimmer", "Color Changer", "Strobe"],
   "meta": {
     "authors": ["Jean-François Losson", "Dyami Caliri"],
-    "createDate": "2018-10-17",
+    "createDate": "2020-10-02",
     "lastModifyDate": "2020-10-02"
   },
   "links": {
@@ -13,26 +13,22 @@
       "https://www.arri.com/resource/blob/65958/560471fec7f8f2e186ef8ca9e6cdd489/arri-skypanel-dmx-protocol-specification-v4-4-en-okt2018-data.pdf"
     ],
     "productPage": [
-      "https://www.arri.com/en/lighting/led/skypanel/s30-c"
+      "https://www.arri.com/en/lighting/led/skypanel/s120-c"
     ],
     "video": [
       "https://www.youtube.com/watch?v=Qq9xhKwpZqc"
     ]
   },
-  "rdm": {
-    "modelId": 514,
-    "softwareVersion": "4.1"
-  },
   "physical": {
-    "dimensions": [499, 133, 397],
-    "weight": 8,
-    "power": 220,
+    "dimensions": [1332, 347, 133],
+    "weight": 13.7,
+    "power": 400,
     "DMXconnector": "5-pin",
     "bulb": {
       "type": "LED"
     },
     "lens": {
-      "degreesMinMax": [115, 115]
+      "degreesMinMax": [110, 110]
     }
   },
   "availableChannels": {

--- a/fixtures/arri/skypanel-s30c.json
+++ b/fixtures/arri/skypanel-s30c.json
@@ -3,9 +3,9 @@
   "name": "Skypanel S30C",
   "categories": ["Dimmer", "Color Changer", "Strobe"],
   "meta": {
-    "authors": ["Jean-François Losson", "Dyami Caliri"],
+    "authors": ["Jean-François Losson"],
     "createDate": "2018-10-17",
-    "lastModifyDate": "2020-10-02"
+    "lastModifyDate": "2018-10-17"
   },
   "links": {
     "manual": [

--- a/fixtures/arri/skypanel-s360c.json
+++ b/fixtures/arri/skypanel-s360c.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Skypanel S30C",
+  "name": "Skypanel S360C",
   "categories": ["Dimmer", "Color Changer", "Strobe"],
   "meta": {
     "authors": ["Jean-François Losson", "Dyami Caliri"],
-    "createDate": "2018-10-17",
+    "createDate": "2020-10-02",
     "lastModifyDate": "2020-10-02"
   },
   "links": {
@@ -13,26 +13,22 @@
       "https://www.arri.com/resource/blob/65958/560471fec7f8f2e186ef8ca9e6cdd489/arri-skypanel-dmx-protocol-specification-v4-4-en-okt2018-data.pdf"
     ],
     "productPage": [
-      "https://www.arri.com/en/lighting/led/skypanel/s30-c"
+      "https://www.arri.com/en/lighting/led/skypanel/s360-c"
     ],
     "video": [
-      "https://www.youtube.com/watch?v=Qq9xhKwpZqc"
+      "https://www.youtube.com/watch?v=0S35iTuTxBo"
     ]
   },
-  "rdm": {
-    "modelId": 514,
-    "softwareVersion": "4.1"
-  },
   "physical": {
-    "dimensions": [499, 133, 397],
-    "weight": 8,
-    "power": 220,
+    "dimensions": [1331, 947, 186],
+    "weight": 41,
+    "power": 1500,
     "DMXconnector": "5-pin",
     "bulb": {
       "type": "LED"
     },
     "lens": {
-      "degreesMinMax": [115, 115]
+      "degreesMinMax": [105, 105]
     }
   },
   "availableChannels": {

--- a/fixtures/arri/skypanel-s60c.json
+++ b/fixtures/arri/skypanel-s60c.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Skypanel S30C",
+  "name": "Skypanel S60C",
   "categories": ["Dimmer", "Color Changer", "Strobe"],
   "meta": {
     "authors": ["Jean-François Losson", "Dyami Caliri"],
-    "createDate": "2018-10-17",
+    "createDate": "2020-10-02",
     "lastModifyDate": "2020-10-02"
   },
   "links": {
@@ -13,20 +13,17 @@
       "https://www.arri.com/resource/blob/65958/560471fec7f8f2e186ef8ca9e6cdd489/arri-skypanel-dmx-protocol-specification-v4-4-en-okt2018-data.pdf"
     ],
     "productPage": [
-      "https://www.arri.com/en/lighting/led/skypanel/s30-c"
+      "https://www.arri.com/en/lighting/led/skypanel/s60-c"
     ],
     "video": [
-      "https://www.youtube.com/watch?v=Qq9xhKwpZqc"
+      "https://www.youtube.com/watch?v=dXyYn9xfGXY",
+      "https://www.youtube.com/watch?v=2xrOoLjaFfU"
     ]
   },
-  "rdm": {
-    "modelId": 514,
-    "softwareVersion": "4.1"
-  },
   "physical": {
-    "dimensions": [499, 133, 397],
-    "weight": 8,
-    "power": 220,
+    "dimensions": [688, 347, 133],
+    "weight": 12.8,
+    "power": 420,
     "DMXconnector": "5-pin",
     "bulb": {
       "type": "LED"


### PR DESCRIPTION
Add Skypanel S60C, S120C and S360C, which all use the same protocol as the S30C.