### PR TITLE
Fix scoped CSS issues

### DIFF
--- a/ui/components/HelpWantedMessage.vue
+++ b/ui/components/HelpWantedMessage.vue
@@ -61,12 +61,9 @@
   flex-wrap: wrap;
   font-size: 90%;
 
-  a, noscript {
+  a {
     flex-grow: 1;
     flex-basis: 10em;
-  }
-
-  a {
     display: inline-block;
     padding: 0.4em 0.6em;
     color: theme-color(text-primary);

--- a/ui/components/editor/EditorPhysical.vue
+++ b/ui/components/editor/EditorPhysical.vue
@@ -108,12 +108,6 @@
   </div>
 </template>
 
-<style lang="scss" scoped>
-.infinitePanTilt {
-  margin-left: 2ex;
-}
-</style>
-
 <script>
 import { clone } from '../../assets/scripts/editor-utils.js';
 import schemaProperties from '../../../lib/schema-properties.js';

--- a/ui/components/fixture-page/FixturePageChannel.vue
+++ b/ui/components/fixture-page/FixturePageChannel.vue
@@ -140,17 +140,6 @@ summary, .summary {
     margin-right: 0;
   }
 }
-
-ol.mode-channels {
-  padding-left: 1.9em;
-  min-height: 1em;
-
-  // switched channels
-  & ol {
-    list-style-type: lower-alpha;
-    padding-left: 1.1em;
-  }
-}
 </style>
 
 <script>

--- a/ui/components/fixture-page/FixturePageMode.vue
+++ b/ui/components/fixture-page/FixturePageMode.vue
@@ -48,6 +48,17 @@
 .collapse-all {
   margin-left: 1ex;
 }
+
+ol.mode-channels {
+  padding-left: 1.9em;
+  min-height: 1em;
+
+  // switched channels
+  ::v-deep ol {
+    list-style-type: lower-alpha;
+    padding-left: 1.1em;
+  }
+}
 </style>
 
 <script>


### PR DESCRIPTION
Reported by https://github.com/future-architect/eslint-plugin-vue-scoped-css.

It doesn't make sense to continually enable the plugin though, as most issues can only really be fixed in Vue.js v3:

* use `::v-deep(…)` instead of `::v-deep …`
* use `::v-global(…)` and make the style block scoped