### PR TITLE
Use Promise-based APIs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,19 @@ const enabledRuleParameters = {
   'promise/valid-params': [],
 
   // eslint-plugin-unicorn
+  'unicorn/import-style': [{
+    styles: {
+      fs: {
+        unassigned: false,
+        default: false,
+        namespace: false,
+        named: false,
+      },
+      'fs/promises': {
+        named: true,
+      },
+    },
+  }],
   'unicorn/numeric-separators-style': [],
   'unicorn/prevent-abbreviations': [{
     replacements: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,7 @@ const enabledRuleParameters = {
   'no-new-object': [],
   'no-prototype-builtins': [],
   'no-return-assign': [],
+  'no-return-await': [],
   'no-shadow': [{ builtinGlobals: false }],
   'no-template-curly-in-string': [],
   'no-trailing-spaces': [],

--- a/cli/export-fixture.js
+++ b/cli/export-fixture.js
@@ -1,5 +1,5 @@
 #!/usr/bin/node
-const fs = require(`fs`);
+const { writeFile } = require(`fs/promises`);
 const path = require(`path`);
 const minimist = require(`minimist`);
 const chalk = require(`chalk`);
@@ -78,7 +78,7 @@ const outDirectory = cliArguments.o ? path.resolve(process.cwd(), cliArguments.o
       if (cliArguments.o) {
         const filePath = path.join(outDirectory, file.name);
         await mkdirp(path.dirname(filePath));
-        fs.writeFileSync(filePath, file.content);
+        await writeFile(filePath, file.content);
         console.log(`Created file ${filePath}`);
       }
       else {

--- a/cli/export-fixture.js
+++ b/cli/export-fixture.js
@@ -68,7 +68,9 @@ const outDirectory = cliArguments.o ? path.resolve(process.cwd(), cliArguments.o
   try {
     const plugin = require(path.join(__dirname, `../plugins`, cliArguments.plugin, `export.js`));
     const files = await plugin.export(
-      fixtures.map(([manufacturer, fixture]) => fixtureFromRepository(manufacturer, fixture)),
+      await Promise.all(fixtures.map(
+        ([manufacturer, fixture]) => fixtureFromRepository(manufacturer, fixture),
+      )),
       {
         baseDirectory: path.join(__dirname, `..`),
         date: new Date(),

--- a/cli/import-fixture.js
+++ b/cli/import-fixture.js
@@ -48,7 +48,7 @@ if (cliArguments._.length !== 1 || !plugins.importPlugins.includes(cliArguments.
     for (const key of Object.keys(result.fixtures)) {
       const [manufacturerKey, fixtureKey] = key.split(`/`);
 
-      const checkResult = checkFixture(manufacturerKey, fixtureKey, result.fixtures[key]);
+      const checkResult = await checkFixture(manufacturerKey, fixtureKey, result.fixtures[key]);
 
       result.warnings[key] = result.warnings[key].concat(checkResult.warnings);
       result.errors[key] = checkResult.errors;

--- a/cli/import-fixture.js
+++ b/cli/import-fixture.js
@@ -2,8 +2,7 @@
 
 const path = require(`path`);
 const minimist = require(`minimist`);
-const promisify = require(`util`).promisify;
-const readFile = promisify(require(`fs`).readFile);
+const { readFile } = require(`fs/promises`);
 
 const { checkFixture } = require(`../tests/fixture-valid.js`);
 const plugins = require(`../plugins/plugins.json`);

--- a/cli/make-dereferenced-schemas.js
+++ b/cli/make-dereferenced-schemas.js
@@ -1,19 +1,19 @@
 #!/usr/bin/node
 
-const fs = require(`fs`);
+const { readdir, writeFile } = require(`fs/promises`);
 const path = require(`path`);
 const chalk = require(`chalk`);
 const schemaRefParser = require(`@apidevtools/json-schema-ref-parser`);
 
 const schemaDirectory = path.join(__dirname, `../schemas/`);
 
-const schemaFiles = process.argv.length > 2
-  ? process.argv.slice(2)
-  : fs.readdirSync(schemaDirectory).filter(
-    schemaFile => path.extname(schemaFile) === `.json`,
-  );
-
 (async () => {
+  const schemaFiles = process.argv.length > 2
+    ? process.argv.slice(2)
+    : await readdir(schemaDirectory).filter(
+      schemaFile => path.extname(schemaFile) === `.json`,
+    );
+
   process.chdir(schemaDirectory);
   for (const schemaFile of schemaFiles) {
     const schema = require(path.join(schemaDirectory, schemaFile));
@@ -21,7 +21,7 @@ const schemaFiles = process.argv.length > 2
 
     try {
       const dereferencedSchema = await schemaRefParser.dereference(schema);
-      fs.writeFileSync(
+      await writeFile(
         dereferencedSchemaFile,
         `${JSON.stringify(dereferencedSchema, null, 2)}\n`,
       );

--- a/cli/make-plugin-data.js
+++ b/cli/make-plugin-data.js
@@ -1,7 +1,12 @@
 #!/usr/bin/node
 
 const path = require(`path`);
-const fs = require(`fs`);
+const {
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} = require(`fs/promises`);
 const chalk = require(`chalk`);
 
 const plugins = {
@@ -13,24 +18,59 @@ const plugins = {
 const allPreviousVersions = {};
 
 const pluginDirectory = path.join(__dirname, `../plugins`);
-for (const pluginKey of fs.readdirSync(pluginDirectory)) {
-  const pluginPath = path.join(pluginDirectory, pluginKey);
 
-  // files are not plugins
-  if (!fs.statSync(pluginPath).isDirectory()) {
-    continue;
+(async () => {
+  const directoryEntries = await readdir(pluginDirectory, { withFileTypes: true });
+  const pluginKeys = directoryEntries.filter(entry => entry.isDirectory()).map(entry => entry.name);
+
+  for (const pluginKey of pluginKeys) {
+    plugins.data[pluginKey] = {};
+
+    await readPluginJson(pluginKey);
+    await readPluginImport(pluginKey);
+    await readPluginExport(pluginKey);
+    await readPluginExportTests(pluginKey);
   }
 
-  const data = {
-    name: null,
-  };
-  plugins.data[pluginKey] = data;
+  for (const [key, data] of Object.entries(allPreviousVersions)) {
+    if (key in plugins.data) {
+      plugins.data[key].newPlugin = data.newPlugin;
+    }
+    else {
+      plugins.data[key] = data;
+    }
+  }
 
-  const pluginJsonPath = path.join(pluginPath, `plugin.json`);
-  if (fs.existsSync(pluginJsonPath)) {
-    const pluginJson = require(pluginJsonPath);
+  // sort plugin data object by key
+  const sortedPluginData = {};
+  Object.keys(plugins.data).sort().forEach(key => {
+    sortedPluginData[key] = plugins.data[key];
+  });
+  plugins.data = sortedPluginData;
 
-    data.name = pluginJson.name;
+  const filename = path.join(pluginDirectory, `plugins.json`);
+
+  try {
+    await writeFile(filename, `${JSON.stringify(plugins, null, 2)}\n`, `utf8`);
+    console.log(chalk.green(`[Success]`), `Updated plugin data file`, filename);
+    process.exit(0);
+  }
+  catch (error) {
+    console.error(chalk.red(`[Fail]`), `Could not write plugin data file.`, error);
+    process.exit(1);
+  }
+})();
+
+
+/**
+ * Reads information from the plugin's `plugin.json` file into `plugins` and `allPreviousVersions`.
+ * @param {String} pluginKey The plugin key.
+ */
+async function readPluginJson(pluginKey) {
+  const pluginJsonPath = path.join(pluginDirectory, pluginKey, `plugin.json`);
+  try {
+    const pluginJson = JSON.parse(await readFile(pluginJsonPath));
+    plugins.data[pluginKey].name = pluginJson.name;
 
     if (pluginJson.previousVersions) {
       Object.entries(pluginJson.previousVersions).forEach(([key, name]) => {
@@ -42,73 +82,79 @@ for (const pluginKey of fs.readdirSync(pluginDirectory)) {
       });
     }
   }
-  else {
-    console.error(`Plugin ${pluginKey} does not contain a plugin.json file.`);
+  catch (error) {
+    console.error(`Plugin ${pluginKey} does not contain a valid plugin.json file:`, error);
     process.exit(1);
-  }
-
-  const importPath = path.join(pluginPath, `import.js`);
-  if (fs.existsSync(importPath)) {
-    try {
-      const importPlugin = require(importPath);
-      plugins.importPlugins.push(pluginKey);
-      data.importPluginVersion = importPlugin.version;
-    }
-    catch (error) {
-      console.error(error.message);
-      process.exit(1);
-    }
-  }
-
-  const exportPath = path.join(pluginPath, `export.js`);
-  if (fs.existsSync(exportPath)) {
-    try {
-      const exportPlugin = require(exportPath);
-      plugins.exportPlugins.push(pluginKey);
-      data.exportPluginVersion = exportPlugin.version;
-      data.exportTests = [];
-    }
-    catch (error) {
-      console.error(error.message);
-      process.exit(1);
-    }
-  }
-
-  const exportTestsPath = path.join(pluginPath, `exportTests`);
-  if (fs.existsSync(exportTestsPath)) {
-    try {
-      for (const test of fs.readdirSync(exportTestsPath)) {
-        const testKey = path.basename(test, path.extname(test));
-        data.exportTests.push(testKey);
-      }
-    }
-    catch (error) {
-      console.error(error.message);
-      process.exit(1);
-    }
   }
 }
 
-for (const [key, data] of Object.entries(allPreviousVersions)) {
-  if (key in plugins.data) {
-    plugins.data[key].newPlugin = data.newPlugin;
+/**
+ * Reads information from the plugin's `import.js` file (if it exists) into `plugins`.
+ * @param {String} pluginKey The plugin key.
+ */
+async function readPluginImport(pluginKey) {
+  const importPath = path.join(pluginDirectory, pluginKey, `import.js`);
+  try {
+    await stat(importPath);
+    const importPlugin = require(importPath);
+    plugins.importPlugins.push(pluginKey);
+    plugins.data[pluginKey].importPluginVersion = importPlugin.version;
   }
-  else {
-    plugins.data[key] = data;
+  catch (error) {
+    if (error.code === `ENOENT`) {
+      // ignore non-existing file
+      return;
+    }
+
+    console.error(error.message);
+    process.exit(1);
   }
 }
 
-// sort plugin data object by key
-const sortedPluginData = {};
-Object.keys(plugins.data).sort().forEach(key => (sortedPluginData[key] = plugins.data[key]));
-plugins.data = sortedPluginData;
+/**
+ * Reads information from the plugin's `export.js` file (if it exists) into `plugins`.
+ * @param {String} pluginKey The plugin key.
+ */
+async function readPluginExport(pluginKey) {
+  const exportPath = path.join(pluginDirectory, pluginKey, `export.js`);
+  try {
+    await stat(exportPath);
+    const exportPlugin = require(exportPath);
+    plugins.exportPlugins.push(pluginKey);
+    plugins.data[pluginKey].exportPluginVersion = exportPlugin.version;
+    plugins.data[pluginKey].exportTests = [];
+  }
+  catch (error) {
+    if (error.code === `ENOENT`) {
+      // ignore non-existing file
+      return;
+    }
 
-const filename = path.join(pluginDirectory, `plugins.json`);
-fs.writeFile(filename, `${JSON.stringify(plugins, null, 2)}\n`, `utf8`, error => {
-  if (error) {
-    console.error(chalk.red(`[Fail]`), `Could not write plugin data file.`, error);
+    console.error(error.message);
     process.exit(1);
   }
-  console.log(chalk.green(`[Success]`), `Updated plugin data file`, filename);
-  process.exit(0);
-});
+}
+
+/**
+ * Adds the plugin's export tests (if any) to `plugins`.
+ * @param {String} pluginKey The plugin key.
+ */
+async function readPluginExportTests(pluginKey) {
+  const exportTestsPath = path.join(pluginDirectory, pluginKey, `exportTests`);
+  try {
+    const exportTestFiles = await readdir(exportTestsPath);
+    for (const test of exportTestFiles) {
+      const testKey = path.basename(test, path.extname(test));
+      plugins.data[pluginKey].exportTests.push(testKey);
+    }
+  }
+  catch (error) {
+    if (error.code === `ENOENT`) {
+      // ignore non-existing directory
+      return;
+    }
+
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/cli/make-register.js
+++ b/cli/make-register.js
@@ -1,6 +1,10 @@
 #!/usr/bin/node
 
-const fs = require(`fs`);
+const {
+  readdir,
+  readFile,
+  writeFile,
+} = require(`fs/promises`);
 const path = require(`path`);
 const chalk = require(`chalk`);
 
@@ -9,31 +13,54 @@ const manufacturers = require(`../fixtures/manufacturers.json`);
 
 const register = new Register(manufacturers);
 
-const fixturePath = path.join(__dirname, `../fixtures`);
+const fixturesPath = path.join(__dirname, `../fixtures`);
 
-try {
-  // add all fixture.json files to the register
-  for (const manufacturerKey of fs.readdirSync(fixturePath)) {
-    const manufacturerDirectory = path.join(fixturePath, manufacturerKey);
+(async () => {
+  try {
+    await addFixturesToRegister();
+  }
+  catch (readError) {
+    console.error(`Read error:`, readError);
+    process.exit(1);
+  }
 
-    // only directories
-    if (!fs.statSync(manufacturerDirectory).isDirectory()) {
-      continue;
-    }
+  const filename = path.join(fixturesPath, (process.argv.length === 3 ? process.argv[2] : `register.json`));
+  const fileContents = `${JSON.stringify(register.getAsSortedObject(), null, 2)}\n`;
+
+  try {
+    await writeFile(filename, fileContents, `utf8`);
+    console.log(chalk.green(`[Success]`), `Updated register file`, filename);
+    process.exit(0);
+  }
+  catch (error) {
+    console.error(chalk.red(`[Fail]`), `Could not write register file.`, error);
+    process.exit(1);
+  }
+})();
 
 
+/**
+ * Loop through all manufacturer directories and fixture files and add them to the register.
+ */
+async function addFixturesToRegister() {
+  const directoryEntries = await readdir(fixturesPath, { withFileTypes: true });
+  const manufacturerKeys = directoryEntries.filter(entry => entry.isDirectory()).map(entry => entry.name);
+
+  for (const manufacturerKey of manufacturerKeys) {
     register.addManufacturer(manufacturerKey, manufacturers[manufacturerKey]);
 
-    for (const filename of fs.readdirSync(manufacturerDirectory)) {
+    const manufacturerDirectory = path.join(fixturesPath, manufacturerKey);
+    const fixtureFiles = await readdir(manufacturerDirectory);
+    for (const filename of fixtureFiles) {
       if (path.extname(filename) !== `.json`) {
         continue;
       }
 
       const fixtureKey = path.basename(filename, `.json`);
-      const fixtureData = JSON.parse(fs.readFileSync(path.join(fixturePath, manufacturerKey, filename), `utf8`));
+      const fixtureData = JSON.parse(await readFile(path.join(fixturesPath, manufacturerKey, filename), `utf8`));
 
       if (fixtureData.$schema.endsWith(`/fixture-redirect.json`)) {
-        const redirectToData = JSON.parse(fs.readFileSync(path.join(fixturePath, `${fixtureData.redirectTo}.json`), `utf8`));
+        const redirectToData = JSON.parse(await readFile(path.join(fixturesPath, `${fixtureData.redirectTo}.json`), `utf8`));
 
         register.addFixtureRedirect(manufacturerKey, fixtureKey, fixtureData, redirectToData);
       }
@@ -43,20 +70,3 @@ try {
     }
   }
 }
-catch (readError) {
-  console.error(`Read error:`, readError);
-  process.exit(1);
-}
-
-
-const filename = path.join(fixturePath, (process.argv.length === 3 ? process.argv[2] : `register.json`));
-const fileContents = `${JSON.stringify(register.getAsSortedObject(), null, 2)}\n`;
-
-fs.writeFile(filename, fileContents, `utf8`, error => {
-  if (error) {
-    console.error(chalk.red(`[Fail]`), `Could not write register file.`, error);
-    process.exit(1);
-  }
-  console.log(chalk.green(`[Success]`), `Updated register file`, filename);
-  process.exit(0);
-});

--- a/cli/make-test-fixtures.js
+++ b/cli/make-test-fixtures.js
@@ -111,7 +111,7 @@ const markdownFile = path.join(__dirname, `../tests/test-fixtures.md`);
 
 
 /**
- * @returns {Array.<FixtureFeature>} An array of all defined fixture features.
+ * @returns {Promise.<Array.<FixtureFeature>>} A Promise that resolves to an array of all defined fixture features.
  */
 async function getFixtureFeatures() {
   const fixtureFeatures = [];

--- a/cli/make-test-fixtures.js
+++ b/cli/make-test-fixtures.js
@@ -44,7 +44,7 @@ const markdownFile = path.join(__dirname, `../tests/test-fixtures.md`);
     const [manufacturerKey, fixtureKey] = manufacturerFixture.split(`/`);
 
     // pre-process data
-    const fixture = fixtureFromRepository(manufacturerKey, fixtureKey);
+    const fixture = await fixtureFromRepository(manufacturerKey, fixtureKey);
     const fixtureResult = {
       man: manufacturerKey,
       key: fixtureKey,

--- a/cli/make-test-fixtures.js
+++ b/cli/make-test-fixtures.js
@@ -5,7 +5,7 @@
  * keeping the set as small as possible) and updates tests/test-fixtures.json and tests/test-fixtures.md.
  */
 
-const fs = require(`fs`);
+const { readdir, writeFile } = require(`fs/promises`);
 const path = require(`path`);
 const chalk = require(`chalk`);
 
@@ -17,17 +17,114 @@ const fixtureFeaturesDirectory = path.join(__dirname, `../lib/fixture-features`)
 const jsonFile = path.join(__dirname, `../tests/test-fixtures.json`);
 const markdownFile = path.join(__dirname, `../tests/test-fixtures.md`);
 
+/**
+ * @typedef {Object} FixtureFeature
+ * @property {String|undefined} id The fixture feature's ID
+ * @property {String} name A short name of the fixture feature.
+ * @property {String} description A longer description of the fixture feature.
+ * @property {Function} hasFeature A function that returns whether a given fixture supports this feature.
+ */
 
-const fixtureFeatures = [];
-const featuresUsed = {}; // feature id -> times used
-for (const featureFile of fs.readdirSync(fixtureFeaturesDirectory)) {
-  if (path.extname(featureFile) === `.js`) {
+/**
+ * @typedef {Object} FixtureFeatureResult
+ * @property {String} man The fixture manufacturer's name.
+ * @property {String} key The combined manufacturer/fixture key.
+ * @property {String} name The fixture name.
+ * @property {Array.<String>} features The IDs of all fixture features that the fixture supports.
+ */
+
+(async () => {
+  const fixtureFeatures = await getFixtureFeatures();
+  const featuresUsed = Object.fromEntries(fixtureFeatures.map(feature => [feature.id, 0]));// check which features each fixture supports
+
+  /** @type {Array.<FixtureFeatureResult>} */
+  let fixtures = [];
+
+  for (const manufacturerFixture of Object.keys(register.filesystem)) {
+    const [manufacturerKey, fixtureKey] = manufacturerFixture.split(`/`);
+
+    // pre-process data
+    const fixture = fixtureFromRepository(manufacturerKey, fixtureKey);
+    const fixtureResult = {
+      man: manufacturerKey,
+      key: fixtureKey,
+      name: fixture.name,
+      features: [],
+    };
+
+    // check all features
+    for (const fixtureFeature of fixtureFeatures) {
+      if (fixtureFeature.hasFeature(fixture)) {
+        fixtureResult.features.push(fixtureFeature.id);
+        featuresUsed[fixtureFeature.id]++;
+      }
+    }
+
+    fixtures.push(fixtureResult);
+  }
+
+  // first fixtures are more likely to be filtered out, so we start with the ones with the fewest features
+  fixtures.sort((a, b) => {
+    if (a.features.length === b.features.length) {
+      return `${a.man}/${a.key}`.localeCompare(`${b.man}/${b.key}`, `en`);
+    }
+
+    return a.features.length - b.features.length;
+  });
+
+  // filter out
+  fixtures = fixtures.filter(fixture => {
+    for (const feature of fixture.features) {
+      // this is the only remaining fixture with that feature -> keep it
+      if (featuresUsed[feature] === 1) {
+        return true;
+      }
+    }
+    // has no new features -> filter out
+    for (const feature of fixture.features) {
+      featuresUsed[feature]--;
+    }
+    return false;
+  });
+
+  // original alphabetic ordering
+  fixtures.sort((a, b) => {
+    return `${a.man}/${a.key}`.localeCompare(`${b.man}/${b.key}`, `en`);
+  });
+
+  console.log(chalk.yellow(`Generated list of test fixtures:`));
+  for (const fixture of fixtures) {
+    console.log(` - ${fixture.man}/${fixture.key}`);
+  }
+
+  try {
+    await writeFile(jsonFile, `${JSON.stringify(fixtures, null, 2)}\n`, `utf8`);
+    console.log(chalk.green(`[Success]`), `Updated ${jsonFile}`);
+
+    await writeFile(markdownFile, getMarkdownCode(fixtures, fixtureFeatures), `utf8`);
+    console.log(chalk.green(`[Success]`), `Updated ${markdownFile}`);
+  }
+  catch (error) {
+    console.error(chalk.red(`[Fail]`), `Could not write test fixtures file:`, error);
+  }
+})();
+
+
+/**
+ * @returns {Array.<FixtureFeature>} An array of all defined fixture features.
+ */
+async function getFixtureFeatures() {
+  const fixtureFeatures = [];
+
+  for (const featureFile of await readdir(fixtureFeaturesDirectory)) {
+    if (path.extname(featureFile) !== `.js`) {
+      continue;
+    }
+
     // module exports array of fix features
     const fixtureFeatureFile = require(path.join(fixtureFeaturesDirectory, featureFile));
 
-    for (let index = 0; index < fixtureFeatureFile.length; index++) {
-      const fixtureFeature = fixtureFeatureFile[index];
-
+    for (const [index, fixtureFeature] of fixtureFeatureFile.entries()) {
       // default id
       if (!(`id` in fixtureFeature)) {
         fixtureFeature.id = path.basename(featureFile, `.js`);
@@ -37,115 +134,40 @@ for (const featureFile of fs.readdirSync(fixtureFeaturesDirectory)) {
       }
 
       // check uniqueness of id
-      if (fixtureFeature.id in featuresUsed) {
+      const featureIdExists = fixtureFeatures.some(feature => feature.id === fixtureFeature.id);
+      if (featureIdExists) {
         console.error(chalk.red(`[Error]`), `Fixture feature id '${fixtureFeature.id}' is used multiple times.`);
         process.exit(1);
       }
 
       fixtureFeatures.push(fixtureFeature);
-      featuresUsed[fixtureFeature.id] = 0;
-    }
-  }
-}
-
-// check which features each fixture supports
-let fixtures = [];
-for (const manufacturerFixture of Object.keys(register.filesystem)) {
-  const [manufacturerKey, fixtureKey] = manufacturerFixture.split(`/`);
-
-  // pre-process data
-  const fixture = fixtureFromRepository(manufacturerKey, fixtureKey);
-  const fixtureResult = {
-    man: manufacturerKey,
-    key: fixtureKey,
-    name: fixture.name,
-    features: [],
-  };
-
-  // check all features
-  for (const fixtureFeature of fixtureFeatures) {
-    if (fixtureFeature.hasFeature(fixture)) {
-      fixtureResult.features.push(fixtureFeature.id);
-      featuresUsed[fixtureFeature.id]++;
     }
   }
 
-  fixtures.push(fixtureResult);
+  return fixtureFeatures;
 }
-
-// first fixtures are more likely to be filtered out, so we start with the ones with the fewest features
-fixtures.sort((a, b) => {
-  if (a.features.length === b.features.length) {
-    return `${a.man}/${a.key}`.localeCompare(`${b.man}/${b.key}`, `en`);
-  }
-
-  return a.features.length - b.features.length;
-});
-
-// filter out
-fixtures = fixtures.filter(fixture => {
-  for (const feature of fixture.features) {
-    // this is the only remaining fixture with that feature -> keep it
-    if (featuresUsed[feature] === 1) {
-      return true;
-    }
-  }
-  // has no new features -> filter out
-  for (const feature of fixture.features) {
-    featuresUsed[feature]--;
-  }
-  return false;
-});
-
-// original alphabetic ordering
-fixtures.sort((a, b) => {
-  return `${a.man}/${a.key}`.localeCompare(`${b.man}/${b.key}`, `en`);
-});
-
-console.log(chalk.yellow(`Generated list of test fixtures:`));
-for (const fixture of fixtures) {
-  console.log(` - ${fixture.man}/${fixture.key}`);
-}
-
-fs.writeFile(jsonFile, `${JSON.stringify(fixtures, null, 2)}\n`, `utf8`, error => {
-  if (error) {
-    console.error(chalk.red(`[Fail]`), `Could not write test-fixtures.json`, error);
-  }
-  else {
-    console.log(chalk.green(`[Success]`), `Updated ${jsonFile}`);
-  }
-});
-
-fs.writeFile(markdownFile, getMarkdownCode(), `utf8`, error => {
-  if (error) {
-    console.error(chalk.red(`[Fail]`), `Could not write test-fixtures.md`, error);
-  }
-  else {
-    console.log(chalk.green(`[Success]`), `Updated ${markdownFile}`);
-  }
-});
 
 /**
  * Generates a markdown table presenting the test fixtures and all fix features.
+ * @param {Array.<FixtureFeatureResult>} fixtures The fixture feature results.
+ * @param {Array.<FixtureFeature>} fixtureFeatures All fixture features.
  * @returns {String} The markdown code to be used in a markdown file.
  */
-function getMarkdownCode() {
+function getMarkdownCode(fixtures, fixtureFeatures) {
   const mdLines = [
     `# Test fixtures`,
     ``,
     `See the [fixture feature documentation](../docs/fixture-features.md). This file is automatically`,
     `generated by [\`cli/make-test-fixtures.js\`](../cli/make-test-fixtures.js).`,
     ``,
+    ...fixtures.map(
+      (fixture, index) => `${index + 1}. [*${manufacturers[fixture.man].name}* ${fixture.name}](../fixtures/${fixture.man}/${fixture.key}.json)`,
+    ),
+    ``,
   ];
 
-  // fixture list
-  fixtures.forEach((fixture, index) => {
-    mdLines.push(`${index + 1}. [*${manufacturers[fixture.man].name}* ${fixture.name}](../fixtures/${fixture.man}/${fixture.key}.json)`);
-  });
-  mdLines.push(``);
-
   // table head
-  const tableHead = [`*Fixture number*`].concat(fixtures.map((fixture, index) => index + 1)).join(` | `);
+  const tableHead = [`*Fixture number*`, ...fixtures.map((fixture, index) => index + 1)].join(` | `);
 
   mdLines.push(tableHead);
   mdLines.push(`|-`.repeat(fixtures.length + 1));

--- a/cli/run-export-test.js
+++ b/cli/run-export-test.js
@@ -53,10 +53,13 @@ const pluginExport = require(path.join(__dirname, `../plugins`, cliArguments.plu
 
 (async () => {
   try {
-    const files = await pluginExport.export(fixtures, {
-      baseDirectory: path.join(__dirname, `..`),
-      date: new Date(),
-    });
+    const files = await pluginExport.export(
+      await Promise.all(fixtures),
+      {
+        baseDirectory: path.join(__dirname, `..`),
+        date: new Date(),
+      },
+    );
 
     await Promise.all(pluginData.exportTests.map(async testKey => {
       const exportTest = require(path.join(__dirname, `../plugins`, cliArguments.plugin, `exportTests/${testKey}.js`));

--- a/docs/fixture-model.md
+++ b/docs/fixture-model.md
@@ -8,10 +8,12 @@ The model uses [ES2015 classes](https://developer.mozilla.org/en-US/docs/Web/Jav
 
 All model classes are located in the [`lib/model/`](../lib/model) directory. When using the model, it usually suffices to import the `fixtureFromRepository` function from `model.js` which returns a `Fixture` instance:
 
+<!-- While top level `await` is not supported by ESLint, skip parsing this code block. -->
+<!-- eslint-skip -->
 ```js
 const { fixtureFromRepository } = require(`./lib/model.js`);
 
-const myFixture = fixtureFromRepository(`cameo`, `nanospot-120`); // instanceof Fixture
+const myFixture = await fixtureFromRepository(`cameo`, `nanospot-120`); // instanceof Fixture
 
 const physicalData = myFixture.physical; // instanceof Physical
 const panFine = myFixture.getChannelByKey(`Pan fine`); // instanceof FineChannel

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -153,9 +153,7 @@ const xml2js = require(`xml2js`);
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
  */
 module.exports = async function testValueCorrectness(exportFile) {
-  const parser = new xml2js.Parser();
-
-  const xml = await parser.parseStringPromise(exportFile.content);
+  const xml = await xml2js.parseStringPromise(exportFile.content);
 
   const errors = [];
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -142,7 +142,6 @@ Each test module should be located at `plugins/<plugin-key>/exportTests/<export-
 
 ```js
 const xml2js = require(`xml2js`);
-const promisify = require(`util`).promisify;
 
 /**
  * @param {Object} exportFile The file returned by the plugins' export module.
@@ -156,7 +155,7 @@ const promisify = require(`util`).promisify;
 module.exports = async function testValueCorrectness(exportFile) {
   const parser = new xml2js.Parser();
 
-  const xml = await promisify(parser.parseString)(exportFile.content);
+  const xml = await parser.parseStringPromise(exportFile.content);
 
   const errors = [];
 

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -1,4 +1,4 @@
-const fs = require(`fs`);
+const { readFile, writeFile } = require(`fs/promises`);
 const path = require(`path`);
 const childProcess = require(`child_process`);
 const JSZip = require(`jszip`);
@@ -87,7 +87,7 @@ module.exports = async function diffPluginOutputs(currentPluginKey, comparePlugi
 
   // unzip compare archive
   await mkdirp(unzipDirectory);
-  const compareArchiveData = await promisify(fs.readFile)(compareArchivePath);
+  const compareArchiveData = await readFile(compareArchivePath);
   const zip = await JSZip.loadAsync(compareArchiveData);
 
   await Promise.all(Object.keys(zip.files).map(async fileName => {
@@ -100,7 +100,7 @@ module.exports = async function diffPluginOutputs(currentPluginKey, comparePlugi
 
     await mkdirp(path.dirname(filePath));
     const fileBuffer = await file.async(`nodebuffer`);
-    await promisify(fs.writeFile)(filePath, fileBuffer);
+    await writeFile(filePath, fileBuffer);
   }));
 
   // delete compare archive
@@ -146,7 +146,7 @@ module.exports = async function diffPluginOutputs(currentPluginKey, comparePlugi
     return await Promise.all(outFiles.map(async outFile => {
       const outFilePath = path.join(outputPath, outFile.name);
       await mkdirp(path.dirname(outFilePath));
-      await promisify(fs.writeFile)(outFilePath, outFile.content);
+      await writeFile(outFilePath, outFile.content);
     }));
   }
 };
@@ -193,8 +193,8 @@ async function findDifferences(currentOut, compareOut) {
 
       case `distinct`: {
         name = getRelativePath(difference.relativePath, difference.name2, difference.type2);
-        const file1 = fs.readFileSync(path.join(difference.path1, difference.name1), `utf8`);
-        const file2 = fs.readFileSync(path.join(difference.path2, difference.name2), `utf8`);
+        const file1 = await readFile(path.join(difference.path1, difference.name1), `utf8`);
+        const file2 = await readFile(path.join(difference.path2, difference.name2), `utf8`);
 
         console.log(chalk.yellow(`Diff for ${name}`));
         console.log(disparity.unified(file1, file2));

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -143,7 +143,7 @@ module.exports = async function diffPluginOutputs(currentPluginKey, comparePlugi
       displayedPluginVersion: `dummy version by diff-plugin-outputs`,
     });
 
-    return await Promise.all(outFiles.map(async outFile => {
+    return Promise.all(outFiles.map(async outFile => {
       const outFilePath = path.join(outputPath, outFile.name);
       await mkdirp(path.dirname(outFilePath));
       await writeFile(outFilePath, outFile.content);

--- a/lib/diff-plugin-outputs.js
+++ b/lib/diff-plugin-outputs.js
@@ -137,11 +137,16 @@ module.exports = async function diffPluginOutputs(currentPluginKey, comparePlugi
     const plugin = require(pluginScript);
     const { fixtureFromRepository } = require(path.join(baseDirectory, `lib`, `model.js`));
 
-    const outFiles = await plugin.export(fixtures.map(([manufacturer, fixture]) => fixtureFromRepository(manufacturer, fixture)), {
-      baseDirectory,
-      date,
-      displayedPluginVersion: `dummy version by diff-plugin-outputs`,
-    });
+    const outFiles = await plugin.export(
+      await Promise.all(fixtures.map(
+        ([manufacturer, fixture]) => fixtureFromRepository(manufacturer, fixture),
+      )),
+      {
+        baseDirectory,
+        date,
+        displayedPluginVersion: `dummy version by diff-plugin-outputs`,
+      },
+    );
 
     return Promise.all(outFiles.map(async outFile => {
       const outFilePath = path.join(outputPath, outFile.name);

--- a/lib/generate-sitemap.js
+++ b/lib/generate-sitemap.js
@@ -7,9 +7,9 @@ const plugins = require(`../plugins/plugins.json`);
 
 /**
  * @param {String} hostname The site's hostname.
- * @returns {SitemapStream} A stream of the generated XML sitemap.
+ * @returns {Promise.<SitemapStream>} A Promise that resolves to a stream of the generated XML sitemap.
  */
-module.exports = function generateSitemap(hostname) {
+module.exports = async function generateSitemap(hostname) {
   const sitemapStream = new SitemapStream({ hostname });
 
   // static URLs
@@ -29,7 +29,7 @@ module.exports = function generateSitemap(hostname) {
 
     // fixture URLs
     for (const fixtureKey of register.manufacturers[manufacturerKey]) {
-      const fixture = fixtureFromRepository(manufacturerKey, fixtureKey);
+      const fixture = await fixtureFromRepository(manufacturerKey, fixtureKey);
       sitemapStream.write({
         url: `/${manufacturerKey}/${fixtureKey}`,
         changefreq: `monthly`,

--- a/lib/load-env-file.js
+++ b/lib/load-env-file.js
@@ -1,8 +1,5 @@
-const fs = require(`fs`);
 const path = require(`path`);
 const env = require(`node-env-file`);
 
 const envFile = path.join(__dirname, `../.env`);
-if (fs.existsSync(envFile)) {
-  env(envFile);
-}
+env(envFile, { raise: false });

--- a/lib/model.js
+++ b/lib/model.js
@@ -35,7 +35,7 @@ async function fixtureFromFile(absolutePath) {
   if (fixtureJson.$schema.endsWith(`/fixture-redirect.json`)) {
     [manufacturerKey, fixtureKey] = fixtureJson.redirectTo.split(`/`);
     absolutePath = path.join(path.dirname(absolutePath), `../${manufacturerKey}/${fixtureKey}.json`);
-    fixtureJson = Object.assign({}, require(absolutePath), { name: fixtureJson.name });
+    fixtureJson = require(absolutePath);
   }
 
   await embedResourcesIntoFixtureJson(fixtureJson);
@@ -50,7 +50,17 @@ async function fixtureFromFile(absolutePath) {
  * @returns {Promise.<Fixture, Error>} A Promise that resolves to the created Fixture instance or is rejected with a `MODULE_NOT_FOUND` error if the given fixture file does not exist.
  */
 async function fixtureFromRepository(manufacturerKey, fixtureKey) {
-  return fixtureFromFile(path.join(__dirname, `../fixtures/${manufacturerKey}/${fixtureKey}.json`));
+  let fixturePath = `../fixtures/${manufacturerKey}/${fixtureKey}.json`;
+  let fixtureJson = require(fixturePath);
+
+  if (fixtureJson.$schema.endsWith(`/fixture-redirect.json`)) {
+    fixturePath = `../fixtures/${fixtureJson.redirectTo}.json`;
+    fixtureJson = Object.assign({}, require(fixturePath), { name: fixtureJson.name });
+  }
+
+  await embedResourcesIntoFixtureJson(fixtureJson);
+
+  return new Fixture(manufacturerKey, fixtureKey, fixtureJson);
 }
 
 /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -25,10 +25,9 @@ const WheelSlot = require(`./model/WheelSlot.js`).default;
 /**
  * Look up the fixture definition in the directory structure and create a Fixture instance.
  * @param {String} absolutePath The fixture file absolute path, including filename.
- * @returns {Fixture} The created Fixture instance, null if not found.
- * @throws {Error} A `MODULE_NOT_FOUND` error when the given fixture file does not exist.
+ * @returns {Promise.<Fixture, Error>} A Promise that resolves to the created Fixture instance or is rejected with a `MODULE_NOT_FOUND` error if the given fixture file does not exist.
  */
-function fixtureFromFile(absolutePath) {
+async function fixtureFromFile(absolutePath) {
   let manufacturerKey = path.basename(path.dirname(absolutePath));
   let fixtureKey = path.basename(absolutePath, path.extname(absolutePath));
   let fixtureJson = require(absolutePath);
@@ -39,7 +38,7 @@ function fixtureFromFile(absolutePath) {
     fixtureJson = Object.assign({}, require(absolutePath), { name: fixtureJson.name });
   }
 
-  embedResourcesIntoFixtureJson(fixtureJson);
+  await embedResourcesIntoFixtureJson(fixtureJson);
 
   return new Fixture(manufacturerKey, fixtureKey, fixtureJson);
 }
@@ -48,33 +47,32 @@ function fixtureFromFile(absolutePath) {
  * Look up the fixture definition in the directory structure and create a Fixture instance.
  * @param {String} manufacturerKey The manufacturer's key (directory name)
  * @param {String} fixtureKey The fixture's key (filename without .json)
- * @returns {Fixture} The created Fixture instance, null if not found.
- * @throws {Error} A `MODULE_NOT_FOUND` error when the given fixture file does not exist.
+ * @returns {Promise.<Fixture, Error>} A Promise that resolves to the created Fixture instance or is rejected with a `MODULE_NOT_FOUND` error if the given fixture file does not exist.
  */
-function fixtureFromRepository(manufacturerKey, fixtureKey) {
+async function fixtureFromRepository(manufacturerKey, fixtureKey) {
   return fixtureFromFile(path.join(__dirname, `../fixtures/${manufacturerKey}/${fixtureKey}.json`));
 }
 
 /**
  * @param {Object} fixtureJson The fixture JSON to embed resoures into.
  */
-function embedResourcesIntoFixtureJson(fixtureJson) {
+async function embedResourcesIntoFixtureJson(fixtureJson) {
   if (`wheels` in fixtureJson) {
-    Object.values(fixtureJson.wheels).forEach(wheel => {
-      wheel.slots.forEach(slot => {
+    for (const wheel of Object.values(fixtureJson.wheels)) {
+      for (const slot of wheel.slots) {
         if (typeof slot.resource === `string`) {
-          slot.resource = getResourceFromString(slot.resource);
+          slot.resource = await getResourceFromString(slot.resource);
         }
-      });
-    });
+      }
+    }
   }
 }
 
 /**
  * @param {String} resourceName The resource name, as specified in a fixture.
- * @returns {Object} The resource object to be embedded into the fixture.
+ * @returns {Promise.<Object>} A Promise that resolves to the resource object to be embedded into the fixture.
  */
-function getResourceFromString(resourceName) {
+async function getResourceFromString(resourceName) {
   const { type, key, alias } = resolveResourceName(resourceName);
 
   const resourceBasePath = path.join(__dirname, `../resources/${type}`);

--- a/lib/model.js
+++ b/lib/model.js
@@ -36,7 +36,7 @@ function fixtureFromFile(absolutePath) {
   if (fixtureJson.$schema.endsWith(`/fixture-redirect.json`)) {
     [manufacturerKey, fixtureKey] = fixtureJson.redirectTo.split(`/`);
     absolutePath = path.join(path.dirname(absolutePath), `../${manufacturerKey}/${fixtureKey}.json`);
-    fixtureJson = require(absolutePath);
+    fixtureJson = Object.assign({}, require(absolutePath), { name: fixtureJson.name });
   }
 
   embedResourcesIntoFixtureJson(fixtureJson);
@@ -52,17 +52,7 @@ function fixtureFromFile(absolutePath) {
  * @throws {Error} A `MODULE_NOT_FOUND` error when the given fixture file does not exist.
  */
 function fixtureFromRepository(manufacturerKey, fixtureKey) {
-  let fixturePath = `../fixtures/${manufacturerKey}/${fixtureKey}.json`;
-  let fixtureJson = require(fixturePath);
-
-  if (fixtureJson.$schema.endsWith(`/fixture-redirect.json`)) {
-    fixturePath = `../fixtures/${fixtureJson.redirectTo}.json`;
-    fixtureJson = Object.assign({}, require(fixturePath), { name: fixtureJson.name });
-  }
-
-  embedResourcesIntoFixtureJson(fixtureJson);
-
-  return new Fixture(manufacturerKey, fixtureKey, fixtureJson);
+  return fixtureFromFile(path.join(__dirname, `../fixtures/${manufacturerKey}/${fixtureKey}.json`));
 }
 
 /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,5 +1,5 @@
 const path = require(`path`);
-const fs = require(`fs`);
+const { readFile } = require(`fs/promises`);
 
 // see https://github.com/standard-things/esm#getting-started
 require = require(`esm`)(module); // eslint-disable-line no-global-assign
@@ -81,7 +81,7 @@ async function getResourceFromString(resourceName) {
   let resourceData;
 
   try {
-    const resourceJsonString = fs.readFileSync(resourcePath, `utf8`);
+    const resourceJsonString = await readFile(resourcePath, `utf8`);
     resourceData = JSON.parse(resourceJsonString);
   }
   catch (error) {
@@ -93,7 +93,7 @@ async function getResourceFromString(resourceName) {
   resourceData.key = key;
   resourceData.type = type;
   resourceData.alias = alias;
-  resourceData.image = getImageForResource(type, resourceBasePath, key);
+  resourceData.image = await getImageForResource(type, resourceBasePath, key);
 
   delete resourceData.$schema;
 
@@ -160,15 +160,15 @@ const mimeTypes = {
  * @param {String} type The resource type, i.e. name of the directory inside the resources directory.
  * @param {String} basePath The path of the resource directory.
  * @param {String} key The resource key.
- * @returns {ResourceImage|undefined} The resource image, or undefined if none could be found.
+ * @returns {Promise.<ResourceImage|undefined>} A Promise that resolves to the resource image, or undefined if none could be found.
  */
-function getImageForResource(type, basePath, key) {
+async function getImageForResource(type, basePath, key) {
   const extensions = Object.keys(mimeTypes);
 
   for (const extension of extensions) {
     try {
       const encoding = (extension === `svg` ? `utf8` : `base64`);
-      let data = fs.readFileSync(`${basePath}/${key}.${extension}`, encoding);
+      let data = await readFile(`${basePath}/${key}.${extension}`, encoding);
       const mimeType = mimeTypes[extension];
 
       if (encoding === `utf8`) {

--- a/main.js
+++ b/main.js
@@ -3,8 +3,7 @@
 // see https://github.com/standard-things/esm#getting-started
 require = require(`esm`)(module); // eslint-disable-line no-global-assign
 
-const promisify = require(`util`).promisify;
-const readFile = promisify(require(`fs`).readFile);
+const { readFile } = require(`fs/promises`);
 const path = require(`path`);
 const express = require(`express`);
 const compression = require(`compression`);

--- a/plugins/d-light/exportTests/attributes-correctness.js
+++ b/plugins/d-light/exportTests/attributes-correctness.js
@@ -1,5 +1,4 @@
 const xml2js = require(`xml2js`);
-const promisify = require(`util`).promisify;
 
 /**
  * @typedef {Object} ExportFile
@@ -19,7 +18,7 @@ module.exports = async function testAttributesCorrectness(exportFile, allExportF
   const parser = new xml2js.Parser();
 
   try {
-    const xml = await promisify(parser.parseString)(exportFile.content);
+    const xml = await parser.parseStringPromise(exportFile.content);
     const errors = [];
 
     const attributeDefinitions = xml.Device.Attributes[0].AttributesDefinition;

--- a/plugins/d-light/exportTests/attributes-correctness.js
+++ b/plugins/d-light/exportTests/attributes-correctness.js
@@ -15,10 +15,8 @@ const xml2js = require(`xml2js`);
  * @returns {Promise.<undefined, Array.<String>|String>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
  */
 module.exports = async function testAttributesCorrectness(exportFile, allExportFiles) {
-  const parser = new xml2js.Parser();
-
   try {
-    const xml = await parser.parseStringPromise(exportFile.content);
+    const xml = await xml2js.parseStringPromise(exportFile.content);
     const errors = [];
 
     const attributeDefinitions = xml.Device.Attributes[0].AttributesDefinition;

--- a/plugins/ecue/import.js
+++ b/plugins/ecue/import.js
@@ -1,6 +1,5 @@
 const colorNameList = require(`color-name-list`);
 const xml2js = require(`xml2js`);
-const promisify = require(`util`).promisify;
 
 module.exports.version = `0.3.1`;
 
@@ -25,7 +24,7 @@ module.exports.import = async function importECue(buffer, filename, authorName) 
     warnings: {},
   };
 
-  const xml = await promisify(parser.parseString)(buffer.toString());
+  const xml = await parser.parseStringPromise(buffer.toString());
 
   if (!(`Library` in xml.Document) || !(`Fixtures` in xml.Document.Library[0]) || !(`Manufacturer` in xml.Document.Library[0].Fixtures[0])) {
     throw new Error(`Nothing to import.`);

--- a/plugins/ecue/import.js
+++ b/plugins/ecue/import.js
@@ -15,7 +15,6 @@ for (const color of colorNameList) {
  * @returns {Promise.<Object, Error>} A Promise resolving to an out object
  */
 module.exports.import = async function importECue(buffer, filename, authorName) {
-  const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);
 
   const out = {
@@ -24,7 +23,7 @@ module.exports.import = async function importECue(buffer, filename, authorName) 
     warnings: {},
   };
 
-  const xml = await parser.parseStringPromise(buffer.toString());
+  const xml = await xml2js.parseStringPromise(buffer.toString());
 
   if (!(`Library` in xml.Document) || !(`Fixtures` in xml.Document.Library[0]) || !(`Manufacturer` in xml.Document.Library[0].Fixtures[0])) {
     throw new Error(`Nothing to import.`);

--- a/plugins/gdtf/import.js
+++ b/plugins/gdtf/import.js
@@ -19,8 +19,6 @@ module.exports.version = `0.2.0`;
  * @returns {Promise.<Object, Error>} A Promise resolving to an out object
  */
 module.exports.import = async function importGdtf(buffer, filename, authorName) {
-  const parser = new xml2js.Parser();
-
   const fixture = {
     $schema: `https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json`,
   };
@@ -41,7 +39,7 @@ module.exports.import = async function importGdtf(buffer, filename, authorName) 
     xmlString = descriptionFile.async(`string`);
   }
 
-  const xml = await parser.parseStringPromise(xmlString);
+  const xml = await xml2js.parseStringPromise(xmlString);
 
   const gdtfFixture = xml.GDTF.FixtureType[0];
   fixture.name = gdtfFixture.$.Name;

--- a/plugins/gdtf/import.js
+++ b/plugins/gdtf/import.js
@@ -1,6 +1,5 @@
 const xml2js = require(`xml2js`);
 const JSZip = require(`jszip`);
-const promisify = require(`util`).promisify;
 
 // see https://github.com/standard-things/esm#getting-started
 require = require(`esm`)(module); // eslint-disable-line no-global-assign
@@ -42,7 +41,7 @@ module.exports.import = async function importGdtf(buffer, filename, authorName) 
     xmlString = descriptionFile.async(`string`);
   }
 
-  const xml = await promisify(parser.parseString)(xmlString);
+  const xml = await parser.parseStringPromise(xmlString);
 
   const gdtfFixture = xml.GDTF.FixtureType[0];
   fixture.name = gdtfFixture.$.Name;

--- a/plugins/qlcplus_4.12.2/exportTests/fixture-tool-validation.js
+++ b/plugins/qlcplus_4.12.2/exportTests/fixture-tool-validation.js
@@ -1,13 +1,9 @@
 const https = require(`https`);
 const path = require(`path`);
-const fs = require(`fs`);
+const { mkdtemp, writeFile } = require(`fs/promises`);
 const os = require(`os`);
 const mkdirp = require(`mkdirp`);
-const { promisify } = require(`util`);
-
-const mkdtemp = promisify(fs.mkdtemp);
-const writeFile = promisify(fs.writeFile);
-const execFile = promisify(require(`child_process`).execFile);
+const execFile = require(`util`).promisify(require(`child_process`).execFile);
 
 const qlcplusGoboAliases = require(`../../../resources/gobos/aliases/qlcplus.json`);
 

--- a/plugins/qlcplus_4.12.2/import.js
+++ b/plugins/qlcplus_4.12.2/import.js
@@ -1,5 +1,4 @@
 const xml2js = require(`xml2js`);
-const promisify = require(`util`).promisify;
 
 const oflManufacturers = require(`../../fixtures/manufacturers.json`);
 const qlcplusGoboAliases = require(`../../resources/gobos/aliases/qlcplus.json`);
@@ -29,7 +28,7 @@ module.exports.import = async function importQlcPlus(buffer, filename, authorNam
     $schema: `https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json`,
   };
 
-  const xml = await promisify(parser.parseString)(buffer.toString());
+  const xml = await parser.parseStringPromise(buffer.toString());
 
   const qlcPlusFixture = xml.FixtureDefinition;
   fixture.name = qlcPlusFixture.Model[0];

--- a/plugins/qlcplus_4.12.2/import.js
+++ b/plugins/qlcplus_4.12.2/import.js
@@ -19,7 +19,6 @@ module.exports.version = `1.1.0`;
  * @returns {Promise.<Object, Error>} A Promise resolving to an out object
  */
 module.exports.import = async function importQlcPlus(buffer, filename, authorName) {
-  const parser = new xml2js.Parser();
   const timestamp = new Date().toISOString().replace(/T.*/, ``);
 
   const warnings = [];
@@ -28,7 +27,7 @@ module.exports.import = async function importQlcPlus(buffer, filename, authorNam
     $schema: `https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json`,
   };
 
-  const xml = await parser.parseStringPromise(buffer.toString());
+  const xml = await xml2js.parseStringPromise(buffer.toString());
 
   const qlcPlusFixture = xml.FixtureDefinition;
   fixture.name = qlcPlusFixture.Model[0];

--- a/tests/external-links.js
+++ b/tests/external-links.js
@@ -151,7 +151,7 @@ async function testExternalLink(url) {
   const resultHEAD = await getResult(`HEAD`);
 
   if (resultHEAD.failed) {
-    return await getResult(`GET`);
+    return getResult(`GET`);
   }
   return resultHEAD;
 

--- a/tests/fixtures-valid.js
+++ b/tests/fixtures-valid.js
@@ -121,7 +121,7 @@ async function checkFixtureFile(manufacturerKey, fixtureKey) {
   try {
     const data = await readFile(filepath, `utf8`);
     const fixtureJson = JSON.parse(data);
-    Object.assign(result, checkFixture(manufacturerKey, fixtureKey, fixtureJson, uniqueValues));
+    Object.assign(result, await checkFixture(manufacturerKey, fixtureKey, fixtureJson, uniqueValues));
   }
   catch (error) {
     result.errors.push(error);

--- a/tests/github/exports-valid.js
+++ b/tests/github/exports-valid.js
@@ -229,10 +229,13 @@ async function getTaskPromise(task) {
   const detailListItems = [];
 
   try {
-    const files = await plugin.export([fixtureFromRepository(task.manufacturerKey, task.fixtureKey)], {
-      baseDirectory: path.join(__dirname, `../..`),
-      date: new Date(),
-    });
+    const files = await plugin.export(
+      [await fixtureFromRepository(task.manufacturerKey, task.fixtureKey)],
+      {
+        baseDirectory: path.join(__dirname, `../..`),
+        date: new Date(),
+      },
+    );
 
     const resultListItems = await Promise.all(files.map(async file => {
       try {

--- a/tests/github/pull-request.js
+++ b/tests/github/pull-request.js
@@ -234,7 +234,7 @@ module.exports.updateComment = async function updateComment(test) {
     }));
   }
 
-  return await Promise.all(promises);
+  return Promise.all(promises);
 };
 
 module.exports.getTestFixturesMessage = function getTestFixturesMessage(fixtures) {

--- a/ui/api/routes/submit-feedback.js
+++ b/ui/api/routes/submit-feedback.js
@@ -32,7 +32,7 @@ async function createFeedbackIssue({ request }) {
     labels.push(`component-fixture`);
 
     const [manufacturerKey, fixtureKey] = context.split(`/`);
-    const fixture = fixtureFromRepository(manufacturerKey, fixtureKey);
+    const fixture = await fixtureFromRepository(manufacturerKey, fixtureKey);
 
     issueContentData.Manufacturer = fixture.manufacturer.name;
     issueContentData.Fixture = fixture.name;


### PR DESCRIPTION
* Avoid `util.promisify` where possible
* Use ``require(`fs/promises`)`` instead of ``require(`fs`)``
* Use `xml2js.parseStringPromise` instead of manually creating a new parser and then calling `promisify(parser.parseString)`