### PR TITLE
Install `lxml` via pip instead of apt

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,7 +45,7 @@ jobs:
           node-version: 14
       - name: Install dependencies
         run: |
-          sudo apt-get install python-lxml # for QLC+ fixture-tool-validation export test
+          sudo pip install lxml # for QLC+ fixture-tool-validation export test
           npm ci
       - name: Run export-diff test
         run: node tests/github/export-diff.js


### PR DESCRIPTION
This should fix the error in #1630 ([workflow run](https://github.com/OpenLightingProject/open-fixture-library/pull/1630/checks?check_run_id=1537302162)):

```
Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/lxml/python-lxml_4.2.1-1ubuntu0.1_amd64.deb  404  Not Found
```