### PR TITLE
Fix typo `Date.new()` → `Date.now()` (#1646)Fix typo `Date.new()` → `Date.now()`

### DIFF
--- a/tests/external-links.js
+++ b/tests/external-links.js
@@ -46,7 +46,7 @@ const excludedUrls = [
       }
     });
 
-    const crawlStartTime = Date.new();
+    const crawlStartTime = Date.now();
     console.log(chalk.blue.bold(`Start crawling the website for external links ...`));
     await crawler.crawl();
 

--- a/tests/http-status.js
+++ b/tests/http-status.js
@@ -7,7 +7,7 @@ require(`../lib/load-env-file.js`);
 const SiteCrawler = require(`../lib/site-crawler.js`);
 
 (async () => {
-  const testStartTime = Date.new();
+  const testStartTime = Date.now();
 
   try {
     const crawler = new SiteCrawler();


### PR DESCRIPTION
This typo was introduced in #1643.