### PR TITLE
Add fixture 'neo/elipsocolor'

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -316,6 +316,9 @@
     "name": "Minuit Une",
     "website": "https://minuitune.com/"
   },
+  "neo": {
+    "name": "Neo"
+  },
   "nicols": {
     "name": "Nicols",
     "website": "http://www.nicols.site-expelec.fr/"

--- a/fixtures/neo/elipsocolor.json
+++ b/fixtures/neo/elipsocolor.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Elipsocolor",
+  "shortName": "Lico led",
+  "categories": ["Dimmer", "Color Changer"],
+  "meta": {
+    "authors": ["Pablo"],
+    "createDate": "2021-02-12",
+    "lastModifyDate": "2021-02-12"
+  },
+  "links": {
+    "productPage": [
+      "https://www.amproweb.com"
+    ],
+    "other": [
+      "https://www.amproweb.com"
+    ]
+  },
+  "physical": {
+    "weight": 8,
+    "power": 400,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "Led"
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "fineChannelAliases": ["Dimmer fine"],
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "fineChannelAliases": ["Red fine"],
+      "highlightValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "fineChannelAliases": ["Green fine"],
+      "highlightValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "fineChannelAliases": ["Blue fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Lime": {
+      "fineChannelAliases": ["Lime fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Lime"
+      }
+    },
+    "Amber": {
+      "fineChannelAliases": ["Amber fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "Color Presets": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    },
+    "Color Temperature": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperature": "0%"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    },
+    "No function": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Reserved": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "17ch",
+      "shortName": "Lico led",
+      "channels": [
+        "Dimmer",
+        "Dimmer fine",
+        "Red",
+        "Red fine",
+        "Green",
+        "Green fine",
+        "Blue",
+        "Blue fine",
+        "Lime",
+        "Lime fine",
+        "Amber",
+        "Amber fine",
+        "Color Presets",
+        "No function",
+        "Color Temperature",
+        "Shutter / Strobe",
+        "Reserved"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'neo/elipsocolor'

### Fixture warnings / errors

* neo/elipsocolor
  - :warning: Mode '17ch' should have shortName '17ch' instead of 'Lico led'.


Thank you **Pablo**!