### PR TITLE
Add fixture 'cinetec/rampe-led'

### DIFF
--- a/fixtures/cinetec/rampe-led.json
+++ b/fixtures/cinetec/rampe-led.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "RAMPE LED",
+  "shortName": "RAMPE LED",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["PLDL"],
+    "createDate": "2021-02-17",
+    "lastModifyDate": "2021-02-17"
+  },
+  "links": {
+    "manual": [
+      "http://www.dimatec.net/documentation/download/cinetec/brochure_cinetec.pdf"
+    ],
+    "productPage": [
+      "http://www.dimatec.net"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "UV": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "RAMPE LED led 14X30W",
+      "shortName": "RAMPE LED led 14X30W",
+      "channels": [
+        "Dimmer",
+        "Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'cinetec/rampe-led'

### Fixture warnings / errors

* cinetec/rampe-led
  - :x: Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **PLDL**!