### PR TITLE
Add fixture `mark/cob-6uv`

### DIFF
--- a/fixtures/mark/cob-6uv.json
+++ b/fixtures/mark/cob-6uv.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Cob 6UV",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["josequioss"],
+    "createDate": "2021-03-26",
+    "lastModifyDate": "2021-03-26"
+  },
+  "links": {
+    "productPage": [
+      "https://www.equipson.es/products/cob-6-uv"
+    ]
+  },
+  "availableChannels": {
+    "Red": {
+      "fineChannelAliases": ["Red fine"],
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "6 channel",
+      "shortName": "6-channel",
+      "channels": [
+        "Red"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'mark/cob-6uv'

### Fixture warnings / errors

* mark/cob-6uv
  - :x: Mode '6 channel' should have 6 channels according to its name but actually has 1.
  - :x: Mode '6 channel' should have 6 channels according to its shortName but actually has 1.
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.
  - :warning: Mode '6 channel' should have shortName '6ch' instead of '6-channel'.
  - :warning: Mode '6 channel' should have shortName '6ch' instead of '6-channel'.
  - :warning: Unused channel(s): red fine


Thank you **josequioss**!