### PR TITLE
Add fixture 'luxibel/lx306'

### DIFF
--- a/fixtures/luxibel/lx306.json
+++ b/fixtures/luxibel/lx306.json
@@ -1,0 +1,419 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LX306",
+  "shortName": "LX306",
+  "categories": ["Strobe"],
+  "meta": {
+    "authors": ["arne"],
+    "createDate": "2021-04-20",
+    "lastModifyDate": "2021-04-20"
+  },
+  "links": {
+    "manual": [
+      "https://www.manualslib.com/manual/1198682/Luxibel-Lx306.html?page=8#manual"
+    ]
+  },
+  "physical": {
+    "dimensions": [455, 221, 103],
+    "weight": 4.5,
+    "power": 460,
+    "DMXconnector": "3-pin and 5-pin",
+    "bulb": {
+      "type": "Led",
+      "colorTemperature": 6500
+    }
+  },
+  "availableChannels": {
+    "Flash": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [6, 249],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "30Hz"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Intensity": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "Intensity",
+          "brightness": "off"
+        },
+        {
+          "dmxRange": [6, 255],
+          "type": "Intensity",
+          "brightnessStart": "dark",
+          "brightnessEnd": "bright"
+        }
+      ]
+    },
+    "Strobe Duration": {
+      "capability": {
+        "type": "StrobeDuration",
+        "durationStart": "15ms",
+        "durationEnd": "990ms"
+      }
+    },
+    "Strobe Speed": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [6, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "30Hz"
+        }
+      ]
+    },
+    "Effect": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [6, 42],
+          "type": "Effect",
+          "effectName": "Rampup"
+        },
+        {
+          "dmxRange": [43, 85],
+          "type": "Effect",
+          "effectName": "Ramp down",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [86, 128],
+          "type": "Effect",
+          "effectName": "Ramp up-down"
+        },
+        {
+          "dmxRange": [129, 171],
+          "type": "Effect",
+          "effectName": "Random"
+        },
+        {
+          "dmxRange": [172, 214],
+          "type": "Effect",
+          "effectName": "Lightning"
+        },
+        {
+          "dmxRange": [215, 255],
+          "type": "Effect",
+          "effectName": "Spikes"
+        }
+      ]
+    },
+    "Pixel Control": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [6, 42],
+          "type": "Effect",
+          "effectName": "Macro 1",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [43, 84],
+          "type": "Effect",
+          "effectName": "Macro 2",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [85, 128],
+          "type": "Effect",
+          "effectName": "Macro 3",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [129, 171],
+          "type": "Effect",
+          "effectName": "Macro 4",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [172, 214],
+          "type": "Effect",
+          "effectName": "Macro 5",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [215, 255],
+          "type": "Effect",
+          "effectName": "Macro 6",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Flash 1": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [6, 249],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "30Hz"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Flash 2": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [6, 249],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "30Hz"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Flash 3": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [6, 249],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "30Hz"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Flash 4": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [6, 249],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "30Hz"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Flash 5": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [6, 249],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "30Hz"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Flash 6": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [6, 249],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "30Hz"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Auto": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 40],
+          "type": "Effect",
+          "effectName": "Auto 1"
+        },
+        {
+          "dmxRange": [41, 70],
+          "type": "Effect",
+          "effectName": "Auto 2"
+        },
+        {
+          "dmxRange": [71, 100],
+          "type": "Effect",
+          "effectName": "Auto 2"
+        },
+        {
+          "dmxRange": [101, 130],
+          "type": "Effect",
+          "effectName": "Auto 3"
+        },
+        {
+          "dmxRange": [131, 160],
+          "type": "Effect",
+          "effectName": "Auto 4"
+        },
+        {
+          "dmxRange": [161, 190],
+          "type": "Effect",
+          "effectName": "Auto 5"
+        },
+        {
+          "dmxRange": [191, 220],
+          "type": "Effect",
+          "effectName": "Auto 6"
+        },
+        {
+          "dmxRange": [221, 255],
+          "type": "Effect",
+          "effectName": "Auto 7"
+        }
+      ]
+    },
+    "Auto speed": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [6, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "1CH",
+      "shortName": "1CH",
+      "channels": [
+        "Flash"
+      ]
+    },
+    {
+      "name": "5CH",
+      "shortName": "5CH",
+      "channels": [
+        "Intensity",
+        "Strobe Duration",
+        "Strobe Speed",
+        "Effect",
+        "Pixel Control"
+      ]
+    },
+    {
+      "name": "6CH",
+      "shortName": "6CH",
+      "channels": [
+        "Flash 1",
+        "Flash 2",
+        "Flash 3",
+        "Flash 4",
+        "Flash 5",
+        "Flash 6"
+      ]
+    },
+    {
+      "name": "10CH",
+      "shortName": "10CH",
+      "channels": [
+        "Flash 1",
+        "Flash 2",
+        "Flash 3",
+        "Flash 4",
+        "Flash 5",
+        "Flash 6",
+        "Auto",
+        "Auto speed",
+        "Intensity",
+        "Strobe"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -292,6 +292,9 @@
     "name": "Look Solutions",
     "website": "https://www.looksolutions.com/"
   },
+  "luxibel": {
+    "name": "Luxibel"
+  },
   "magicfx": {
     "name": "MagicFX",
     "website": "https://www.magicfx.eu/",


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'luxibel/lx306'

### Fixture warnings / errors

* luxibel/lx306
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedStart "slow CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedStart "slow CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedEnd "fast CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2/speedEnd "fast CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Effect/capabilities/2 (type: Effect) must match "then" schema
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedStart "slow CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedStart "slow CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedEnd "fast CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1/speedEnd "fast CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/1 (type: Effect) must match "then" schema
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedStart "slow CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedStart "slow CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedEnd "fast CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2/speedEnd "fast CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/2 (type: Effect) must match "then" schema
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedStart "slow CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedStart "slow CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedEnd "fast CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3/speedEnd "fast CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/3 (type: Effect) must match "then" schema
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedStart "slow CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedStart "slow CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedEnd "fast CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4/speedEnd "fast CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/4 (type: Effect) must match "then" schema
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedStart "slow CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedStart "slow CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedEnd "fast CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5/speedEnd "fast CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/5 (type: Effect) must match "then" schema
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedStart "slow CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedStart "slow CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedEnd "fast CW" should be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6/speedEnd "fast CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Pixel Control/capabilities/6 (type: Effect) must match "then" schema


Thank you @arneman44!