### PR TITLE
Add fixture 'clay-paky/axcor-spot-300'

### DIFF
--- a/fixtures/clay-paky/axcor-spot-300.json
+++ b/fixtures/clay-paky/axcor-spot-300.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Axcor Spot 300",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Pepito"],
+    "createDate": "2021-05-15",
+    "lastModifyDate": "2021-05-15"
+  },
+  "links": {
+    "productPage": [
+      "https://www.claypaky.it/en/products/axcor-spot-300"
+    ]
+  },
+  "availableChannels": {
+    "Cyan": {
+      "defaultValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Cyan"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "00",
+      "shortName": "00",
+      "channels": [
+        "Cyan"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'clay-paky/axcor-spot-300'

### Fixture warnings / errors

* clay-paky/axcor-spot-300
  - :x: Category 'Moving Head' invalid since there are not both pan and tilt channels.


Thank you **Pepito**!