### PR TITLE
Fix `null` error in `getAjvErrorMessages`

### DIFF
--- a/lib/get-ajv-error-messages.js
+++ b/lib/get-ajv-error-messages.js
@@ -60,7 +60,7 @@ function getDataDescription(data) {
   if (typeof data === `string`) {
     return ` "${getShortenedString(data)}"`;
   }
-  if (typeof data === `number` || typeof data === `boolean`) {
+  if (typeof data === `number` || typeof data === `boolean` || data === null) {
     return ` ${data}`;
   }
   if (typeof data === `object` && `type` in data) {

--- a/lib/get-ajv-error-messages.js
+++ b/lib/get-ajv-error-messages.js
@@ -58,10 +58,7 @@ export default function getAjvErrorMessages(ajvErrors, rootName = `root`) {
  */
 function getDataDescription(data) {
   if (typeof data === `string`) {
-    if (data.length > 16) {
-      return ` "${data.slice(0, 15)}…"`;
-    }
-    return ` "${data}"`;
+    return ` "${getShortenedString(data)}"`;
   }
   if (typeof data === `number` || typeof data === `boolean`) {
     return ` ${data}`;
@@ -70,4 +67,12 @@ function getDataDescription(data) {
     return ` (type: ${data.type})`;
   }
   return ``;
+}
+
+/**
+ * @param {String} string The string to shorten
+ * @returns {String} The shortened string, or the original string if it's already short.
+ */
+function getShortenedString(string) {
+  return (string.length > 16) ? `${string.slice(0, 15)}}…` : string;
 }

--- a/ui/api/routes/fixtures/submit.js
+++ b/ui/api/routes/fixtures/submit.js
@@ -35,7 +35,7 @@ export async function submitFixtures({ request }) {
     return {
       statusCode: 500,
       body: {
-        error: error.message,
+        error: `${error.toString()}\n${error.stack}`,
       },
     };
   }

--- a/ui/components/editor/EditorSubmitDialog.vue
+++ b/ui/components/editor/EditorSubmitDialog.vue
@@ -267,8 +267,8 @@ export default {
       const rawData = JSON.stringify(this.requestBody, null, 2);
 
       if (this.state === `error`) {
-        // eslint-disable-next-line quotes, prefer-template
-        return '```json\n' + rawData + '\n```\n\n' + this.error;
+        const backticks = '```'; // eslint-disable-line quotes
+        return `${backticks}json\n${rawData}\n\n${this.error}\n${backticks}`;
       }
 
       return rawData;


### PR DESCRIPTION
And make debugging fixture editor error messages easier in the future.

Closes #1896.