### PR TITLE
Improve JSON Schema errors

### DIFF
--- a/lib/get-ajv-error-messages.js
+++ b/lib/get-ajv-error-messages.js
@@ -17,7 +17,7 @@ const getDetailsPerAjvKeyword = {
     return `${error.message} (${error.params.additionalProperty})`;
   },
   enum(error) {
-    return `should be equal to one of [${error.params.allowedValues.join(`, `)}]`;
+    return `must be equal to one of [${error.params.allowedValues.join(`, `)}]`;
   },
   oneOf(error) {
     if (error.params.passingSchemas) {
@@ -28,7 +28,7 @@ const getDetailsPerAjvKeyword = {
 
       if (allAreOnlyRequired) {
         const properties = passingSchemas.map(schema => schema.required.join(`+`));
-        return `should not have a combination of the properties ${properties.join(` / `)}`;
+        return `must not have a combination of the properties ${properties.join(` / `)}`;
       }
     }
 

--- a/lib/get-ajv-error-messages.js
+++ b/lib/get-ajv-error-messages.js
@@ -45,7 +45,19 @@ const getDetailsPerAjvKeyword = {
  * @returns {String} A human-readable validation error message.
  */
 export default function getAjvErrorMessages(ajvErrors, rootName = `root`) {
-  const errors = ajvErrors.filter(error => !(`propertyName` in error));
+  const errors = ajvErrors.filter(error => {
+    if (`propertyName` in error) {
+      // the information from this error will be displayed in the related `propertyNames` error
+      return false;
+    }
+
+    if (error.keyword === `if` && error.schema === true) {
+      // this is a useless error
+      return false;
+    }
+
+    return true;
+  });
 
   return errors.map(error => {
     const getDetails = getDetailsPerAjvKeyword[error.keyword] || (() => error.message);

--- a/lib/get-ajv-error-messages.js
+++ b/lib/get-ajv-error-messages.js
@@ -74,5 +74,5 @@ function getDataDescription(data) {
  * @returns {String} The shortened string, or the original string if it's already short.
  */
 function getShortenedString(string) {
-  return (string.length > 16) ? `${string.slice(0, 15)}}…` : string;
+  return (string.length > 16) ? `${string.slice(0, 15)}…` : string;
 }

--- a/lib/get-ajv-error-messages.js
+++ b/lib/get-ajv-error-messages.js
@@ -89,5 +89,6 @@ function getDataDescription(data) {
  * @returns {String} The shortened string, or the original string if it's already short.
  */
 function getShortenedString(string) {
-  return (string.length > 16) ? `${string.slice(0, 15)}…` : string;
+  const maxLength = 30;
+  return (string.length > maxLength) ? `${string.slice(0, maxLength - 1)}…` : string;
 }

--- a/lib/get-ajv-error-messages.js
+++ b/lib/get-ajv-error-messages.js
@@ -34,6 +34,9 @@ const getDetailsPerAjvKeyword = {
 
     return error.message;
   },
+  const(error) {
+    return `${error.message} "${getShortenedString(error.params.allowedValue)}"`;
+  },
 };
 
 /**


### PR DESCRIPTION
* Fix excess character in shortened strings
* Better describe AJV errors for `const` keyword
* Exclude useless errors
* Replace "should" with "must" to be consistent with original AJV errors (see https://github.com/ajv-validator/ajv/releases/tag/v8.0.0)
* Increase maximum length in shortened strings