### PR TITLE
Simplify JSON Schemas

### DIFF
--- a/lib/ajv-validator.js
+++ b/lib/ajv-validator.js
@@ -9,6 +9,7 @@ const ajv = new Ajv({
   verbose: true,
   strict: false,
   allErrors: true,
+  discriminator: true,
 });
 addFormats(ajv);
 ajv.addKeyword(`version`);

--- a/lib/schema-properties.js
+++ b/lib/schema-properties.js
@@ -15,8 +15,8 @@ export const capabilityTypes = Object.fromEntries(capabilitySchema.allOf.map(
   ({ if: ifClause, then: thenClause }) => [ifClause.properties.type.const, thenClause],
 ));
 
-export const wheelSlotTypes = Object.fromEntries(wheelSlotSchema.allOf.map(
-  ({ if: ifClause, then: thenClause }) => [ifClause.properties.type.const, thenClause],
+export const wheelSlotTypes = Object.fromEntries(wheelSlotSchema.oneOf.map(
+  schema => [schema.properties.type.const, schema],
 ));
 
 export const manufacturerProperties = manufacturersSchema.additionalProperties.properties;
@@ -27,7 +27,6 @@ export const physicalLensProperties = physicalProperties.lens.properties;
 export const modeProperties = fixtureProperties.modes.items.properties;
 export const channelProperties = channelSchema.properties;
 export const capabilityProperties = capabilitySchema.properties;
-export const wheelSlotProperties = wheelSlotSchema.properties;
 export const schemaDefinitions = definitionsSchema;
 export const unitsSchema = definitionsSchema.units;
 export const entitiesSchema = definitionsSchema.entities;

--- a/lib/schema-properties.js
+++ b/lib/schema-properties.js
@@ -11,8 +11,8 @@ import {
 export const fixtureProperties = fixtureSchema.properties;
 export const physicalProperties = fixtureProperties.physical.properties;
 
-export const capabilityTypes = Object.fromEntries(capabilitySchema.allOf.map(
-  ({ if: ifClause, then: thenClause }) => [ifClause.properties.type.const, thenClause],
+export const capabilityTypes = Object.fromEntries(capabilitySchema.oneOf.map(
+  schema => [schema.properties.type.const, schema],
 ));
 
 export const wheelSlotTypes = Object.fromEntries(wheelSlotSchema.oneOf.map(
@@ -26,7 +26,7 @@ export const physicalBulbProperties = physicalProperties.bulb.properties;
 export const physicalLensProperties = physicalProperties.lens.properties;
 export const modeProperties = fixtureProperties.modes.items.properties;
 export const channelProperties = channelSchema.properties;
-export const capabilityProperties = capabilitySchema.properties;
+export const capabilityDmxRange = capabilitySchema.definitions.dmxRange;
 export const schemaDefinitions = definitionsSchema;
 export const unitsSchema = definitionsSchema.units;
 export const entitiesSchema = definitionsSchema.entities;

--- a/plugins/dragonframe/exportTests/json-schema-conformity.js
+++ b/plugins/dragonframe/exportTests/json-schema-conformity.js
@@ -75,10 +75,10 @@ async function getSchemas() {
   definitionsSchema.goboResourceString = { type: `object` };
 
   // allow changed schema property
-  fixtureSchema.patternProperties[`^\\$schema$`].const = `${SCHEMA_BASE_URL}fixture.json`;
-  fixtureSchema.patternProperties[`^\\$schema$`].enum = undefined;
-  manufacturersSchema.patternProperties[`^\\$schema$`].const = `${SCHEMA_BASE_URL}manufacturers.json`;
-  manufacturersSchema.patternProperties[`^\\$schema$`].enum = undefined;
+  fixtureSchema.properties.$schema = { const: `${SCHEMA_BASE_URL}fixture.json` };
+  fixtureSchema.patternProperties = undefined;
+  manufacturersSchema.properties.$schema = { const: `${SCHEMA_BASE_URL}manufacturers.json` };
+  manufacturersSchema.patternProperties = undefined;
 
   return schemasJson;
 }

--- a/plugins/dragonframe/exportTests/json-schema-conformity.js
+++ b/plugins/dragonframe/exportTests/json-schema-conformity.js
@@ -77,7 +77,7 @@ async function getSchemas() {
   // allow changed schema property
   fixtureSchema.properties.$schema = { const: `${SCHEMA_BASE_URL}fixture.json` };
   fixtureSchema.patternProperties = undefined;
-  manufacturersSchema.properties.$schema = { const: `${SCHEMA_BASE_URL}manufacturers.json` };
+  manufacturersSchema.properties = { $schema: { const: `${SCHEMA_BASE_URL}manufacturers.json` } };
   manufacturersSchema.patternProperties = undefined;
 
   return schemasJson;

--- a/plugins/millumin/exportTests/json-schema-conformity.js
+++ b/plugins/millumin/exportTests/json-schema-conformity.js
@@ -59,8 +59,8 @@ async function getSchemas() {
   fixtureSchema.properties.oflURL = true;
 
   // allow changed schema property
-  fixtureSchema.patternProperties[`^\\$schema$`].const = `${SCHEMA_BASE_URL}fixture.json`;
-  fixtureSchema.patternProperties[`^\\$schema$`].enum = undefined;
+  fixtureSchema.properties.$schema = { const: `${SCHEMA_BASE_URL}fixture.json` };
+  fixtureSchema.patternProperties = undefined;
 
   // allow new colors from schema version 11.1.0
   // see https://github.com/OpenLightingProject/open-fixture-library/pull/763

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -59,7 +59,7 @@
     },
     "ofl": {
       "name": "Open Fixture Library JSON",
-      "exportPluginVersion": "12.2.1",
+      "exportPluginVersion": "12.2.2",
       "exportTests": []
     },
     "op-z": {

--- a/schemas/capability.json
+++ b/schemas/capability.json
@@ -40,672 +40,431 @@
   },
 
   "type": "object",
-  "properties": {
-    "dmxRange": { "$ref": "#/definitions/dmxRange" },
-    "type": { "enum": [
-      "NoFunction",
-      "ShutterStrobe",
-      "StrobeSpeed",
-      "StrobeDuration",
-      "Intensity",
-      "ColorIntensity",
-      "ColorPreset",
-      "ColorTemperature",
-      "Pan",
-      "PanContinuous",
-      "Tilt",
-      "TiltContinuous",
-      "PanTiltSpeed",
-      "WheelSlot",
-      "WheelShake",
-      "WheelSlotRotation",
-      "WheelRotation",
-      "Effect",
-      "EffectSpeed",
-      "EffectDuration",
-      "EffectParameter",
-      "SoundSensitivity",
-      "BeamAngle",
-      "BeamPosition",
-      "Focus",
-      "Zoom",
-      "Iris",
-      "IrisEffect",
-      "Frost",
-      "FrostEffect",
-      "Prism",
-      "PrismRotation",
-      "BladeInsertion",
-      "BladeRotation",
-      "BladeSystemRotation",
-      "Fog",
-      "FogOutput",
-      "FogType",
-      "Rotation",
-      "Speed",
-      "Time",
-      "Maintenance",
-      "Generic"
-    ] },
-    "comment": { "$ref": "definitions.json#/nonEmptyString" },
-    "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
-    "menuClick": { "$ref": "#/definitions/menuClick" },
-    "switchChannels": { "$ref": "#/definitions/switchChannels" }
-  },
-  "required": ["type"],
-  "allOf": [
+  "discriminator": { "propertyName": "type" },
+  "oneOf": [
     {
-      "if": {
-        "properties": {
-          "type": { "const": "NoFunction" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "NoFunction" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "ShutterStrobe" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "ShutterStrobe" },
+        "shutterEffect": { "enum": [
+          "Open",
+          "Closed",
+          "Strobe",
+          "Pulse",
+          "RampUp",
+          "RampDown",
+          "RampUpDown",
+          "Lightning",
+          "Spikes"
+        ] },
+        "soundControlled": { "type": "boolean" },
+        "speed": { "$ref": "definitions.json#/entities/speed" },
+        "speedStart": { "$ref": "definitions.json#/entities/speed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/speed" },
+        "duration": { "$ref": "definitions.json#/entities/time" },
+        "durationStart": { "$ref": "definitions.json#/entities/time" },
+        "durationEnd": { "$ref": "definitions.json#/entities/time" },
+        "randomTiming": { "type": "boolean" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "shutterEffect": { "enum": [
-            "Open",
-            "Closed",
-            "Strobe",
-            "Pulse",
-            "RampUp",
-            "RampDown",
-            "RampUpDown",
-            "Lightning",
-            "Spikes"
-          ] },
-          "soundControlled": { "type": "boolean" },
-          "speed": { "$ref": "definitions.json#/entities/speed" },
-          "speedStart": { "$ref": "definitions.json#/entities/speed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/speed" },
-          "duration": { "$ref": "definitions.json#/entities/time" },
-          "durationStart": { "$ref": "definitions.json#/entities/time" },
-          "durationEnd": { "$ref": "definitions.json#/entities/time" },
-          "randomTiming": { "type": "boolean" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "required": ["shutterEffect"],
-        "not": {
-          "anyOf": [
-            { "required": ["speed", "speedStart"] },
-            { "required": ["duration", "durationStart"] }
+      "required": ["type", "shutterEffect"],
+      "not": {
+        "anyOf": [
+          { "required": ["speed", "speedStart"] },
+          { "required": ["duration", "durationStart"] }
+        ]
+      },
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"],
+        "durationStart": ["durationEnd"],
+        "durationEnd": ["durationStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "StrobeSpeed" },
+        "speed": { "$ref": "definitions.json#/entities/speed" },
+        "speedStart": { "$ref": "definitions.json#/entities/speed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/speed" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] }
+      ],
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "StrobeDuration" },
+        "duration": { "$ref": "definitions.json#/entities/time" },
+        "durationStart": { "$ref": "definitions.json#/entities/time" },
+        "durationEnd": { "$ref": "definitions.json#/entities/time" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["duration"] },
+        { "required": ["durationStart"] }
+      ],
+      "dependencies": {
+        "durationStart": ["durationEnd"],
+        "durationEnd": ["durationStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Intensity" },
+        "brightness": { "$ref": "definitions.json#/entities/brightness" },
+        "brightnessStart": { "$ref": "definitions.json#/entities/brightness" },
+        "brightnessEnd": { "$ref": "definitions.json#/entities/brightness" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "not": { "required": ["brightness", "brightnessStart"] },
+      "dependencies": {
+        "brightnessStart": ["brightnessEnd"],
+        "brightnessEnd": ["brightnessStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "ColorIntensity" },
+        "color": {
+          "enum": [
+            "Red",
+            "Green",
+            "Blue",
+            "Cyan",
+            "Magenta",
+            "Yellow",
+            "Amber",
+            "White",
+            "Warm White",
+            "Cold White",
+            "UV",
+            "Lime",
+            "Indigo"
           ]
         },
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"],
-          "durationStart": ["durationEnd"],
-          "durationEnd": ["durationStart"]
-        },
-        "additionalProperties": false
-      }
+        "brightness": { "$ref": "definitions.json#/entities/brightness" },
+        "brightnessStart": { "$ref": "definitions.json#/entities/brightness" },
+        "brightnessEnd": { "$ref": "definitions.json#/entities/brightness" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type", "color"],
+      "not": { "required": ["brightness", "brightnessStart"] },
+      "dependencies": {
+        "brightnessStart": ["brightnessEnd"],
+        "brightnessEnd": ["brightnessStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "StrobeSpeed" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "ColorPreset" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "colors": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "definitions.json#/colorString" }
+        },
+        "colorsStart": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "definitions.json#/colorString" }
+        },
+        "colorsEnd": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "definitions.json#/colorString" }
+        },
+        "colorTemperature": { "$ref": "definitions.json#/entities/colorTemperature" },
+        "colorTemperatureStart": { "$ref": "definitions.json#/entities/colorTemperature" },
+        "colorTemperatureEnd": { "$ref": "definitions.json#/entities/colorTemperature" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "speed": { "$ref": "definitions.json#/entities/speed" },
-          "speedStart": { "$ref": "definitions.json#/entities/speed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/speed" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] }
-        ],
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "not": {
+        "anyOf": [
+          { "required": ["colors", "colorsStart"] },
+          { "required": ["colorTemperature", "colorTemperatureStart"] }
+        ]
+      },
+      "dependencies": {
+        "colorsStart": ["colorsEnd"],
+        "colorsEnd": ["colorsStart"],
+        "colorTemperatureStart": ["colorTemperatureEnd"],
+        "colorTemperatureEnd": ["colorTemperatureStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "StrobeDuration" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "ColorTemperature" },
+        "colorTemperature": { "$ref": "definitions.json#/entities/colorTemperature" },
+        "colorTemperatureStart": { "$ref": "definitions.json#/entities/colorTemperature" },
+        "colorTemperatureEnd": { "$ref": "definitions.json#/entities/colorTemperature" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "duration": { "$ref": "definitions.json#/entities/time" },
-          "durationStart": { "$ref": "definitions.json#/entities/time" },
-          "durationEnd": { "$ref": "definitions.json#/entities/time" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["duration"] },
-          { "required": ["durationStart"] }
-        ],
-        "dependencies": {
-          "durationStart": ["durationEnd"],
-          "durationEnd": ["durationStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["colorTemperature"] },
+        { "required": ["colorTemperatureStart"] }
+      ],
+      "dependencies": {
+        "colorTemperatureStart": ["colorTemperatureEnd"],
+        "colorTemperatureEnd": ["colorTemperatureStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "Intensity" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Pan" },
+        "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "brightness": { "$ref": "definitions.json#/entities/brightness" },
-          "brightnessStart": { "$ref": "definitions.json#/entities/brightness" },
-          "brightnessEnd": { "$ref": "definitions.json#/entities/brightness" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "not": { "required": ["brightness", "brightnessStart"] },
-        "dependencies": {
-          "brightnessStart": ["brightnessEnd"],
-          "brightnessEnd": ["brightnessStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "dependencies": {
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "ColorIntensity" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "PanContinuous" },
+        "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "color": {
-            "enum": [
-              "Red",
-              "Green",
-              "Blue",
-              "Cyan",
-              "Magenta",
-              "Yellow",
-              "Amber",
-              "White",
-              "Warm White",
-              "Cold White",
-              "UV",
-              "Lime",
-              "Indigo"
-            ]
-          },
-          "brightness": { "$ref": "definitions.json#/entities/brightness" },
-          "brightnessStart": { "$ref": "definitions.json#/entities/brightness" },
-          "brightnessEnd": { "$ref": "definitions.json#/entities/brightness" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "required": ["color"],
-        "not": { "required": ["brightness", "brightnessStart"] },
-        "dependencies": {
-          "brightnessStart": ["brightnessEnd"],
-          "brightnessEnd": ["brightnessStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] }
+      ],
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "ColorPreset" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Tilt" },
+        "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "comment": {},
-          "colors": {
-            "type": "array",
-            "minItems": 1,
-            "items": { "$ref": "definitions.json#/colorString" }
-          },
-          "colorsStart": {
-            "type": "array",
-            "minItems": 1,
-            "items": { "$ref": "definitions.json#/colorString" }
-          },
-          "colorsEnd": {
-            "type": "array",
-            "minItems": 1,
-            "items": { "$ref": "definitions.json#/colorString" }
-          },
-          "colorTemperature": { "$ref": "definitions.json#/entities/colorTemperature" },
-          "colorTemperatureStart": { "$ref": "definitions.json#/entities/colorTemperature" },
-          "colorTemperatureEnd": { "$ref": "definitions.json#/entities/colorTemperature" },
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "not": {
-          "anyOf": [
-            { "required": ["colors", "colorsStart"] },
-            { "required": ["colorTemperature", "colorTemperatureStart"] }
-          ]
-        },
-        "dependencies": {
-          "colorsStart": ["colorsEnd"],
-          "colorsEnd": ["colorsStart"],
-          "colorTemperatureStart": ["colorTemperatureEnd"],
-          "colorTemperatureEnd": ["colorTemperatureStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "dependencies": {
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "ColorTemperature" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "TiltContinuous" },
+        "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "colorTemperature": { "$ref": "definitions.json#/entities/colorTemperature" },
-          "colorTemperatureStart": { "$ref": "definitions.json#/entities/colorTemperature" },
-          "colorTemperatureEnd": { "$ref": "definitions.json#/entities/colorTemperature" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["colorTemperature"] },
-          { "required": ["colorTemperatureStart"] }
-        ],
-        "dependencies": {
-          "colorTemperatureStart": ["colorTemperatureEnd"],
-          "colorTemperatureEnd": ["colorTemperatureStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] }
+      ],
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "Pan" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "PanTiltSpeed" },
+        "speed": { "$ref": "definitions.json#/entities/speed" },
+        "speedStart": { "$ref": "definitions.json#/entities/speed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/speed" },
+        "duration": { "$ref": "definitions.json#/entities/time" },
+        "durationStart": { "$ref": "definitions.json#/entities/time" },
+        "durationEnd": { "$ref": "definitions.json#/entities/time" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "dependencies": {
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] },
+        { "required": ["duration"] },
+        { "required": ["durationStart"] }
+      ],
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"],
+        "durationStart": ["durationEnd"],
+        "durationEnd": ["durationStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "PanContinuous" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "WheelSlot" },
+        "wheel": { "$ref": "definitions.json#/nonEmptyString" },
+        "slotNumber": { "$ref": "definitions.json#/entities/slotNumber" },
+        "slotNumberStart": { "$ref": "definitions.json#/entities/slotNumber" },
+        "slotNumberEnd": { "$ref": "definitions.json#/entities/slotNumber" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] }
-        ],
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["slotNumber"] },
+        { "required": ["slotNumberStart"] }
+      ],
+      "dependencies": {
+        "slotNumberStart": ["slotNumberEnd"],
+        "slotNumberEnd": ["slotNumberStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "Tilt" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "WheelShake" },
+        "wheel": {},
+        "isShaking": {
+          "enum": ["wheel", "slot"]
+        },
+        "slotNumber": { "$ref": "definitions.json#/entities/slotNumber" },
+        "slotNumberStart": { "$ref": "definitions.json#/entities/slotNumber" },
+        "slotNumberEnd": { "$ref": "definitions.json#/entities/slotNumber" },
+        "shakeSpeed": { "$ref": "definitions.json#/entities/speed" },
+        "shakeSpeedStart": { "$ref": "definitions.json#/entities/speed" },
+        "shakeSpeedEnd": { "$ref": "definitions.json#/entities/speed" },
+        "shakeAngle": { "$ref": "definitions.json#/entities/swingAngle" },
+        "shakeAngleStart": { "$ref": "definitions.json#/entities/swingAngle" },
+        "shakeAngleEnd": { "$ref": "definitions.json#/entities/swingAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "dependencies": {
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "TiltContinuous" }
-        }
+      "required": ["type"],
+      "not": {
+        "anyOf": [
+          { "required": ["slotNumber", "slotNumberStart"] },
+          { "required": ["shakeSpeed", "shakeSpeedStart"] },
+          { "required": ["shakeAngle", "shakeAngleStart"] }
+        ]
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] }
-        ],
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "PanTiltSpeed" }
-        }
+      "dependencies": {
+        "shakeSpeedStart": ["shakeSpeedEnd"],
+        "shakeSpeedEnd": ["shakeSpeedStart"],
+        "shakeAngleStart": ["shakeAngleEnd"],
+        "shakeAngleEnd": ["shakeAngleStart"],
+        "slotNumberStart": ["slotNumberEnd"],
+        "slotNumberEnd": ["slotNumberStart"]
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "speed": { "$ref": "definitions.json#/entities/speed" },
-          "speedStart": { "$ref": "definitions.json#/entities/speed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/speed" },
-          "duration": { "$ref": "definitions.json#/entities/time" },
-          "durationStart": { "$ref": "definitions.json#/entities/time" },
-          "durationEnd": { "$ref": "definitions.json#/entities/time" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] },
-          { "required": ["duration"] },
-          { "required": ["durationStart"] }
-        ],
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"],
-          "durationStart": ["durationEnd"],
-          "durationEnd": ["durationStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
       "if": {
-        "properties": {
-          "type": { "const": "WheelSlot" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "wheel": { "$ref": "definitions.json#/nonEmptyString" },
-          "slotNumber": { "$ref": "definitions.json#/entities/slotNumber" },
-          "slotNumberStart": { "$ref": "definitions.json#/entities/slotNumber" },
-          "slotNumberEnd": { "$ref": "definitions.json#/entities/slotNumber" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
+        "$comment": "slotNumber is set",
+        "anyOf": [
           { "required": ["slotNumber"] },
           { "required": ["slotNumberStart"] }
-        ],
-        "dependencies": {
-          "slotNumberStart": ["slotNumberEnd"],
-          "slotNumberEnd": ["slotNumberStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "WheelShake" }
-        }
+        ]
       },
       "then": {
+        "$comment": "wheel must be a single wheel",
         "properties": {
-          "dmxRange": {},
-          "type": {},
-          "wheel": {},
-          "isShaking": {
-            "enum": ["wheel", "slot"]
-          },
-          "slotNumber": { "$ref": "definitions.json#/entities/slotNumber" },
-          "slotNumberStart": { "$ref": "definitions.json#/entities/slotNumber" },
-          "slotNumberEnd": { "$ref": "definitions.json#/entities/slotNumber" },
-          "shakeSpeed": { "$ref": "definitions.json#/entities/speed" },
-          "shakeSpeedStart": { "$ref": "definitions.json#/entities/speed" },
-          "shakeSpeedEnd": { "$ref": "definitions.json#/entities/speed" },
-          "shakeAngle": { "$ref": "definitions.json#/entities/swingAngle" },
-          "shakeAngleStart": { "$ref": "definitions.json#/entities/swingAngle" },
-          "shakeAngleEnd": { "$ref": "definitions.json#/entities/swingAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "not": {
-          "anyOf": [
-            { "required": ["slotNumber", "slotNumberStart"] },
-            { "required": ["shakeSpeed", "shakeSpeedStart"] },
-            { "required": ["shakeAngle", "shakeAngleStart"] }
-          ]
-        },
-        "dependencies": {
-          "shakeSpeedStart": ["shakeSpeedEnd"],
-          "shakeSpeedEnd": ["shakeSpeedStart"],
-          "shakeAngleStart": ["shakeAngleEnd"],
-          "shakeAngleEnd": ["shakeAngleStart"],
-          "slotNumberStart": ["slotNumberEnd"],
-          "slotNumberEnd": ["slotNumberStart"]
-        },
-        "if": {
-          "$comment": "slotNumber is set",
-          "anyOf": [
-            { "required": ["slotNumber"] },
-            { "required": ["slotNumberStart"] }
-          ]
-        },
-        "then": {
-          "$comment": "wheel must be a single wheel",
-          "properties": {
-            "wheel": { "$ref": "definitions.json#/nonEmptyString" }
-          }
-        },
-        "else": {
-          "$comment": "wheel can be a single wheel or multiple wheels",
-          "properties": {
-            "wheel": {
-              "oneOf": [
-                { "$ref": "definitions.json#/nonEmptyString" },
-                {
-                  "type": "array",
-                  "uniqueItems": true,
-                  "minItems": 2,
-                  "items": { "$ref": "definitions.json#/nonEmptyString" }
-                }
-              ]
-            }
-          }
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "WheelSlotRotation" }
+          "wheel": { "$ref": "definitions.json#/nonEmptyString" }
         }
       },
-      "then": {
+      "else": {
+        "$comment": "wheel can be a single wheel or multiple wheels",
         "properties": {
-          "dmxRange": {},
-          "type": {},
-          "wheel": {},
-          "slotNumber": { "$ref": "definitions.json#/entities/slotNumber" },
-          "slotNumberStart": { "$ref": "definitions.json#/entities/slotNumber" },
-          "slotNumberEnd": { "$ref": "definitions.json#/entities/slotNumber" },
-          "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] },
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "not": { "required": ["slotNumber", "slotNumberStart"] },
-        "dependencies": {
-          "slotNumberStart": ["slotNumberEnd"],
-          "slotNumberEnd": ["slotNumberStart"],
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"],
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "if": {
-          "$comment": "slotNumber is set",
-          "anyOf": [
-            { "required": ["slotNumber"] },
-            { "required": ["slotNumberStart"] }
-          ]
-        },
-        "then": {
-          "$comment": "wheel must be a single wheel",
-          "properties": {
-            "wheel": { "$ref": "definitions.json#/nonEmptyString" }
-          }
-        },
-        "else": {
-          "$comment": "wheel can be a single wheel or multiple wheels",
-          "properties": {
-            "wheel": {
-              "oneOf": [
-                { "$ref": "definitions.json#/nonEmptyString" },
-                {
-                  "type": "array",
-                  "uniqueItems": true,
-                  "minItems": 2,
-                  "items": { "$ref": "definitions.json#/nonEmptyString" }
-                }
-              ]
-            }
-          }
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "WheelRotation" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
           "wheel": {
             "oneOf": [
               { "$ref": "definitions.json#/nonEmptyString" },
@@ -716,836 +475,760 @@
                 "items": { "$ref": "definitions.json#/nonEmptyString" }
               }
             ]
-          },
-          "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] },
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"],
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Effect" }
+          }
         }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "effectName": { "$ref": "definitions.json#/nonEmptyString" },
-          "effectPreset": { "$ref": "definitions.json#/effectPreset" },
-          "speed": { "$ref": "definitions.json#/entities/speed" },
-          "speedStart": { "$ref": "definitions.json#/entities/speed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/speed" },
-          "duration": { "$ref": "definitions.json#/entities/time" },
-          "durationStart": { "$ref": "definitions.json#/entities/time" },
-          "durationEnd": { "$ref": "definitions.json#/entities/time" },
-          "parameter": { "$ref": "definitions.json#/entities/parameter" },
-          "parameterStart": { "$ref": "definitions.json#/entities/parameter" },
-          "parameterEnd": { "$ref": "definitions.json#/entities/parameter" },
-          "soundControlled": { "type": "boolean" },
-          "soundSensitivity": { "$ref": "definitions.json#/entities/percent" },
-          "soundSensitivityStart": { "$ref": "definitions.json#/entities/percent" },
-          "soundSensitivityEnd": { "$ref": "definitions.json#/entities/percent" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["effectName"] },
-          { "required": ["effectPreset"] }
-        ],
-        "not": {
-          "anyOf": [
-            { "required": ["speed", "speedStart"] },
-            { "required": ["duration", "durationStart"] },
-            { "required": ["parameter", "parameterStart"] },
-            { "required": ["soundSensitivity", "soundSensitivityStart"] }
-          ]
-        },
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"],
-          "durationStart": ["durationEnd"],
-          "durationEnd": ["durationStart"],
-          "parameterStart": ["parameterEnd"],
-          "parameterEnd": ["parameterStart"],
-          "soundSensitivityStart": ["soundSensitivityEnd"],
-          "soundSensitivityEnd": ["soundSensitivityStart"]
-        },
-        "additionalProperties": false
-      }
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "EffectSpeed" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "WheelSlotRotation" },
+        "wheel": {},
+        "slotNumber": { "$ref": "definitions.json#/entities/slotNumber" },
+        "slotNumberStart": { "$ref": "definitions.json#/entities/slotNumber" },
+        "slotNumberEnd": { "$ref": "definitions.json#/entities/slotNumber" },
+        "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "speed": { "$ref": "definitions.json#/entities/speed" },
-          "speedStart": { "$ref": "definitions.json#/entities/speed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/speed" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] }
-        ],
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "EffectDuration" }
-        }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] },
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "not": { "required": ["slotNumber", "slotNumberStart"] },
+      "dependencies": {
+        "slotNumberStart": ["slotNumberEnd"],
+        "slotNumberEnd": ["slotNumberStart"],
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"],
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "duration": { "$ref": "definitions.json#/entities/time" },
-          "durationStart": { "$ref": "definitions.json#/entities/time" },
-          "durationEnd": { "$ref": "definitions.json#/entities/time" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["duration"] },
-          { "required": ["durationStart"] }
-        ],
-        "dependencies": {
-          "durationStart": ["durationEnd"],
-          "durationEnd": ["durationStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
       "if": {
-        "properties": {
-          "type": { "const": "EffectParameter" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "parameter": { "$ref": "definitions.json#/entities/parameter" },
-          "parameterStart": { "$ref": "definitions.json#/entities/parameter" },
-          "parameterEnd": { "$ref": "definitions.json#/entities/parameter" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["parameter"] },
-          { "required": ["parameterStart"] }
-        ],
-        "dependencies": {
-          "parameterStart": ["parameterEnd"],
-          "parameterEnd": ["parameterStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "SoundSensitivity" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "soundSensitivity": { "$ref": "definitions.json#/entities/percent" },
-          "soundSensitivityStart": { "$ref": "definitions.json#/entities/percent" },
-          "soundSensitivityEnd": { "$ref": "definitions.json#/entities/percent" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["soundSensitivity"] },
-          { "required": ["soundSensitivityStart"] }
-        ],
-        "dependencies": {
-          "soundSensitivityStart": ["soundSensitivityEnd"],
-          "soundSensitivityEnd": ["soundSensitivityStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "BeamAngle" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "angle": { "$ref": "definitions.json#/entities/beamAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/beamAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/beamAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "dependencies": {
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "BeamPosition" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "horizontalAngle": { "$ref": "definitions.json#/entities/horizontalAngle" },
-          "horizontalAngleStart": { "$ref": "definitions.json#/entities/horizontalAngle" },
-          "horizontalAngleEnd": { "$ref": "definitions.json#/entities/horizontalAngle" },
-          "verticalAngle": { "$ref": "definitions.json#/entities/verticalAngle" },
-          "verticalAngleStart": { "$ref": "definitions.json#/entities/verticalAngle" },
-          "verticalAngleEnd": { "$ref": "definitions.json#/entities/verticalAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
+        "$comment": "slotNumber is set",
         "anyOf": [
-          { "oneOf": [
-            { "required": ["horizontalAngle"] },
-            { "required": ["horizontalAngleStart"] }
-          ] },
-          { "oneOf": [
-            { "required": ["verticalAngle"] },
-            { "required": ["verticalAngleStart"] }
-          ] }
-        ],
-        "dependencies": {
-          "horizontalAngleStart": ["horizontalAngleEnd"],
-          "horizontalAngleEnd": ["horizontalAngleStart"],
-          "verticalAngleStart": ["verticalAngleEnd"],
-          "verticalAngleEnd": ["verticalAngleStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Focus" }
-        }
+          { "required": ["slotNumber"] },
+          { "required": ["slotNumberStart"] }
+        ]
       },
       "then": {
+        "$comment": "wheel must be a single wheel",
         "properties": {
-          "dmxRange": {},
-          "type": {},
-          "distance": { "$ref": "definitions.json#/entities/distance" },
-          "distanceStart": { "$ref": "definitions.json#/entities/distance" },
-          "distanceEnd": { "$ref": "definitions.json#/entities/distance" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["distance"] },
-          { "required": ["distanceStart"] }
-        ],
-        "dependencies": {
-          "distanceStart": ["distanceEnd"],
-          "distanceEnd": ["distanceStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Zoom" }
+          "wheel": { "$ref": "definitions.json#/nonEmptyString" }
         }
       },
-      "then": {
+      "else": {
+        "$comment": "wheel can be a single wheel or multiple wheels",
         "properties": {
-          "dmxRange": {},
-          "type": {},
-          "angle": { "$ref": "definitions.json#/entities/beamAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/beamAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/beamAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "dependencies": {
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Iris" }
+          "wheel": {
+            "oneOf": [
+              { "$ref": "definitions.json#/nonEmptyString" },
+              {
+                "type": "array",
+                "uniqueItems": true,
+                "minItems": 2,
+                "items": { "$ref": "definitions.json#/nonEmptyString" }
+              }
+            ]
+          }
         }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "openPercent": { "$ref": "definitions.json#/entities/irisPercent" },
-          "openPercentStart": { "$ref": "definitions.json#/entities/irisPercent" },
-          "openPercentEnd": { "$ref": "definitions.json#/entities/irisPercent" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["openPercent"] },
-          { "required": ["openPercentStart"] }
-        ],
-        "dependencies": {
-          "openPercentStart": ["openPercentEnd"],
-          "openPercentEnd": ["openPercentStart"]
-        },
-        "additionalProperties": false
-      }
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "IrisEffect" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "effectName": { "$ref": "definitions.json#/nonEmptyString" },
-          "speed": { "$ref": "definitions.json#/entities/speed" },
-          "speedStart": { "$ref": "definitions.json#/entities/speed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/speed" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "required": ["effectName"],
-        "not": { "required": ["speed", "speedStart"] },
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Frost" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "frostIntensity": { "$ref": "definitions.json#/entities/percent" },
-          "frostIntensityStart": { "$ref": "definitions.json#/entities/percent" },
-          "frostIntensityEnd": { "$ref": "definitions.json#/entities/percent" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["frostIntensity"] },
-          { "required": ["frostIntensityStart"] }
-        ],
-        "dependencies": {
-          "frostIntensityStart": ["frostIntensityEnd"],
-          "frostIntensityEnd": ["frostIntensityStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "FrostEffect" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "effectName": { "$ref": "definitions.json#/nonEmptyString" },
-          "speed": { "$ref": "definitions.json#/entities/speed" },
-          "speedStart": { "$ref": "definitions.json#/entities/speed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/speed" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "required": ["effectName"],
-        "not": { "required": ["speed", "speedStart"] },
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"]
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Prism" }
-        }
-      },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "not": {
-          "anyOf": [
-            { "required": ["speed", "speedStart"] },
-            { "required": ["angle", "angleStart"] },
-            { "required": ["speed", "angle"] },
-            { "required": ["speed", "angleStart"] },
-            { "required": ["speedStart", "angle"] },
-            { "required": ["speedStart", "angleStart"] }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "WheelRotation" },
+        "wheel": {
+          "oneOf": [
+            { "$ref": "definitions.json#/nonEmptyString" },
+            {
+              "type": "array",
+              "uniqueItems": true,
+              "minItems": 2,
+              "items": { "$ref": "definitions.json#/nonEmptyString" }
+            }
           ]
         },
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"],
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
+        "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] },
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"],
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "PrismRotation" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Effect" },
+        "effectName": { "$ref": "definitions.json#/nonEmptyString" },
+        "effectPreset": { "$ref": "definitions.json#/effectPreset" },
+        "speed": { "$ref": "definitions.json#/entities/speed" },
+        "speedStart": { "$ref": "definitions.json#/entities/speed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/speed" },
+        "duration": { "$ref": "definitions.json#/entities/time" },
+        "durationStart": { "$ref": "definitions.json#/entities/time" },
+        "durationEnd": { "$ref": "definitions.json#/entities/time" },
+        "parameter": { "$ref": "definitions.json#/entities/parameter" },
+        "parameterStart": { "$ref": "definitions.json#/entities/parameter" },
+        "parameterEnd": { "$ref": "definitions.json#/entities/parameter" },
+        "soundControlled": { "type": "boolean" },
+        "soundSensitivity": { "$ref": "definitions.json#/entities/percent" },
+        "soundSensitivityStart": { "$ref": "definitions.json#/entities/percent" },
+        "soundSensitivityEnd": { "$ref": "definitions.json#/entities/percent" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] },
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"],
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["effectName"] },
+        { "required": ["effectPreset"] }
+      ],
+      "not": {
+        "anyOf": [
+          { "required": ["speed", "speedStart"] },
+          { "required": ["duration", "durationStart"] },
+          { "required": ["parameter", "parameterStart"] },
+          { "required": ["soundSensitivity", "soundSensitivityStart"] }
+        ]
+      },
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"],
+        "durationStart": ["durationEnd"],
+        "durationEnd": ["durationStart"],
+        "parameterStart": ["parameterEnd"],
+        "parameterEnd": ["parameterStart"],
+        "soundSensitivityStart": ["soundSensitivityEnd"],
+        "soundSensitivityEnd": ["soundSensitivityStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "BladeInsertion" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "EffectSpeed" },
+        "speed": { "$ref": "definitions.json#/entities/speed" },
+        "speedStart": { "$ref": "definitions.json#/entities/speed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/speed" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "blade": {
-            "oneOf": [
-              { "enum": ["Top", "Right", "Bottom", "Left"] },
-              { "$ref": "definitions.json#/units/positiveInteger" }
-            ]
-          },
-          "insertion": { "$ref": "definitions.json#/entities/insertion" },
-          "insertionStart": { "$ref": "definitions.json#/entities/insertion" },
-          "insertionEnd": { "$ref": "definitions.json#/entities/insertion" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "required": ["blade"],
-        "oneOf": [
-          { "required": ["insertion"] },
-          { "required": ["insertionStart"] }
-        ],
-        "dependencies": {
-          "insertionStart": ["insertionEnd"],
-          "insertionEnd": ["insertionStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] }
+      ],
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "BladeRotation" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "EffectDuration" },
+        "duration": { "$ref": "definitions.json#/entities/time" },
+        "durationStart": { "$ref": "definitions.json#/entities/time" },
+        "durationEnd": { "$ref": "definitions.json#/entities/time" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "blade": {
-            "oneOf": [
-              { "enum": ["Top", "Right", "Bottom", "Left"] },
-              { "$ref": "definitions.json#/units/positiveInteger" }
-            ]
-          },
-          "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "required": ["blade"],
-        "oneOf": [
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "dependencies": {
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["duration"] },
+        { "required": ["durationStart"] }
+      ],
+      "dependencies": {
+        "durationStart": ["durationEnd"],
+        "durationEnd": ["durationStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "BladeSystemRotation" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "EffectParameter" },
+        "parameter": { "$ref": "definitions.json#/entities/parameter" },
+        "parameterStart": { "$ref": "definitions.json#/entities/parameter" },
+        "parameterEnd": { "$ref": "definitions.json#/entities/parameter" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "dependencies": {
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["parameter"] },
+        { "required": ["parameterStart"] }
+      ],
+      "dependencies": {
+        "parameterStart": ["parameterEnd"],
+        "parameterEnd": ["parameterStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "Fog" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "SoundSensitivity" },
+        "soundSensitivity": { "$ref": "definitions.json#/entities/percent" },
+        "soundSensitivityStart": { "$ref": "definitions.json#/entities/percent" },
+        "soundSensitivityEnd": { "$ref": "definitions.json#/entities/percent" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "fogType": { "enum": ["Fog", "Haze"] },
-          "fogOutput": { "$ref": "definitions.json#/entities/fogOutput" },
-          "fogOutputStart": { "$ref": "definitions.json#/entities/fogOutput" },
-          "fogOutputEnd": { "$ref": "definitions.json#/entities/fogOutput" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "not": { "required": ["fogOutput", "fogOutputStart"] },
-        "dependencies": {
-          "fogOutputStart": ["fogOutputEnd"],
-          "fogOutputEnd": ["fogOutputStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["soundSensitivity"] },
+        { "required": ["soundSensitivityStart"] }
+      ],
+      "dependencies": {
+        "soundSensitivityStart": ["soundSensitivityEnd"],
+        "soundSensitivityEnd": ["soundSensitivityStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "FogOutput" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "BeamAngle" },
+        "angle": { "$ref": "definitions.json#/entities/beamAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/beamAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/beamAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "fogOutput": { "$ref": "definitions.json#/entities/fogOutput" },
-          "fogOutputStart": { "$ref": "definitions.json#/entities/fogOutput" },
-          "fogOutputEnd": { "$ref": "definitions.json#/entities/fogOutput" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["fogOutput"] },
-          { "required": ["fogOutputStart"] }
-        ],
-        "dependencies": {
-          "fogOutputStart": ["fogOutputEnd"],
-          "fogOutputEnd": ["fogOutputStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "dependencies": {
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "FogType" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "BeamPosition" },
+        "horizontalAngle": { "$ref": "definitions.json#/entities/horizontalAngle" },
+        "horizontalAngleStart": { "$ref": "definitions.json#/entities/horizontalAngle" },
+        "horizontalAngleEnd": { "$ref": "definitions.json#/entities/horizontalAngle" },
+        "verticalAngle": { "$ref": "definitions.json#/entities/verticalAngle" },
+        "verticalAngleStart": { "$ref": "definitions.json#/entities/verticalAngle" },
+        "verticalAngleEnd": { "$ref": "definitions.json#/entities/verticalAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "fogType": { "enum": ["Fog", "Haze"] },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "required": ["fogType"],
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "anyOf": [
+        { "oneOf": [
+          { "required": ["horizontalAngle"] },
+          { "required": ["horizontalAngleStart"] }
+        ] },
+        { "oneOf": [
+          { "required": ["verticalAngle"] },
+          { "required": ["verticalAngleStart"] }
+        ] }
+      ],
+      "dependencies": {
+        "horizontalAngleStart": ["horizontalAngleEnd"],
+        "horizontalAngleEnd": ["horizontalAngleStart"],
+        "verticalAngleStart": ["verticalAngleEnd"],
+        "verticalAngleEnd": ["verticalAngleStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "Rotation" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Focus" },
+        "distance": { "$ref": "definitions.json#/entities/distance" },
+        "distanceStart": { "$ref": "definitions.json#/entities/distance" },
+        "distanceEnd": { "$ref": "definitions.json#/entities/distance" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
-          "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] },
-          { "required": ["angle"] },
-          { "required": ["angleStart"] }
-        ],
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"],
-          "angleStart": ["angleEnd"],
-          "angleEnd": ["angleStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["distance"] },
+        { "required": ["distanceStart"] }
+      ],
+      "dependencies": {
+        "distanceStart": ["distanceEnd"],
+        "distanceEnd": ["distanceStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "Speed" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Zoom" },
+        "angle": { "$ref": "definitions.json#/entities/beamAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/beamAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/beamAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "speed": { "$ref": "definitions.json#/entities/speed" },
-          "speedStart": { "$ref": "definitions.json#/entities/speed" },
-          "speedEnd": { "$ref": "definitions.json#/entities/speed" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["speed"] },
-          { "required": ["speedStart"] }
-        ],
-        "dependencies": {
-          "speedStart": ["speedEnd"],
-          "speedEnd": ["speedStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "dependencies": {
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "Time" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Iris" },
+        "openPercent": { "$ref": "definitions.json#/entities/irisPercent" },
+        "openPercentStart": { "$ref": "definitions.json#/entities/irisPercent" },
+        "openPercentEnd": { "$ref": "definitions.json#/entities/irisPercent" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "time": { "$ref": "definitions.json#/entities/time" },
-          "timeStart": { "$ref": "definitions.json#/entities/time" },
-          "timeEnd": { "$ref": "definitions.json#/entities/time" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "oneOf": [
-          { "required": ["time"] },
-          { "required": ["timeStart"] }
-        ],
-        "dependencies": {
-          "timeStart": ["timeEnd"],
-          "timeEnd": ["timeStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["openPercent"] },
+        { "required": ["openPercentStart"] }
+      ],
+      "dependencies": {
+        "openPercentStart": ["openPercentEnd"],
+        "openPercentEnd": ["openPercentStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "Maintenance" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "IrisEffect" },
+        "effectName": { "$ref": "definitions.json#/nonEmptyString" },
+        "speed": { "$ref": "definitions.json#/entities/speed" },
+        "speedStart": { "$ref": "definitions.json#/entities/speed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/speed" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "parameter": { "$ref": "definitions.json#/entities/parameter" },
-          "parameterStart": { "$ref": "definitions.json#/entities/parameter" },
-          "parameterEnd": { "$ref": "definitions.json#/entities/parameter" },
-          "hold": { "$ref": "definitions.json#/entities/time" },
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
-        },
-        "not": { "required": ["parameter", "parameterStart"] },
-        "dependencies": {
-          "parameterStart": ["parameterEnd"],
-          "parameterEnd": ["parameterStart"]
-        },
-        "additionalProperties": false
-      }
+      "required": ["type", "effectName"],
+      "not": { "required": ["speed", "speedStart"] },
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"]
+      },
+      "additionalProperties": false
     },
     {
-      "if": {
-        "properties": {
-          "type": { "const": "Generic" }
-        }
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Frost" },
+        "frostIntensity": { "$ref": "definitions.json#/entities/percent" },
+        "frostIntensityStart": { "$ref": "definitions.json#/entities/percent" },
+        "frostIntensityEnd": { "$ref": "definitions.json#/entities/percent" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
       },
-      "then": {
-        "properties": {
-          "dmxRange": {},
-          "type": {},
-          "comment": {},
-          "helpWanted": {},
-          "menuClick": {},
-          "switchChannels": {}
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["frostIntensity"] },
+        { "required": ["frostIntensityStart"] }
+      ],
+      "dependencies": {
+        "frostIntensityStart": ["frostIntensityEnd"],
+        "frostIntensityEnd": ["frostIntensityStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "FrostEffect" },
+        "effectName": { "$ref": "definitions.json#/nonEmptyString" },
+        "speed": { "$ref": "definitions.json#/entities/speed" },
+        "speedStart": { "$ref": "definitions.json#/entities/speed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/speed" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type", "effectName"],
+      "not": { "required": ["speed", "speedStart"] },
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Prism" },
+        "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "not": {
+        "anyOf": [
+          { "required": ["speed", "speedStart"] },
+          { "required": ["angle", "angleStart"] },
+          { "required": ["speed", "angle"] },
+          { "required": ["speed", "angleStart"] },
+          { "required": ["speedStart", "angle"] },
+          { "required": ["speedStart", "angleStart"] }
+        ]
+      },
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"],
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "PrismRotation" },
+        "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] },
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"],
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "BladeInsertion" },
+        "blade": {
+          "oneOf": [
+            { "enum": ["Top", "Right", "Bottom", "Left"] },
+            { "$ref": "definitions.json#/units/positiveInteger" }
+          ]
         },
-        "additionalProperties": false
-      }
+        "insertion": { "$ref": "definitions.json#/entities/insertion" },
+        "insertionStart": { "$ref": "definitions.json#/entities/insertion" },
+        "insertionEnd": { "$ref": "definitions.json#/entities/insertion" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type", "blade"],
+      "oneOf": [
+        { "required": ["insertion"] },
+        { "required": ["insertionStart"] }
+      ],
+      "dependencies": {
+        "insertionStart": ["insertionEnd"],
+        "insertionEnd": ["insertionStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "BladeRotation" },
+        "blade": {
+          "oneOf": [
+            { "enum": ["Top", "Right", "Bottom", "Left"] },
+            { "$ref": "definitions.json#/units/positiveInteger" }
+          ]
+        },
+        "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type", "blade"],
+      "oneOf": [
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "dependencies": {
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "BladeSystemRotation" },
+        "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "dependencies": {
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Fog" },
+        "fogType": { "enum": ["Fog", "Haze"] },
+        "fogOutput": { "$ref": "definitions.json#/entities/fogOutput" },
+        "fogOutputStart": { "$ref": "definitions.json#/entities/fogOutput" },
+        "fogOutputEnd": { "$ref": "definitions.json#/entities/fogOutput" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "not": { "required": ["fogOutput", "fogOutputStart"] },
+      "dependencies": {
+        "fogOutputStart": ["fogOutputEnd"],
+        "fogOutputEnd": ["fogOutputStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "FogOutput" },
+        "fogOutput": { "$ref": "definitions.json#/entities/fogOutput" },
+        "fogOutputStart": { "$ref": "definitions.json#/entities/fogOutput" },
+        "fogOutputEnd": { "$ref": "definitions.json#/entities/fogOutput" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["fogOutput"] },
+        { "required": ["fogOutputStart"] }
+      ],
+      "dependencies": {
+        "fogOutputStart": ["fogOutputEnd"],
+        "fogOutputEnd": ["fogOutputStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "FogType" },
+        "fogType": { "enum": ["Fog", "Haze"] },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type", "fogType"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Rotation" },
+        "speed": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedStart": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/rotationSpeed" },
+        "angle": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleStart": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "angleEnd": { "$ref": "definitions.json#/entities/rotationAngle" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] },
+        { "required": ["angle"] },
+        { "required": ["angleStart"] }
+      ],
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"],
+        "angleStart": ["angleEnd"],
+        "angleEnd": ["angleStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Speed" },
+        "speed": { "$ref": "definitions.json#/entities/speed" },
+        "speedStart": { "$ref": "definitions.json#/entities/speed" },
+        "speedEnd": { "$ref": "definitions.json#/entities/speed" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["speed"] },
+        { "required": ["speedStart"] }
+      ],
+      "dependencies": {
+        "speedStart": ["speedEnd"],
+        "speedEnd": ["speedStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Time" },
+        "time": { "$ref": "definitions.json#/entities/time" },
+        "timeStart": { "$ref": "definitions.json#/entities/time" },
+        "timeEnd": { "$ref": "definitions.json#/entities/time" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "oneOf": [
+        { "required": ["time"] },
+        { "required": ["timeStart"] }
+      ],
+      "dependencies": {
+        "timeStart": ["timeEnd"],
+        "timeEnd": ["timeStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Maintenance" },
+        "parameter": { "$ref": "definitions.json#/entities/parameter" },
+        "parameterStart": { "$ref": "definitions.json#/entities/parameter" },
+        "parameterEnd": { "$ref": "definitions.json#/entities/parameter" },
+        "hold": { "$ref": "definitions.json#/entities/time" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "not": { "required": ["parameter", "parameterStart"] },
+      "dependencies": {
+        "parameterStart": ["parameterEnd"],
+        "parameterEnd": ["parameterStart"]
+      },
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "dmxRange": { "$ref": "#/definitions/dmxRange" },
+        "type": { "const": "Generic" },
+        "comment": { "$ref": "definitions.json#/nonEmptyString" },
+        "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
+        "menuClick": { "$ref": "#/definitions/menuClick" },
+        "switchChannels": { "$ref": "#/definitions/switchChannels" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
     }
   ]
 }

--- a/schemas/capability.json
+++ b/schemas/capability.json
@@ -4,14 +4,44 @@
 
   "$comment": "This file is used by another schema file and should not be used directly as a JSON schema.",
 
-  "type": "object",
-  "properties": {
+  "definitions": {
     "dmxRange": {
       "type": "array",
       "minItems": 2,
       "maxItems": 2,
       "items": { "$ref": "definitions.json#/units/dmxValue" }
     },
+    "menuClick": {
+      "enum": ["start", "center", "end", "hidden"]
+    },
+    "switchChannels": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": {
+        "$comment": "switching channel alias keys",
+        "oneOf": [
+          { "$ref": "definitions.json#/noVariablesString" },
+          { "$ref": "definitions.json#/variablePixelKeyString" }
+        ]
+      },
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "$comment": "channel key or channel alias key",
+            "$ref": "definitions.json#/noVariablesString"
+          },
+          {
+            "$comment": "template channel key or template channel alias key",
+            "$ref": "definitions.json#/variablePixelKeyString"
+          }
+        ]
+      }
+    }
+  },
+
+  "type": "object",
+  "properties": {
+    "dmxRange": { "$ref": "#/definitions/dmxRange" },
     "type": { "enum": [
       "NoFunction",
       "ShutterStrobe",
@@ -59,30 +89,8 @@
     ] },
     "comment": { "$ref": "definitions.json#/nonEmptyString" },
     "helpWanted": { "$ref": "definitions.json#/nonEmptyString" },
-    "menuClick": { "enum": ["start", "center", "end", "hidden"] },
-    "switchChannels": {
-      "type": "object",
-      "minProperties": 1,
-      "propertyNames": {
-        "$comment": "switching channel alias keys",
-        "oneOf": [
-          { "$ref": "definitions.json#/noVariablesString" },
-          { "$ref": "definitions.json#/variablePixelKeyString" }
-        ]
-      },
-      "additionalProperties": {
-        "oneOf": [
-          {
-            "$comment": "channel key or channel alias key",
-            "$ref": "definitions.json#/noVariablesString"
-          },
-          {
-            "$comment": "template channel key or template channel alias key",
-            "$ref": "definitions.json#/variablePixelKeyString"
-          }
-        ]
-      }
-    }
+    "menuClick": { "$ref": "#/definitions/menuClick" },
+    "switchChannels": { "$ref": "#/definitions/switchChannels" }
   },
   "required": ["type"],
   "allOf": [

--- a/schemas/channel.json
+++ b/schemas/channel.json
@@ -58,14 +58,8 @@
     "dmxValueResolution": ["fineChannelAliases"]
   },
   "oneOf": [
-    {
-      "required": ["capability"],
-      "not": { "required": ["capabilities"] }
-    },
-    {
-      "not": { "required": ["capability"] },
-      "required": ["capabilities"]
-    }
+    { "required": ["capability"] },
+    { "required": ["capabilities"] }
   ],
   "allOf": [
     {

--- a/schemas/channel.json
+++ b/schemas/channel.json
@@ -7,7 +7,7 @@
   "type": "object",
   "properties": {
     "name": {
-      "$comment": "if not set: use channel key",
+      "description": "if not set: use channel key",
       "$ref": "definitions.json#/nonEmptyString"
     },
     "fineChannelAliases": {

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -65,10 +65,7 @@
   },
   "goboResourceString": {
     "type": "string",
-    "oneOf": [
-      { "pattern": "^gobos/[a-z0-9-]+$" },
-      { "pattern": "^gobos/aliases/[a-z0-9_.-]+/" }
-    ]
+    "pattern": "^gobos/[a-z0-9-]+$|^gobos/aliases/[a-z0-9_.-]+/"
   },
 
   "units": {

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -48,7 +48,7 @@
     "format": "color-hex"
   },
   "dimensionsXYZ": {
-    "$comment": "width, height, depth (in mm)",
+    "description": "width, height, depth (in mm)",
     "type": "array",
     "minItems": 3,
     "maxItems": 3,

--- a/schemas/fixture-redirect.json
+++ b/schemas/fixture-redirect.json
@@ -10,7 +10,7 @@
       "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture-redirect.json"
     },
     "name": {
-      "$comment": "unique in manufacturer",
+      "description": "unique in manufacturer",
       "$ref": "definitions.json#/nonEmptyString"
     },
     "redirectTo": {

--- a/schemas/fixture-redirect.json
+++ b/schemas/fixture-redirect.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture-redirect.json",
 
-  "version": "12.2.1",
+  "version": "12.2.2",
 
   "type": "object",
   "properties": {

--- a/schemas/fixture-redirect.json
+++ b/schemas/fixture-redirect.json
@@ -24,5 +24,6 @@
       ]
     }
   },
+  "required": ["$schema", "name", "redirectTo", "reason"],
   "additionalProperties": false
 }

--- a/schemas/fixture-redirect.json
+++ b/schemas/fixture-redirect.json
@@ -6,6 +6,9 @@
 
   "type": "object",
   "properties": {
+    "$schema": {
+      "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture-redirect.json"
+    },
     "name": {
       "$comment": "unique in manufacturer",
       "$ref": "definitions.json#/nonEmptyString"
@@ -19,11 +22,6 @@
         "FixtureRenamed",
         "SameAsDifferentBrand"
       ]
-    }
-  },
-  "patternProperties": {
-    "^\\$schema$": {
-      "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture-redirect.json"
     }
   },
   "additionalProperties": false

--- a/schemas/fixture.json
+++ b/schemas/fixture.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
 
-  "version": "12.2.1",
+  "version": "12.2.2",
 
   "type": "object",
   "properties": {

--- a/schemas/fixture.json
+++ b/schemas/fixture.json
@@ -176,7 +176,8 @@
           "properties": {
             "dimensions": { "$ref": "definitions.json#/dimensionsXYZ" },
             "spacing": { "$ref": "definitions.json#/dimensionsXYZ" }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/schemas/fixture.json
+++ b/schemas/fixture.json
@@ -10,16 +10,16 @@
       "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json"
     },
     "name": {
-      "$comment": "unique in manufacturer",
+      "description": "unique in manufacturer",
       "$ref": "definitions.json#/nonEmptyString"
     },
     "shortName": {
-      "$comment": "unique globally; if not set: use name",
+      "description": "unique globally; if not set: use name",
       "$ref": "definitions.json#/nonEmptyString"
     },
     "categories": {
       "type": "array",
-      "$comment": "most important category first",
+      "description": "most important category first",
       "minItems": 1,
       "uniqueItems": true,
       "items": {
@@ -108,12 +108,12 @@
           "$ref": "definitions.json#/dimensionsXYZ"
         },
         "weight": {
-          "$comment": "in kg",
+          "description": "in kg",
           "type": "number",
           "exclusiveMinimum": 0
         },
         "power": {
-          "$comment": "in W",
+          "description": "in W",
           "type": "number",
           "exclusiveMinimum": 0
         },
@@ -134,11 +134,11 @@
           "minProperties": 1,
           "properties": {
             "type": {
-              "$comment": "e.g. 'LED'",
+              "description": "e.g. 'LED'",
               "$ref": "definitions.json#/nonEmptyString"
             },
             "colorTemperature": {
-              "$comment": "in K",
+              "description": "in K",
               "type": "number",
               "exclusiveMinimum": 0
             },
@@ -154,7 +154,7 @@
           "minProperties": 1,
           "properties": {
             "name": {
-              "$comment": "e.g. 'PC', 'Fresnel'",
+              "description": "e.g. 'PC', 'Fresnel'",
               "$ref": "definitions.json#/nonEmptyString"
             },
             "degreesMinMax": {

--- a/schemas/fixture.json
+++ b/schemas/fixture.json
@@ -6,6 +6,9 @@
 
   "type": "object",
   "properties": {
+    "$schema": {
+      "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json"
+    },
     "name": {
       "$comment": "unique in manufacturer",
       "$ref": "definitions.json#/nonEmptyString"
@@ -325,10 +328,5 @@
       ]
     }
   ],
-  "patternProperties": {
-    "^\\$schema$": {
-      "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json"
-    }
-  },
   "additionalProperties": false
 }

--- a/schemas/gobo.json
+++ b/schemas/gobo.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/gobo.json",
 
-  "version": "12.2.1",
+  "version": "12.2.2",
 
   "type": "object",
   "properties": {

--- a/schemas/manufacturers.json
+++ b/schemas/manufacturers.json
@@ -5,6 +5,12 @@
   "version": "12.2.1",
 
   "type": "object",
+  "properties": {
+    "$schema": {
+      "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/manufacturers.json"
+    }
+  },
+  "required": ["$schema"],
   "propertyNames": {
     "$comment": "manufacturer key",
     "type": "string",
@@ -24,11 +30,5 @@
     },
     "required": ["name"],
     "additionalProperties": false
-  },
-  "required": ["$schema"],
-  "patternProperties": {
-    "^\\$schema$": {
-      "const": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/manufacturers.json"
-    }
   }
 }

--- a/schemas/manufacturers.json
+++ b/schemas/manufacturers.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/manufacturers.json",
 
-  "version": "12.2.1",
+  "version": "12.2.2",
 
   "type": "object",
   "properties": {

--- a/schemas/matrix.json
+++ b/schemas/matrix.json
@@ -12,26 +12,30 @@
       "items": { "$ref": "#/definitions/pixelNumberConstraint" }
     },
     "pixelNumberConstraint": {
-      "type": "string",
       "oneOf": [
         {
           "$comment": "exact position",
+          "type": "string",
           "pattern": "^=[1-9][0-9]*$"
         },
         {
           "$comment": "minimum position",
+          "type": "string",
           "pattern": "^>=[1-9][0-9]*$"
         },
         {
           "$comment": "maximum position",
+          "type": "string",
           "pattern": "^<=[1-9][0-9]*$"
         },
         {
           "$comment": "position divisible by number",
+          "type": "string",
           "pattern": "^[1-9][0-9]*n$"
         },
         {
           "$comment": "position divisible by number with remainder",
+          "type": "string",
           "pattern": "^[1-9][0-9]*n\\+[1-9][0-9]*$"
         },
         {

--- a/schemas/matrix.json
+++ b/schemas/matrix.json
@@ -51,7 +51,7 @@
   "type": "object",
   "properties": {
     "pixelCount": {
-      "$comment": "amount of pixels in X, Y and Z directions",
+      "description": "amount of pixels in X, Y and Z directions",
       "type": "array",
       "minItems": 3,
       "maxItems": 3,
@@ -61,7 +61,7 @@
       }
     },
     "pixelKeys": {
-      "$comment": "pixelKeys in a structure of arrays for the Z, Y and X directions",
+      "description": "pixelKeys in a structure of arrays for the Z, Y and X directions",
       "type": "array",
       "minItems": 1,
       "items": {

--- a/schemas/matrix.json
+++ b/schemas/matrix.json
@@ -115,7 +115,8 @@
                   "format": "regex"
                 }
               }
-            }
+            },
+            "additionalProperties": false
           }
         ]
       }

--- a/schemas/plugin.json
+++ b/schemas/plugin.json
@@ -28,6 +28,7 @@
 
   "type": "object",
   "properties": {
+    "$schema": { "const": "../../schemas/plugin.json" },
     "name": {
       "type": "string"
     },
@@ -66,11 +67,6 @@
     "additionalInfo": { "$ref": "#/definitions/htmlStringLines" },
     "helpWanted": { "type": "string" }
   },
-  "required": ["name", "description", "links"],
-  "patternProperties": {
-    "^\\$schema$": {
-      "const": "../../schemas/plugin.json"
-    }
-  },
+  "required": ["$schema", "name", "description", "links"],
   "additionalProperties": false
 }

--- a/schemas/plugin.json
+++ b/schemas/plugin.json
@@ -43,12 +43,12 @@
     "links": {
       "type": "object",
       "minProperties": 1,
-      "properties": {
-        "Website": { "$ref": "#/definitions/urlString" },
-        "Fixture library download": { "$ref": "#/definitions/urlString" },
-        "Fixture format documentation": { "$ref": "#/definitions/urlString" }
-      },
-      "additionalProperties": { "$ref": "#/definitions/urlString" }
+      "additionalProperties": { "$ref": "#/definitions/urlString" },
+      "default": {
+        "Website": "",
+        "Fixture library download": "",
+        "Fixture format documentation": ""
+      }
     },
     "fixtureUsage": { "$ref": "#/definitions/htmlStringLines" },
     "fileLocations": {
@@ -57,12 +57,14 @@
       "properties": {
         "subDirectoriesAllowed": {
           "type": "boolean"
-        },
-        "Windows": { "$ref": "#/definitions/fileLocations" },
-        "Mac OS": { "$ref": "#/definitions/fileLocations" },
-        "Linux": { "$ref": "#/definitions/fileLocations" }
+        }
       },
-      "additionalProperties": { "$ref": "#/definitions/fileLocations" }
+      "additionalProperties": { "$ref": "#/definitions/fileLocations" },
+      "default": {
+        "Windows": "",
+        "Mac OS": "",
+        "Linux": ""
+      }
     },
     "additionalInfo": { "$ref": "#/definitions/htmlStringLines" },
     "helpWanted": { "type": "string" }

--- a/schemas/wheel-slot.json
+++ b/schemas/wheel-slot.json
@@ -5,156 +5,87 @@
   "$comment": "This file is used by another schema file and should not be used directly as a JSON schema.",
 
   "type": "object",
-  "properties": {
-    "type": {
-      "enum": [
-        "Open",
-        "Closed",
-        "Color",
-        "Gobo",
-        "Prism",
-        "Iris",
-        "Frost",
-        "AnimationGoboStart",
-        "AnimationGoboEnd"
-      ]
+  "discriminator": { "propertyName": "type" },
+  "oneOf": [
+    {
+      "properties": {
+        "type": { "const": "Open" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "type": { "const": "Closed" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "type": { "const": "Color" },
+        "name": { "$ref": "definitions.json#/nonEmptyString" },
+        "colors": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "definitions.json#/colorString" }
+        },
+        "colorTemperature": { "$ref": "definitions.json#/entities/colorTemperature" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "type": { "const": "Gobo" },
+        "resource": { "$ref": "definitions.json#/goboResourceString" },
+        "name": { "$ref": "definitions.json#/nonEmptyString" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "type": { "const": "Prism" },
+        "name": { "$ref": "definitions.json#/nonEmptyString" },
+        "facets": {
+          "type": "integer",
+          "minimum": 2
+        }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "type": { "const": "Iris" },
+        "openPercent": { "$ref": "definitions.json#/entities/irisPercent" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "type": { "const": "Frost" },
+        "frostIntensity": { "$ref": "definitions.json#/entities/percent" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "type": { "const": "AnimationGoboStart" },
+        "name": { "$ref": "definitions.json#/nonEmptyString" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
+    },
+    {
+      "properties": {
+        "type": { "const": "AnimationGoboEnd" }
+      },
+      "required": ["type"],
+      "additionalProperties": false
     }
-  },
-  "allOf": [
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Open" }
-        }
-      },
-      "then": {
-        "properties": {
-          "type": {}
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Closed" }
-        }
-      },
-      "then": {
-        "properties": {
-          "type": {}
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Color" }
-        }
-      },
-      "then": {
-        "properties": {
-          "type": {},
-          "name": { "$ref": "definitions.json#/nonEmptyString" },
-          "colors": {
-            "type": "array",
-            "minItems": 1,
-            "items": { "$ref": "definitions.json#/colorString" }
-          },
-          "colorTemperature": { "$ref": "definitions.json#/entities/colorTemperature" }
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Gobo" }
-        }
-      },
-      "then": {
-        "properties": {
-          "type": {},
-          "resource": { "$ref": "definitions.json#/goboResourceString" },
-          "name": { "$ref": "definitions.json#/nonEmptyString" }
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Prism" }
-        }
-      },
-      "then": {
-        "properties": {
-          "type": {},
-          "name": { "$ref": "definitions.json#/nonEmptyString" },
-          "facets": {
-            "type": "integer",
-            "minimum": 2
-          }
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Iris" }
-        }
-      },
-      "then": {
-        "properties": {
-          "type": {},
-          "openPercent": { "$ref": "definitions.json#/entities/irisPercent" }
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "Frost" }
-        }
-      },
-      "then": {
-        "properties": {
-          "type": {},
-          "frostIntensity": { "$ref": "definitions.json#/entities/percent" }
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "AnimationGoboStart" }
-        }
-      },
-      "then": {
-        "properties": {
-          "type": {},
-          "name": { "$ref": "definitions.json#/nonEmptyString" }
-        },
-        "additionalProperties": false
-      }
-    },
-    {
-      "if": {
-        "properties": {
-          "type": { "const": "AnimationGoboEnd" }
-        }
-      },
-      "then": {
-        "properties": {
-          "type": {}
-        },
-        "additionalProperties": false
-      }
-    }
-  ],
-  "required": ["type"]
+  ]
 }

--- a/ui/components/editor/EditorCapability.vue
+++ b/ui/components/editor/EditorCapability.vue
@@ -19,7 +19,7 @@
           v-model="capability.dmxRange"
           :formstate="formstate"
           :name="`capability${capability.uuid}-dmxRange`"
-          :schema-property="capabilityProperties.dmxRange"
+          :schema-property="capabilityDmxRange"
           :range-min="min"
           :range-max="max"
           :start-hint="capabilities.length === 1 ? `${min}` : `start`"
@@ -94,7 +94,7 @@ a.remove {
 </style>
 
 <script>
-import { capabilityProperties } from '../../../lib/schema-properties.js';
+import { capabilityDmxRange } from '../../../lib/schema-properties.js';
 import { getEmptyCapability, isCapabilityChanged } from '../../assets/scripts/editor-utils.js';
 
 import ConditionalDetails from '../ConditionalDetails.vue';
@@ -130,7 +130,7 @@ export default {
   data() {
     return {
       dmxMin: 0,
-      capabilityProperties,
+      capabilityDmxRange,
     };
   },
   computed: {

--- a/ui/components/editor/EditorCapabilityTypeData.vue
+++ b/ui/components/editor/EditorCapabilityTypeData.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import { capabilityProperties } from '../../../lib/schema-properties.js';
+import { capabilityTypes } from '../../../lib/schema-properties.js';
 
 import LabeledInput from '../LabeledInput.vue';
 
@@ -152,7 +152,7 @@ export default {
   },
   data() {
     return {
-      capabilityTypes: capabilityProperties.type.enum,
+      capabilityTypes: Object.keys(capabilityTypes),
       capabilityTypeHint: null,
     };
   },

--- a/ui/components/editor/EditorWheelSlot.vue
+++ b/ui/components/editor/EditorWheelSlot.vue
@@ -45,7 +45,7 @@
 </style>
 
 <script>
-import { wheelSlotProperties } from '../../../lib/schema-properties.js';
+import { wheelSlotTypes } from '../../../lib/schema-properties.js';
 import { getEmptyWheelSlot } from '../../assets/scripts/editor-utils.js';
 
 import ConditionalDetails from '../ConditionalDetails.vue';
@@ -99,7 +99,7 @@ export default {
   },
   data() {
     return {
-      slotTypes: wheelSlotProperties.type.enum,
+      slotTypes: Object.keys(wheelSlotTypes),
       open: false,
     };
   },


### PR DESCRIPTION
* Define `$schema` property in regular [`properties`](https://ajv.js.org/json-schema.html#properties) rather than in `patternProperties`
* Simplify plugin schema with [`default`](https://ajv.js.org/guide/modifying-data.html#assigning-defaults) instead of an enum + allowed free text
* Simplify wheel-slot and capability schemas with [`discriminator`](https://ajv.js.org/json-schema.html#discriminator) and `oneOf`
* Fix required and additional properties
* Define `type` and `pattern` in the same object
* Simplify `oneOf`
* Replace some `$comment`s with `description`s → will be shown in VS Code
