### PR TITLE
Add fixture 'misseey/par-light'

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -325,6 +325,9 @@
     "name": "Minuit Une",
     "website": "https://minuitune.com/"
   },
+  "misseey": {
+    "name": "Misseey"
+  },
   "nicols": {
     "name": "Nicols",
     "website": "http://www.nicols.site-expelec.fr/"

--- a/fixtures/misseey/par-light.json
+++ b/fixtures/misseey/par-light.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Par Light",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Wyatt L Vaughan"],
+    "createDate": "2021-07-08",
+    "lastModifyDate": "2021-07-08"
+  },
+  "links": {
+    "manual": [
+      "https://www.missyee.com/collections/lamp-series"
+    ],
+    "productPage": [
+      "https://www.missyee.com/collections/lamp-series"
+    ],
+    "video": [
+      "https://www.missyee.com/collections/lamp-series"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Strobe Speed": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speed": "0Hz"
+      }
+    },
+    "Color Presets": {
+      "capability": {
+        "type": "WheelRotation",
+        "speed": "1Hz"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Normal",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "Strobe Speed",
+        "Color Presets"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'misseey/par-light'

### Fixture warnings / errors

* misseey/par-light
  - :x: Capability 'Wheel rotation 1Hz' (0…255) in channel 'Color Presets' does not explicitly reference any wheel, but the default wheel 'Color Presets' (through the channel name) does not exist.


Thank you **Wyatt L Vaughan**!