### PR TITLE
Add fixture 'chauvet-dj/slimpar-t12-usb'

### DIFF
--- a/fixtures/chauvet-dj/slimpar-t12-usb.json
+++ b/fixtures/chauvet-dj/slimpar-t12-usb.json
@@ -87,7 +87,7 @@
         "speedEnd": "fast"
       }
     },
-    "Sensitivity": {
+    "Sound Sensitivity": {
       "capabilities": [
         {
           "dmxRange": [0, 10],
@@ -95,7 +95,7 @@
           "soundSensitivity": "off"
         },
         {
-          "dmxRange": [16, 255],
+          "dmxRange": [11, 255],
           "type": "SoundSensitivity",
           "soundSensitivityStart": "low",
           "soundSensitivityEnd": "high"


### PR DESCRIPTION
* Add fixture 'chauvet-dj/slimpar-t12-usb'

### Fixture warnings / errors

* chauvet-dj/slimpar-t12-usb
  - :warning: Mode '3-Channel' should have shortName '3ch' instead of '3-CH'.
  - :warning: Mode '3-Channel' should have shortName '3ch' instead of '3-CH'.
  - :warning: Mode '8-Channel' should have shortName '8ch' instead of '8-CH'.
  - :warning: Mode '8-Channel' should have shortName '8ch' instead of '8-CH'.


Thank you **Anonymous**!