### PR TITLE
Add fixture 'alladin-light/alladin-5ch'

### DIFF
--- a/fixtures/alladin-light/alladin-5ch.json
+++ b/fixtures/alladin-light/alladin-5ch.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Alladin 5ch",
+  "categories": ["Matrix"],
+  "meta": {
+    "authors": ["AleBi"],
+    "createDate": "2021-09-22",
+    "lastModifyDate": "2021-09-22"
+  },
+  "links": {
+    "productPage": [
+      "https://aladdin-lights.com/"
+    ]
+  },
+  "availableChannels": {
+    "Intensity": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Color Temperature": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "2900K",
+        "colorTemperatureEnd": "6100K"
+      }
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "5ch",
+      "channels": [
+        "Intensity",
+        "Color Temperature",
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -20,6 +20,11 @@
     "name": "AFX",
     "website": "https://www.afx-light.com"
   },
+  "alladin-light": {
+    "name": "Alladin-Light",
+    "website": "https://aladdin-lights.com/",
+    "rdmId": 0
+  },
   "american-dj": {
     "name": "American DJ",
     "website": "https://www.adj.com/"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'alladin-light/alladin-5ch'

### Fixture warnings / errors

* alladin-light/alladin-5ch
  - :x: Category 'Matrix' invalid since fixture does not define a matrix.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **AleBi**!