### PR TITLE
Add fixture `laserworld/cs1000mk2ii`

### DIFF
--- a/fixtures/laserworld/cs1000mk2ii.json
+++ b/fixtures/laserworld/cs1000mk2ii.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "CS1000Mk2ii",
+  "categories": ["Laser"],
+  "meta": {
+    "authors": ["cri.00"],
+    "createDate": "2021-10-16",
+    "lastModifyDate": "2021-10-16"
+  },
+  "links": {
+    "other": [
+      "http://images.getinthemix.com/resources/1462783952_0321.pdf"
+    ]
+  },
+  "availableChannels": {
+    "Mode Selection": {
+      "defaultValue": 255,
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Pattern Selection": {
+      "defaultValue": 255,
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Circular Movement": {
+      "defaultValue": 255,
+      "capability": {
+        "type": "WheelSlotRotation",
+        "speed": "100rpm"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "CS.FXR",
+      "channels": [
+        "Mode Selection",
+        "Pattern Selection",
+        "Circular Movement"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'laserworld/cs1000mk2ii'

### Fixture warnings / errors

* laserworld/cs1000mk2ii
  - :x: Capability 'Wheel slot rotation 100rpm' (0…255) in channel 'Circular Movement' does not explicitly reference any wheel, but the default wheel 'Circular Movement' (through the channel name) does not exist.


Thank you **cri.00**!