### PR TITLE
Fix undefined property in Vue template

### DIFF
--- a/ui/components/editor/capabilities/IrisEffect.vue
+++ b/ui/components/editor/capabilities/IrisEffect.vue
@@ -9,7 +9,7 @@
         v-model="capability.typeData.effectName"
         :formstate="formstate"
         :name="`capability${capability.uuid}-effectName`"
-        :schema-property="properties.definitions.nonEmptyString"
+        :schema-property="schemaDefinitions.nonEmptyString"
         :required="true" />
     </LabeledInput>
 


### PR DESCRIPTION
This was caught by `eslint-plugin-vue`'s new `no-undef-properties` rule in #2209. Since that can't be merged as-is, this fix is extracted into a separate PR.

The issue was introduced in [`5750a99` (#1947)](https://github.com/OpenLightingProject/open-fixture-library/pull/1947/commits/5750a99c0798008d4065771ad8f2f42062e45443#diff-6bbb6853e16676962939b001af2939019d650ef59fdb9f574af5c05a60d0769c).