### PR TITLE
Add fixture `tomshine/mini-gobo-moving-head`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -476,6 +476,9 @@
     "website": "https://tmb.com/",
     "rdmId": 6906
   },
+  "tomshine": {
+    "name": "Tomshine"
+  },
   "uking": {
     "name": "U`King",
     "website": "https://www.uking-online.com/"

--- a/fixtures/tomshine/mini-gobo-moving-head.json
+++ b/fixtures/tomshine/mini-gobo-moving-head.json
@@ -1,0 +1,530 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Mini Gobo Moving Head",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Gaudig", "Francisco Gil Pastor"],
+    "createDate": "2021-10-28",
+    "lastModifyDate": "2021-10-28",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2021-10-28",
+      "comment": "created by Q Light Controller Plus (version 4.12.3 GIT)"
+    }
+  },
+  "physical": {
+    "dimensions": [210, 270, 210],
+    "weight": 3.62,
+    "power": 80,
+    "DMXconnector": "5-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "wheels": {
+    "Color wheel": {
+      "slots": [
+        {
+          "type": "Color",
+          "name": "White",
+          "colors": ["#ffffff"]
+        },
+        {
+          "type": "Color",
+          "name": "Red",
+          "colors": ["#ff0000"]
+        },
+        {
+          "type": "Color",
+          "name": "Green",
+          "colors": ["#00ff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Blue",
+          "colors": ["#0000ff"]
+        },
+        {
+          "type": "Color",
+          "name": "Yellow",
+          "colors": ["#ffff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Orange",
+          "colors": ["#ffaa00"]
+        },
+        {
+          "type": "Color",
+          "name": "Light Blue",
+          "colors": ["#00aaff"]
+        },
+        {
+          "type": "Color",
+          "name": "Cyan",
+          "colors": ["#00ffff"]
+        },
+        {
+          "type": "Color",
+          "name": "White/Red",
+          "colors": ["#ffffff", "#ff0000"]
+        },
+        {
+          "type": "Color",
+          "name": "Red/Green",
+          "colors": ["#ff0000", "#00ff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Green/Blue",
+          "colors": ["#00ff00", "#0000ff"]
+        },
+        {
+          "type": "Color",
+          "name": "Blue/Yellow",
+          "colors": ["#0000ff", "#ffff00"]
+        },
+        {
+          "type": "Color",
+          "name": "Yellow/Orange",
+          "colors": ["#ffff00", "#ffaa00"]
+        },
+        {
+          "type": "Color",
+          "name": "Orange/LightBlue",
+          "colors": ["#ffaa00", "#00aaff"]
+        },
+        {
+          "type": "Color",
+          "name": "LightBlue/Cyan",
+          "colors": ["#00aaff", "#00ffff"]
+        },
+        {
+          "type": "Color",
+          "name": "Cyan/White",
+          "colors": ["#00ffff", "#ffffff"]
+        },
+        {
+          "type": "Color",
+          "name": "Color Change FWD"
+        },
+        {
+          "type": "Color",
+          "name": "Color Change REV"
+        }
+      ]
+    },
+    "Gobo wheel": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo",
+          "resource": "gobos/aliases/qlcplus/Others/gobo00091.svg",
+          "name": "Double Lines Star"
+        },
+        {
+          "type": "Gobo",
+          "resource": "gobos/aliases/qlcplus/Others/gobo00025.svg",
+          "name": "Square Arrows"
+        },
+        {
+          "type": "Gobo",
+          "resource": "gobos/aliases/qlcplus/Chauvet/gobo00045.svg",
+          "name": "Fan"
+        },
+        {
+          "type": "Gobo",
+          "resource": "gobos/aliases/qlcplus/Others/gobo00042.svg",
+          "name": "Star"
+        },
+        {
+          "type": "Gobo",
+          "resource": "gobos/aliases/qlcplus/Others/gobo00028.svg",
+          "name": "Stones"
+        },
+        {
+          "type": "Gobo",
+          "resource": "gobos/aliases/qlcplus/SGM/gobo00136.svg",
+          "name": "Eliptic"
+        },
+        {
+          "type": "Gobo",
+          "resource": "gobos/aliases/qlcplus/SGM/gobo00361.svg",
+          "name": "Caro Flower"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo Switch FWD"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo Switch REV"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "defaultValue": 0,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "defaultValue": 0,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "230deg"
+      }
+    },
+    "Pan/Tilt speed": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open",
+          "comment": "No function"
+        },
+        {
+          "dmxRange": [8, 99],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Slow to fast"
+        },
+        {
+          "dmxRange": [100, 149],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "fast",
+          "speedEnd": "slow",
+          "comment": "Fast to slow"
+        },
+        {
+          "dmxRange": [150, 199],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "Strobe Effect 1",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        },
+        {
+          "dmxRange": [200, 245],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "Strobe Effect 2",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        },
+        {
+          "dmxRange": [246, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "Fastest Strobe Effect",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        }
+      ]
+    },
+    "Color wheel": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "White"
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Blue"
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "Yellow"
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "Light Blue"
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 8,
+          "comment": "Cyan"
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "WheelSlot",
+          "slotNumber": 9,
+          "comment": "White/Red"
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "WheelSlot",
+          "slotNumber": 10,
+          "comment": "Red/Green"
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "WheelSlot",
+          "slotNumber": 11,
+          "comment": "Green/Blue"
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "WheelSlot",
+          "slotNumber": 12,
+          "comment": "Blue/Yellow"
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "WheelSlot",
+          "slotNumber": 13,
+          "comment": "Yellow/Orange"
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "WheelSlot",
+          "slotNumber": 14,
+          "comment": "Orange/LightBlue"
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "WheelSlot",
+          "slotNumber": 15,
+          "comment": "LightBlue/Cyan"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelSlot",
+          "slotNumber": 16,
+          "comment": "Cyan/White"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "WheelSlot",
+          "slotNumber": 17,
+          "comment": "Color Change FWD"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "WheelSlot",
+          "slotNumber": 18,
+          "comment": "Color Change REV"
+        }
+      ]
+    },
+    "Gobo wheel": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Double Lines Star"
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Square Arrows"
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Fan"
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "Star"
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "Stones"
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "Eliptic"
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 8,
+          "comment": "Caro Flower"
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "WheelShake",
+          "slotNumber": 9,
+          "comment": "Open Shake"
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "WheelShake",
+          "slotNumber": 10,
+          "comment": "Double Lines Star Shake"
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "WheelShake",
+          "slotNumber": 11,
+          "comment": "Square Arrows Shake"
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "WheelShake",
+          "slotNumber": 12,
+          "comment": "Fan Shake"
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "WheelShake",
+          "slotNumber": 13,
+          "comment": "Star Shake"
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "WheelShake",
+          "slotNumber": 14,
+          "comment": "Stones Shake"
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "WheelShake",
+          "slotNumber": 15,
+          "comment": "Eliptic Shake"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelShake",
+          "slotNumber": 16,
+          "comment": "Caro Flower Shake"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "WheelSlot",
+          "slotNumber": 17,
+          "comment": "Gobo Switch FWD"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "WheelSlot",
+          "slotNumber": 18,
+          "comment": "Gobo Switch REV"
+        }
+      ]
+    },
+    "Sound Mode": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "Effect",
+          "effectName": "Manual"
+        },
+        {
+          "dmxRange": [128, 255],
+          "type": "Effect",
+          "effectName": "Auto Mode"
+        }
+      ]
+    },
+    "Reset": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 240],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [241, 255],
+          "type": "Generic",
+          "comment": "RESET",
+          "helpWanted": "Unknown QLC+ capability preset ResetAll, Res1=\"undefined\", Res2=\"undefined\"."
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "Normal",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Pan/Tilt speed",
+        "Dimmer",
+        "Strobe",
+        "Color wheel",
+        "Gobo wheel",
+        "Sound Mode",
+        "Reset"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'tomshine/mini-gobo-moving-head'

### Fixture warnings / errors

* tomshine/mini-gobo-moving-head
  - :x: Resource alias 'Others/gobo00091.svg' not defined in file 'resources/gobos/aliases/qlcplus.json'.
  - :x: Resource alias 'Others/gobo00025.svg' not defined in file 'resources/gobos/aliases/qlcplus.json'.
  - :x: Resource alias 'Chauvet/gobo00045.svg' not defined in file 'resources/gobos/aliases/qlcplus.json'.
  - :x: Resource alias 'Others/gobo00042.svg' not defined in file 'resources/gobos/aliases/qlcplus.json'.
  - :x: Resource alias 'Others/gobo00028.svg' not defined in file 'resources/gobos/aliases/qlcplus.json'.
  - :x: Resource alias 'SGM/gobo00136.svg' not defined in file 'resources/gobos/aliases/qlcplus.json'.
  - :x: Resource alias 'SGM/gobo00361.svg' not defined in file 'resources/gobos/aliases/qlcplus.json'.
  - :x: Capability 'Open shake (Square Arrows Shake)' (80…87) in channel 'Gobo wheel' references wheel slot 11 which is outside the allowed range 0…11 (exclusive).
  - :x: Capability 'Gobo Double Lines Star shake (Fan Shake)' (88…95) in channel 'Gobo wheel' references wheel slot 12 which is outside the allowed range 0…11 (exclusive).
  - :x: Capability 'Gobo Square Arrows shake (Star Shake)' (96…103) in channel 'Gobo wheel' references wheel slot 13 which is outside the allowed range 0…11 (exclusive).
  - :x: Capability 'Gobo Fan shake (Stones Shake)' (104…111) in channel 'Gobo wheel' references wheel slot 14 which is outside the allowed range 0…11 (exclusive).
  - :x: Capability 'Gobo Star shake (Eliptic Shake)' (112…119) in channel 'Gobo wheel' references wheel slot 15 which is outside the allowed range 0…11 (exclusive).
  - :x: Capability 'Gobo Stones shake (Caro Flower Shake)' (120…127) in channel 'Gobo wheel' references wheel slot 16 which is outside the allowed range 0…11 (exclusive).
  - :x: Capability 'Gobo Eliptic (Gobo Switch FWD)' (128…191) in channel 'Gobo wheel' references wheel slot 17 which is outside the allowed range 0…11 (exclusive).
  - :x: Capability 'Gobo Caro Flower (Gobo Switch REV)' (192…255) in channel 'Gobo wheel' references wheel slot 18 which is outside the allowed range 0…11 (exclusive).
  - :warning: Please check if manufacturer is correct and add manufacturer URL.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Gaudig** and **Francisco Gil Pastor**!