### PR TITLE
Add fixture 'alien/alien-s'

### DIFF
--- a/fixtures/alien/alien-s.json
+++ b/fixtures/alien/alien-s.json
@@ -1,0 +1,290 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Alien-S",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["yrd.art", "yrd214"],
+    "createDate": "2021-11-08",
+    "lastModifyDate": "2021-11-08",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2021-11-08",
+      "comment": "created by Q Light Controller Plus (version 4.12.4a)"
+    }
+  },
+  "physical": {
+    "dimensions": [1070, 65, 80],
+    "weight": 2.6,
+    "power": 30,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "matrixPixels": {
+      "spacing": [0, 0, 0]
+    }
+  },
+  "matrix": {
+    "pixelCount": [
+      1,
+      8,
+      1
+    ]
+  },
+  "availableChannels": {
+    "Red1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red4": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green4": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue4": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red5": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green5": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue5": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red6": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green6": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue6": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red7": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green7": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue7": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red8": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green8": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue8": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Flash": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Master Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "templateChannels": {},
+  "modes": [
+    {
+      "name": "3-channel",
+      "shortName": "3ch",
+      "channels": [
+        "Red1",
+        "Green1",
+        "Blue1"
+      ]
+    },
+    {
+      "name": "4-channel",
+      "shortName": "4ch",
+      "channels": [
+        "Red1",
+        "Green1",
+        "Blue1",
+        "Master Dimmer"
+      ]
+    },
+    {
+      "name": "14-channel",
+      "shortName": "14ch",
+      "channels": [
+        "Red1",
+        "Green1",
+        "Blue1",
+        "Red2",
+        "Green2",
+        "Blue2",
+        "Red3",
+        "Green3",
+        "Blue3",
+        "Red4",
+        "Green4",
+        "Blue4",
+        "Flash",
+        "Master Dimmer"
+      ]
+    },
+    {
+      "name": "26-channel",
+      "shortName": "26ch",
+      "channels": [
+        "Red1",
+        "Green1",
+        "Blue1",
+        "Red2",
+        "Green2",
+        "Blue2",
+        "Red3",
+        "Green3",
+        "Blue3",
+        "Red4",
+        "Green4",
+        "Blue4",
+        "Red5",
+        "Green5",
+        "Blue5",
+        "Red6",
+        "Green6",
+        "Blue6",
+        "Red7",
+        "Green7",
+        "Blue7",
+        "Red8",
+        "Green8",
+        "Blue8",
+        "Flash",
+        "Master Dimmer"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -20,6 +20,9 @@
     "name": "AFX",
     "website": "https://www.afx-light.com"
   },
+  "alien": {
+    "name": "Alien"
+  },
   "american-dj": {
     "name": "American DJ",
     "website": "https://www.adj.com/"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'alien/alien-s'

### Fixture warnings / errors

* alien/alien-s
  - :x: File does not match schema: fixture/templateChannels must NOT have fewer than 1 items
  - :warning: Please check if manufacturer is correct and add manufacturer URL.
  - :warning: Please add 14-channel mode's Head #1 to the fixture's matrix. The included channels were Red1, Green1, Blue1.
  - :warning: Please add 14-channel mode's Head #2 to the fixture's matrix. The included channels were Red2, Green2, Blue2.
  - :warning: Please add 14-channel mode's Head #3 to the fixture's matrix. The included channels were Red3, Green3, Blue3.
  - :warning: Please add 14-channel mode's Head #4 to the fixture's matrix. The included channels were Red4, Green4, Blue4.
  - :warning: Please add 26-channel mode's Head #1 to the fixture's matrix. The included channels were Red1, Green1, Blue1.
  - :warning: Please add 26-channel mode's Head #2 to the fixture's matrix. The included channels were Red2, Green2, Blue2.
  - :warning: Please add 26-channel mode's Head #3 to the fixture's matrix. The included channels were Red3, Green3, Blue3.
  - :warning: Please add 26-channel mode's Head #4 to the fixture's matrix. The included channels were Red4, Green4, Blue4.
  - :warning: Please add 26-channel mode's Head #5 to the fixture's matrix. The included channels were Red5, Green5, Blue5.
  - :warning: Please add 26-channel mode's Head #6 to the fixture's matrix. The included channels were Red6, Green6, Blue6.
  - :warning: Please add 26-channel mode's Head #7 to the fixture's matrix. The included channels were Red7, Green7, Blue7.
  - :warning: Please add 26-channel mode's Head #8 to the fixture's matrix. The included channels were Red8, Green8, Blue8.


### User comment

Alien-S

Thank you @yrd214!