### PR TITLE
Add fixture `chauvet-professional/ovation-e-910fc-ip`

### DIFF
--- a/fixtures/chauvet-professional/ovation-e-910fc-ip.json
+++ b/fixtures/chauvet-professional/ovation-e-910fc-ip.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Ovation E-910FC IP",
+  "shortName": "Ovation IP",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["DA"],
+    "createDate": "2021-11-12",
+    "lastModifyDate": "2021-11-12"
+  },
+  "links": {
+    "manual": [
+      "https://www.chauvetprofessional.com/wp-content/uploads/2015/01/Ovation_E-910FC_IP_UM_Rev7.pdf"
+    ],
+    "productPage": [
+      "https://www.chauvetprofessional.com/products/ovation-e-910fc-ip/"
+    ]
+  },
+  "physical": {
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "Lime": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Lime"
+      }
+    },
+    "Gobo Rotation": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "WheelSlotRotation",
+          "angleStart": "0deg",
+          "angleEnd": "0deg"
+        },
+        {
+          "dmxRange": [128, 190],
+          "type": "WheelSlotRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [191, 192],
+          "type": "WheelSlotRotation",
+          "speedStart": "stop",
+          "speedEnd": "stop"
+        },
+        {
+          "dmxRange": [193, 255],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "6 channel",
+      "shortName": "6CH",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Amber",
+        "Lime",
+        "Gobo Rotation"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'chauvet-professional/ovation-e-910fc-ip'

### Fixture warnings / errors

* chauvet-professional/ovation-e-910fc-ip
  - :x: Capability 'Wheel slot rotation 0°' (0…127) in channel 'Gobo Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation CW fast…slow' (128…190) in channel 'Gobo Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation stop' (191…192) in channel 'Gobo Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation CCW slow…fast' (193…255) in channel 'Gobo Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Rotation' (through the channel name) does not exist.
  - :warning: Mode '6 channel' should have shortName '6ch' instead of '6CH'.
  - :warning: Mode '6 channel' should have shortName '6ch' instead of '6CH'.


Thank you **DA**!