### PR TITLE
Add fixture 'archwork/arcpar7fc'

### DIFF
--- a/fixtures/archwork/arcpar7fc.json
+++ b/fixtures/archwork/arcpar7fc.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "ARCPAR7FC",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Jihem"],
+    "createDate": "2022-01-22",
+    "lastModifyDate": "2022-01-22"
+  },
+  "links": {
+    "manual": [
+      "https://support.musiclights.it/ajx.php?usst=1&docs=17052&ID_USER="
+    ],
+    "productPage": [
+      "https://www.musiclights.it/product/ARCPAR7FC"
+    ]
+  },
+  "physical": {
+    "dimensions": [192, 241, 221],
+    "weight": 4.9,
+    "power": 51,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [15, 15]
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "stop",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "4 channel",
+      "shortName": "4CH",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    },
+    {
+      "name": "6 Channel",
+      "shortName": "6CH",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -28,6 +28,10 @@
     "name": "Ape Labs",
     "website": "https://apelabs.com/"
   },
+  "archwork": {
+    "name": "ArchWork",
+    "website": "https://www.musiclights.it/ARCHWORK.html"
+  },
   "arri": {
     "name": "ARRI",
     "website": "https://www.arri.com/en",


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'archwork/arcpar7fc'

### Fixture warnings / errors

* archwork/arcpar7fc
  - :warning: Mode '4 channel' should have shortName '4ch' instead of '4CH'.
  - :warning: Mode '4 channel' should have shortName '4ch' instead of '4CH'.
  - :warning: Mode '6 Channel' should have shortName '6ch' instead of '6CH'.
  - :warning: Mode '6 Channel' should have shortName '6ch' instead of '6CH'.


Thank you @MrJihem!