### PR TITLE
Parse JSON encoded bodies in download endpoints

### DIFF
--- a/ui/api/download.js
+++ b/ui/api/download.js
@@ -63,6 +63,9 @@ async function downloadFixtures(response, pluginKey, fixtures, zipName, errorDes
 
 const router = express.Router();
 
+// support JSON encoded bodies
+router.use(express.json({ limit: `50mb` }));
+
 router.get(`/download.:format([a-z0-9_.-]+)`, async (request, response, next) => {
   const { format } = request.params;
 


### PR DESCRIPTION
Fixes #2449. See description of the bug there.