### PR TITLE
Add fixture 'starway/parkolor120hdv3'

### DIFF
--- a/fixtures/starway/parkolor120hdv3.json
+++ b/fixtures/starway/parkolor120hdv3.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Parkolor120HDV3",
+  "categories": ["Stand"],
+  "meta": {
+    "authors": ["Jules Huvig"],
+    "createDate": "2022-03-09",
+    "lastModifyDate": "2022-03-09"
+  },
+  "links": {
+    "productPage": [
+      "https://www.star-way.com/parkolor-120hd-3"
+    ]
+  },
+  "physical": {
+    "bulb": {
+      "type": "led"
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": 255,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Shutter / Strobe": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [6, 10],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [11, 90],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe"
+        },
+        {
+          "dmxRange": [91, 170],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true
+        },
+        {
+          "dmxRange": [171, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true,
+          "comment": "Synced"
+        }
+      ]
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "7channel",
+      "shortName": "7channel",
+      "channels": [
+        "Dimmer",
+        "Shutter / Strobe",
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'starway/parkolor120hdv3'

### Fixture warnings / errors

* starway/parkolor120hdv3
  - :x: Mode '7channel' should have 7 channels according to its name but actually has 5.
  - :x: Mode '7channel' should have 7 channels according to its shortName but actually has 5.
  - :warning: Mode '7channel' should have shortName '7ch' instead of '7channel'.
  - :warning: Mode '7channel' should have shortName '7ch' instead of '7channel'.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Jules Huvig**!