### PR TITLE
Add fixture 'american-dj/inno-spot-pro'

### DIFF
--- a/fixtures/american-dj/inno-spot-pro.json
+++ b/fixtures/american-dj/inno-spot-pro.json
@@ -299,23 +299,27 @@
         {
           "dmxRange": [0, 127],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
           "angleStart": "0deg",
           "angleEnd": "360deg"
         },
         {
           "dmxRange": [128, 189],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
           "speedStart": "fast CW",
           "speedEnd": "slow CW"
         },
         {
           "dmxRange": [190, 193],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
           "speed": "stop"
         },
         {
           "dmxRange": [194, 255],
           "type": "WheelSlotRotation",
+          "wheel": "Gobo Wheel",
           "speedStart": "slow CCW",
           "speedEnd": "fast CCW"
         }

--- a/fixtures/american-dj/inno-spot-pro.json
+++ b/fixtures/american-dj/inno-spot-pro.json
@@ -1,0 +1,509 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Inno Spot Pro",
+  "categories": ["Moving Head", "Color Changer"],
+  "meta": {
+    "authors": ["Ken Harris"],
+    "createDate": "2022-03-19",
+    "lastModifyDate": "2022-03-19"
+  },
+  "links": {
+    "manual": [
+      "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/6922/inno_spot_pro.pdf"
+    ],
+    "productPage": [
+      "https://www.adj.com/inno-spot-pro"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=qZIVSOfQyBE"
+    ]
+  },
+  "physical": {
+    "dimensions": [288, 425, 167],
+    "weight": 8.5,
+    "power": 140,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [12, 17]
+    }
+  },
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Color",
+          "name": "Red"
+        },
+        {
+          "type": "Color",
+          "name": "Orange"
+        },
+        {
+          "type": "Color",
+          "name": "Yellow"
+        },
+        {
+          "type": "Color",
+          "name": "Green"
+        },
+        {
+          "type": "Color",
+          "name": "Blue"
+        },
+        {
+          "type": "Color",
+          "name": "Purple"
+        },
+        {
+          "type": "Color",
+          "name": "Light Blue"
+        },
+        {
+          "type": "Color",
+          "name": "Pink"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "slots": [
+        {
+          "type": "Gobo",
+          "name": "Spot"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 1"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 2"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 3"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 4"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 5"
+        },
+        {
+          "type": "Gobo",
+          "name": "Gobo 6"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "240deg"
+      }
+    },
+    "Color Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [8, 14],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [15, 21],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [22, 28],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [29, 35],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [36, 42],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [43, 49],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [50, 56],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [57, 63],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [64, 127],
+          "type": "Effect",
+          "effectName": "Color Mixing"
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "WheelRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "WheelRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [10, 18],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [19, 27],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [28, 36],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [37, 45],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [46, 54],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [55, 63],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [64, 73],
+          "type": "WheelShake",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [74, 82],
+          "type": "WheelShake",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [83, 91],
+          "type": "WheelShake",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [92, 100],
+          "type": "WheelShake",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [101, 109],
+          "type": "WheelShake",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [110, 118],
+          "type": "WheelShake",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [119, 127],
+          "type": "WheelShake",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "Assuming this is CW, analogous to the color wheel (but speed is backward?)"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "WheelRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "WheelRotation",
+          "speedStart": "fast CCW",
+          "speedEnd": "slow CCW",
+          "comment": "Assuming this is CCW, analogous to the color wheel (but speed is backward?)"
+        }
+      ]
+    },
+    "Gobo Stencil Rotation": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "WheelSlotRotation",
+          "angleStart": "0deg",
+          "angleEnd": "360deg"
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "WheelSlotRotation",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "WheelSlotRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW"
+        }
+      ]
+    },
+    "Prism": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [8, 255],
+          "type": "Prism"
+        }
+      ]
+    },
+    "Prism Rotation": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "PrismRotation",
+          "angleStart": "0deg",
+          "angleEnd": "360deg"
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "PrismRotation",
+          "speedStart": "fast CCW",
+          "speedEnd": "slow CCW"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "PrismRotation",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "PrismRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Focus": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "far",
+        "distanceEnd": "near"
+      }
+    },
+    "Shutter / Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [16, 131],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [132, 139],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [140, 181],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampDown",
+          "comment": "\"Shutter slow open - fast close\"?"
+        },
+        {
+          "dmxRange": [182, 189],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [190, 231],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUp",
+          "comment": "\"Shutter slow close - fast open\"?"
+        },
+        {
+          "dmxRange": [232, 239],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [240, 247],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true
+        },
+        {
+          "dmxRange": [248, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Blackout/Reset": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 69],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [70, 79],
+          "type": "Maintenance",
+          "comment": "Blackout w/ pan/tilt movement"
+        },
+        {
+          "dmxRange": [80, 89],
+          "type": "Maintenance",
+          "comment": "No blackout pan tilt movement"
+        },
+        {
+          "dmxRange": [90, 99],
+          "type": "Maintenance",
+          "comment": "Blackout w/ color change"
+        },
+        {
+          "dmxRange": [100, 109],
+          "type": "Maintenance",
+          "comment": "No blackout w/ color change"
+        },
+        {
+          "dmxRange": [110, 119],
+          "type": "Maintenance",
+          "comment": "Blackout w/ gobo change"
+        },
+        {
+          "dmxRange": [120, 129],
+          "type": "Maintenance",
+          "comment": "No blackout w/ gobo change"
+        },
+        {
+          "dmxRange": [130, 199],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [200, 209],
+          "type": "Maintenance",
+          "comment": "Reset all"
+        },
+        {
+          "dmxRange": [210, 255],
+          "type": "Effect",
+          "effectName": "Sound Active",
+          "soundControlled": true
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "14-channel",
+      "shortName": "14ch",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Color Wheel",
+        "Gobo Wheel",
+        "Gobo Stencil Rotation",
+        "Prism",
+        "Prism Rotation",
+        "Focus",
+        "Shutter / Strobe",
+        "Dimmer",
+        "Pan/Tilt Speed",
+        "Blackout/Reset"
+      ]
+    }
+  ]
+}

--- a/fixtures/american-dj/inno-spot-pro.json
+++ b/fixtures/american-dj/inno-spot-pro.json
@@ -133,7 +133,8 @@
         {
           "dmxRange": [0, 7],
           "type": "WheelSlot",
-          "slotNumber": 1
+          "slotNumber": 1,
+          "helpWanted": "The colors in the manual don't match the color wheel on the product page."
         },
         {
           "dmxRange": [8, 14],
@@ -178,7 +179,8 @@
         {
           "dmxRange": [64, 127],
           "type": "Effect",
-          "effectName": "Color Mixing"
+          "effectName": "Color Mixing",
+          "helpWanted": "How does this effect look?"
         },
         {
           "dmxRange": [128, 189],
@@ -276,7 +278,7 @@
           "type": "WheelRotation",
           "speedStart": "slow CW",
           "speedEnd": "fast CW",
-          "comment": "Assuming this is CW, analogous to the color wheel (but speed is backward?)"
+          "helpWanted": "Assuming this is CW, analogous to the color wheel (but speed is backward?)"
         },
         {
           "dmxRange": [190, 193],
@@ -288,7 +290,7 @@
           "type": "WheelRotation",
           "speedStart": "fast CCW",
           "speedEnd": "slow CCW",
-          "comment": "Assuming this is CCW, analogous to the color wheel (but speed is backward?)"
+          "helpWanted": "Assuming this is CCW, analogous to the color wheel (but speed is backward?)"
         }
       ]
     },

--- a/fixtures/american-dj/inno-spot-pro.json
+++ b/fixtures/american-dj/inno-spot-pro.json
@@ -399,8 +399,7 @@
         {
           "dmxRange": [140, 181],
           "type": "ShutterStrobe",
-          "shutterEffect": "RampDown",
-          "comment": "\"Shutter slow open - fast close\"?"
+          "shutterEffect": "RampUp"
         },
         {
           "dmxRange": [182, 189],
@@ -410,8 +409,7 @@
         {
           "dmxRange": [190, 231],
           "type": "ShutterStrobe",
-          "shutterEffect": "RampUp",
-          "comment": "\"Shutter slow close - fast open\"?"
+          "shutterEffect": "RampDown"
         },
         {
           "dmxRange": [232, 239],

--- a/fixtures/american-dj/inno-spot-pro.json
+++ b/fixtures/american-dj/inno-spot-pro.json
@@ -452,7 +452,7 @@
         {
           "dmxRange": [70, 79],
           "type": "Maintenance",
-          "comment": "Blackout w/ pan/tilt movement"
+          "comment": "Blackout with pan/tilt movement"
         },
         {
           "dmxRange": [80, 89],
@@ -462,22 +462,22 @@
         {
           "dmxRange": [90, 99],
           "type": "Maintenance",
-          "comment": "Blackout w/ color change"
+          "comment": "Blackout with color change"
         },
         {
           "dmxRange": [100, 109],
           "type": "Maintenance",
-          "comment": "No blackout w/ color change"
+          "comment": "No blackout with color change"
         },
         {
           "dmxRange": [110, 119],
           "type": "Maintenance",
-          "comment": "Blackout w/ gobo change"
+          "comment": "Blackout with gobo change"
         },
         {
           "dmxRange": [120, 129],
           "type": "Maintenance",
-          "comment": "No blackout w/ gobo change"
+          "comment": "No blackout with gobo change"
         },
         {
           "dmxRange": [130, 199],

--- a/fixtures/american-dj/inno-spot-pro.json
+++ b/fixtures/american-dj/inno-spot-pro.json
@@ -24,7 +24,7 @@
     "power": 140,
     "DMXconnector": "3-pin",
     "bulb": {
-      "type": "LED"
+      "type": "1× 80W White LED"
     },
     "lens": {
       "degreesMinMax": [12, 17]
@@ -327,7 +327,8 @@
         },
         {
           "dmxRange": [8, 255],
-          "type": "Prism"
+          "type": "Prism",
+          "comment": "3-facet"
         }
       ]
     },
@@ -381,8 +382,8 @@
           "dmxRange": [16, 131],
           "type": "ShutterStrobe",
           "shutterEffect": "Strobe",
-          "speedStart": "slow",
-          "speedEnd": "fast"
+          "speedStart": "0.3Hz",
+          "speedEnd": "12Hz"
         },
         {
           "dmxRange": [132, 139],

--- a/fixtures/american-dj/inno-spot-pro.json
+++ b/fixtures/american-dj/inno-spot-pro.json
@@ -38,35 +38,43 @@
         },
         {
           "type": "Color",
-          "name": "Red"
+          "name": "Red",
+          "colors": ["#ff0000"]
         },
         {
           "type": "Color",
-          "name": "Orange"
+          "name": "Orange",
+          "colors": ["#ff7f00"]
         },
         {
           "type": "Color",
-          "name": "Yellow"
+          "name": "Yellow",
+          "colors": ["#ffff00"]
         },
         {
           "type": "Color",
-          "name": "Green"
+          "name": "Green",
+          "colors": ["#00ff00"]
         },
         {
           "type": "Color",
-          "name": "Blue"
+          "name": "Blue",
+          "colors": ["#0000ff"]
         },
         {
           "type": "Color",
-          "name": "Purple"
+          "name": "Purple",
+          "colors": ["#b803b8"]
         },
         {
           "type": "Color",
-          "name": "Light Blue"
+          "name": "Light Blue",
+          "colors": ["#007fff"]
         },
         {
           "type": "Color",
-          "name": "Pink"
+          "name": "Pink",
+          "colors": ["#ff6aff"]
         }
       ]
     },


### PR DESCRIPTION
* Add fixture 'american-dj/inno-spot-pro'

### Fixture warnings / errors

* american-dj/inno-spot-pro
  - :x: Capability 'Wheel slot rotation 0…360°' (0…127) in channel 'Gobo Stencil Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Stencil Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation CW fast…slow' (128…189) in channel 'Gobo Stencil Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Stencil Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation stop' (190…193) in channel 'Gobo Stencil Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Stencil Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel slot rotation CCW slow…fast' (194…255) in channel 'Gobo Stencil Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Stencil Rotation' (through the channel name) does not exist.


Thank you @kengruven!