### PR TITLE
Add fixture 'american-dj/dream-barr'

### DIFF
--- a/fixtures/american-dj/dream-barr.json
+++ b/fixtures/american-dj/dream-barr.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Dream Barr",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["boch"],
+    "createDate": "2022-04-20",
+    "lastModifyDate": "2022-04-20"
+  },
+  "links": {
+    "other": [
+      "https://audioluces.com/producto/barra-led-adj-flash-kling-batten-160x0-164w-rgb/"
+    ]
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red 2": {
+      "name": "Red",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 2": {
+      "name": "Green",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 2": {
+      "name": "Blue",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Pixel480 Chanel",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Red 2",
+        "Green 2",
+        "Blue 2"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'american-dj/dream-barr'

### Fixture warnings / errors

* american-dj/dream-barr
  - :x: Mode 'Pixel480 Chanel' should have 480 channels according to its name but actually has 6.
  - :x: Mode 'Pixel480 Chanel' should have 480 channels according to its shortName but actually has 6.
  - :x: Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **boch**!