### PR TITLE
Add fixture 'chauvet-dj/kinta-hp'

### DIFF
--- a/fixtures/chauvet-dj/kinta-hp.json
+++ b/fixtures/chauvet-dj/kinta-hp.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Kinta HP",
+  "categories": ["Flower"],
+  "meta": {
+    "authors": ["Einor!", "Einor"],
+    "createDate": "2022-04-23",
+    "lastModifyDate": "2022-04-23",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2022-04-23",
+      "comment": "created by Q Light Controller Plus (version 4.12.3)"
+    }
+  },
+  "physical": {
+    "dimensions": [220, 240, 230],
+    "weight": 2.3,
+    "power": 34,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Auto Program": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [1, 250],
+          "type": "Effect",
+          "effectName": "Automatic Program"
+        },
+        {
+          "dmxRange": [251, 255],
+          "type": "Effect",
+          "effectName": "Sound Active Mode",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Program Speed / Sound Sensitivity": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Speed",
+        "comment": "Slow to Fast / Low to High",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "Are the automatically added speed values correct?"
+      }
+    },
+    "RED": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Cyan": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Cyan"
+      }
+    },
+    "Magenta": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Magenta"
+      }
+    },
+    "Yellow": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Yellow"
+      }
+    },
+    "Orange": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber",
+        "comment": "Orange intensity (0 - 100%)"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [6, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Motor rotation": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [1, 127],
+          "type": "Effect",
+          "effectName": "Position CW 0-360 degrees"
+        },
+        {
+          "dmxRange": [128, 190],
+          "type": "Rotation",
+          "speedStart": "fast CCW",
+          "speedEnd": "slow CCW",
+          "comment": "Motor speed"
+        },
+        {
+          "dmxRange": [191, 255],
+          "type": "Rotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "Motor speed"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "12-channel",
+      "shortName": "12ch",
+      "channels": [
+        "Auto Program",
+        "Program Speed / Sound Sensitivity",
+        "RED",
+        "Green",
+        "Blue",
+        "White",
+        "Cyan",
+        "Magenta",
+        "Yellow",
+        "Orange",
+        "Strobe",
+        "Motor rotation"
+      ]
+    },
+    {
+      "name": "3-channel",
+      "shortName": "3ch",
+      "channels": [
+        "Auto Program",
+        "Program Speed / Sound Sensitivity",
+        "Motor rotation"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'chauvet-dj/kinta-hp'

### Fixture warnings / errors

* chauvet-dj/kinta-hp
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


### User comment

website: https://www.chauvetdj.com/products/kinta-hp/
manual: https://www.chauvetdj.com/wp-content/uploads/2020/10/Kinta_HP_UM_Rev1.pdf

Thank you **Einor!** and **Einor**!