### PR TITLE
Improve Strobe channel in `eurolite/led-bar-3-hcl-bar` fixture

### DIFF
--- a/fixtures/eurolite/led-bar-3-hcl-bar.json
+++ b/fixtures/eurolite/led-bar-3-hcl-bar.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Rainer Jung"],
     "createDate": "2020-01-14",
-    "lastModifyDate": "2020-01-14"
+    "lastModifyDate": "2022-05-21"
   },
   "links": {
     "manual": [

--- a/fixtures/eurolite/led-bar-3-hcl-bar.json
+++ b/fixtures/eurolite/led-bar-3-hcl-bar.json
@@ -236,13 +236,20 @@
       ]
     },
     "Strobe": {
-      "capability": {
-        "type": "ShutterStrobe",
-        "shutterEffect": "Strobe",
-        "speedStart": "0Hz",
-        "speedEnd": "20Hz",
-        "helpWanted": "At which DMX values is strobe disabled?"
-      }
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [10, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0.5Hz",
+          "speedEnd": "20Hz"
+        }
+      ]
     }
   },
   "modes": [

--- a/fixtures/eurolite/led-bar-3-hcl-bar.json
+++ b/fixtures/eurolite/led-bar-3-hcl-bar.json
@@ -236,6 +236,8 @@
       ]
     },
     "Strobe": {
+      "defaultValue": 0,
+      "highlightValue": 128,
       "capabilities": [
         {
           "dmxRange": [0, 9],


### PR DESCRIPTION
I checked the value for the strobe effect to be enabled and updated it.  
Other than another fixture for Eurolight, I chose to use `shutterEffect` to be `open` when the Strobe is not enabled, I assume this declares the function better than `NoFunction`.