### PR TITLE
New fixture: Eurolite LED Bar-12 QCL RGBA Bar

### DIFF
--- a/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
+++ b/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
@@ -79,7 +79,7 @@
         {
           "dmxRange": [10, 119],
           "type": "Effect",
-          "effectPreset": "ColorFade" 
+          "effectPreset": "ColorFade"
         },
         {
           "dmxRange": [120, 255],

--- a/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
+++ b/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
@@ -79,14 +79,12 @@
         {
           "dmxRange": [10, 119],
           "type": "Effect",
-          "effectPreset": "ColorFade",
-          "speedStart": "slow",
-          "speedEnd": "fast"
+          "effectPreset": "ColorFade" 
         },
         {
           "dmxRange": [120, 255],
           "type": "Effect",
-          "effectPreset": "ColorJump",
+          "effectPreset": "ColorFade",
           "soundControlled": true,
           "soundSensitivityStart": "low",
           "soundSensitivityEnd": "high"
@@ -95,7 +93,7 @@
     },
     "Auto Program Speed": {
       "capability": {
-        "type": "Speed",
+        "type": "EffectSpeed",
         "speedStart": "slow",
         "speedEnd": "fast"
       }
@@ -222,7 +220,7 @@
         }
       ]
     },
-    "Strobe Program": {
+    "Strobe / Program": {
       "capabilities": [
         {
           "dmxRange": [0, 0],
@@ -232,9 +230,7 @@
           "dmxRange": [1, 5],
           "type": "Effect",
           "effectPreset": "ColorJump",
-          "soundControlled": true,
-          "soundSensitivityStart": "low",
-          "soundSensitivityEnd": "high"
+          "soundControlled": true
         },
         {
           "dmxRange": [6, 10],
@@ -263,42 +259,42 @@
         {
           "dmxRange": [30, 49],
           "type": "ColorTemperature",
-          "colorTemperature": "2700K"
+          "colorTemperature": "3200K"
         },
         {
           "dmxRange": [50, 69],
           "type": "ColorTemperature",
-          "colorTemperature": "2700K"
+          "colorTemperature": "3400K"
         },
         {
           "dmxRange": [70, 89],
           "type": "ColorTemperature",
-          "colorTemperature": "2700K"
+          "colorTemperature": "4200K"
         },
         {
           "dmxRange": [90, 109],
           "type": "ColorTemperature",
-          "colorTemperature": "2700K"
+          "colorTemperature": "4900K"
         },
         {
           "dmxRange": [110, 129],
           "type": "ColorTemperature",
-          "colorTemperature": "2700K"
+          "colorTemperature": "5600K"
         },
         {
           "dmxRange": [130, 149],
           "type": "ColorTemperature",
-          "colorTemperature": "2700K"
+          "colorTemperature": "6000K"
         },
         {
           "dmxRange": [150, 169],
           "type": "ColorTemperature",
-          "colorTemperature": "2700K"
+          "colorTemperature": "6500K"
         },
         {
           "dmxRange": [170, 189],
           "type": "ColorTemperature",
-          "colorTemperature": "2700K"
+          "colorTemperature": "7500K"
         },
         {
           "dmxRange": [190, 255],
@@ -365,7 +361,7 @@
         "Blue",
         "Amber",
         "Dimmer",
-        "Strobe Program"
+        "Strobe / Program"
       ]
     },
     {

--- a/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
+++ b/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
@@ -4,8 +4,8 @@
   "categories": ["Color Changer"],
   "meta": {
     "authors": ["Rainer Jung"],
-    "createDate": "2022-05-21",
-    "lastModifyDate": "2022-05-21"
+    "createDate": "2022-05-22",
+    "lastModifyDate": "2022-05-22"
   },
   "links": {
     "manual": [

--- a/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
+++ b/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
@@ -33,11 +33,13 @@
   "availableChannels": {
     "Dimmer": {
       "defaultValue": 0,
+      "highlightValue": 255,
       "capability": {
         "type": "Intensity"
       }
     },
     "Red": {
+      "defaultValue": 0,
       "highlightValue": 255,
       "capability": {
         "type": "ColorIntensity",
@@ -45,6 +47,7 @@
       }
     },
     "Green": {
+      "defaultValue": 0,
       "highlightValue": 255,
       "capability": {
         "type": "ColorIntensity",
@@ -52,6 +55,7 @@
       }
     },
     "Blue": {
+      "defaultValue": 0,
       "highlightValue": 255,
       "capability": {
         "type": "ColorIntensity",
@@ -59,6 +63,7 @@
       }
     },
     "Amber": {
+      "defaultValue": 0,
       "highlightValue": 255,
       "capability": {
         "type": "ColorIntensity",
@@ -249,7 +254,7 @@
         "Green",
         "Blue",
         "Amber",
-        "XXX",
+        "Color Temperature",
         "Dimmer",
         "Strobe",
         "Auto Program",

--- a/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
+++ b/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
@@ -100,6 +100,128 @@
         "speedEnd": "fast"
       }
     },
+    "Color Presets": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [10, 19],
+          "type": "ColorPreset",
+          "comment": "Red",
+          "colors": ["#ff0000"]
+        },
+        {
+          "dmxRange": [20, 29],
+          "type": "ColorPreset",
+          "comment": "Green",
+          "colors": ["#00ff00"]
+        },
+        {
+          "dmxRange": [30, 39],
+          "type": "ColorPreset",
+          "comment": "Blue",
+          "colors": ["#0000ff"]
+        },
+        {
+          "dmxRange": [40, 49],
+          "type": "ColorPreset",
+          "comment": "White",
+          "colors": ["#ffffff"]
+        },
+        {
+          "dmxRange": [50, 59],
+          "type": "ColorPreset",
+          "comment": "Amber",
+          "colors": ["#ffbf00"]
+        },
+        {
+          "dmxRange": [60, 69],
+          "type": "ColorPreset",
+          "comment": "UV",
+          "colors": ["#8800ff"]
+        },
+        {
+          "dmxRange": [70, 79],
+          "type": "ColorPreset",
+          "comment": "Yellow",
+          "colors": ["#ffff00"]
+        },
+        {
+          "dmxRange": [80, 89],
+          "type": "ColorPreset",
+          "comment": "Magenta",
+          "colors": ["#ff00ff"]
+        },
+        {
+          "dmxRange": [90, 99],
+          "type": "ColorPreset",
+          "comment": "Cyan",
+          "colors": ["#00ffff"]
+        },
+        {
+          "dmxRange": [100, 109],
+          "type": "ColorPreset",
+          "comment": "Dark Orange",
+          "colors": ["#be6500"]
+        },
+        {
+          "dmxRange": [110, 119],
+          "type": "ColorPreset",
+          "comment": "Green Yellow",
+          "colors": ["#8cff00"]
+        },
+        {
+          "dmxRange": [120, 129],
+          "type": "ColorPreset",
+          "comment": "Salmon",
+          "colors": ["#ff8c8c"]
+        },
+        {
+          "dmxRange": [130, 139],
+          "type": "ColorPreset",
+          "comment": "Turquoise",
+          "colors": ["#8cffff"]
+        },
+        {
+          "dmxRange": [140, 149],
+          "type": "ColorPreset",
+          "comment": "Light Green",
+          "colors": ["#8cff8c"]
+        },
+        {
+          "dmxRange": [150, 159],
+          "type": "ColorPreset",
+          "comment": "Orange",
+          "colors": ["#ff8c00"]
+        },
+        {
+          "dmxRange": [160, 169],
+          "type": "ColorPreset",
+          "comment": "Lavender",
+          "colors": ["#ccbfff"]
+        },
+        {
+          "dmxRange": [170, 179],
+          "type": "ColorPreset",
+          "comment": "Light Blue",
+          "colors": ["#8c8cff"]
+        },
+        {
+          "dmxRange": [180, 189],
+          "type": "ColorPreset",
+          "comment": "Dark Blue",
+          "colors": ["#00008c"]
+        },
+        {
+          "dmxRange": [190, 255],
+          "type": "ColorPreset",
+          "comment": "Pink",
+          "colors": ["#ff008c"]
+        }
+      ]
+    },
     "Strobe Program": {
       "capabilities": [
         {

--- a/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
+++ b/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
@@ -85,9 +85,7 @@
           "dmxRange": [120, 255],
           "type": "Effect",
           "effectPreset": "ColorFade",
-          "soundControlled": true,
-          "soundSensitivityStart": "low",
-          "soundSensitivityEnd": "high"
+          "soundControlled": true
         }
       ]
     },

--- a/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
+++ b/fixtures/eurolite/led-bar-12-qcl-rgba-bar.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED Bar-12 QCL RGBA Bar",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Rainer Jung"],
+    "createDate": "2022-05-21",
+    "lastModifyDate": "2022-05-21"
+  },
+  "links": {
+    "manual": [
+      "https://www.steinigke.de/download/51930396-Manual-120587-1.200-eurolite-led-bar-12-qcl-rgba-bar-de_en.pdf"
+    ],
+    "productPage": [
+      "https://www.steinigke.de/en/mpn51930396-eurolite-led-bar-12-qcl-rgba-bar.html"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=ZIj0aZyng1Q"
+    ]
+  },
+  "physical": {
+    "dimensions": [1090, 65, 100],
+    "weight": 2.9,
+    "power": 24,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [17, 17]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Amber": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "Auto Program": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [10, 119],
+          "type": "Effect",
+          "effectPreset": "ColorFade",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [120, 255],
+          "type": "Effect",
+          "effectPreset": "ColorJump",
+          "soundControlled": true,
+          "soundSensitivityStart": "low",
+          "soundSensitivityEnd": "high"
+        }
+      ]
+    },
+    "Auto Program Speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Strobe Program": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [1, 5],
+          "type": "Effect",
+          "effectPreset": "ColorJump",
+          "soundControlled": true,
+          "soundSensitivityStart": "low",
+          "soundSensitivityEnd": "high"
+        },
+        {
+          "dmxRange": [6, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0.5Hz",
+          "speedEnd": "20Hz"
+        }
+      ]
+    },
+    "Color Temperature": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [10, 29],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [30, 49],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [50, 69],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [70, 89],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [90, 109],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [110, 129],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [130, 149],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [150, 169],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [170, 189],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [190, 255],
+          "type": "ColorTemperature",
+          "colorTemperature": "8000K"
+        }
+      ]
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "highlightValue": 128,
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [10, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0.5Hz",
+          "speedEnd": "20Hz"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "2-channel",
+      "shortName": "2ch",
+      "channels": [
+        "Auto Program",
+        "Auto Program Speed"
+      ]
+    },
+    {
+      "name": "4-channel",
+      "shortName": "4ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Amber"
+      ]
+    },
+    {
+      "name": "5-channel",
+      "shortName": "5ch",
+      "channels": [
+        "Dimmer",
+        "Color Presets",
+        "Strobe",
+        "Auto Program",
+        "Auto Program Speed"
+      ]
+    },
+    {
+      "name": "6-channel",
+      "shortName": "6ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Amber",
+        "Dimmer",
+        "Strobe Program"
+      ]
+    },
+    {
+      "name": "9-channel",
+      "shortName": "9ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Amber",
+        "XXX",
+        "Dimmer",
+        "Strobe",
+        "Auto Program",
+        "Auto Program Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Added a new Fixture.

There's the almost same `Eurolite LED BAR 6-QCL RGBA` and those also exist with `RGBW`. They are mainly duplicates, just with 6 instead of 12 LEDs and White instead of Amber.  
I can make some copies containing the relevant links of that's the way to go here. The control should be the same, so I kept just this one.