### PR TITLE
Add fixture 'stage-right/rgbw-cob-led-dmx-ellipsoidal'

### DIFF
--- a/fixtures/stage-right/rgbw-cob-led-dmx-ellipsoidal.json
+++ b/fixtures/stage-right/rgbw-cob-led-dmx-ellipsoidal.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "RGBW COB LED DMX Ellipsoidal",
+  "categories": ["Dimmer", "Color Changer"],
+  "meta": {
+    "authors": ["Chad Norman"],
+    "createDate": "2022-05-23",
+    "lastModifyDate": "2022-05-23"
+  },
+  "links": {
+    "manual": [
+      "https://downloads.monoprice.com/files/manuals/612754_Manual_151019.pdf"
+    ],
+    "productPage": [
+      "https://www.monoprice.com/product?p_id=612754"
+    ]
+  },
+  "physical": {
+    "power": 180
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    },
+    "Color Wheel Rotation": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 134],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [135, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Strobe Speed": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "5Hz",
+          "speedEnd": "20Hz"
+        }
+      ]
+    },
+    "Dimmer speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Master Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Elipsoidal",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Color Macros",
+        "Color Wheel Rotation",
+        "Strobe Speed",
+        "Dimmer speed",
+        "Master Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'stage-right/rgbw-cob-led-dmx-ellipsoidal'

### Fixture warnings / errors

* stage-right/rgbw-cob-led-dmx-ellipsoidal
  - :x: Capability 'Wheel rotation CW slow…fast' (11…134) in channel 'Color Wheel Rotation' does not explicitly reference any wheel, but the default wheel 'Color Wheel Rotation' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (135…255) in channel 'Color Wheel Rotation' does not explicitly reference any wheel, but the default wheel 'Color Wheel Rotation' (through the channel name) does not exist.


Thank you @cnorm5623!