### PR TITLE
Add fixture `velleman/smart-led-rgb`

### DIFF
--- a/fixtures/velleman/smart-led-rgb.json
+++ b/fixtures/velleman/smart-led-rgb.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Smart led rgb",
+  "shortName": "VDPL1203RGB",
+  "categories": ["Color Changer", "Pixel Bar"],
+  "meta": {
+    "authors": ["Rocheteau"],
+    "createDate": "2022-06-03",
+    "lastModifyDate": "2022-06-03"
+  },
+  "links": {
+    "manual": [
+      "https://www.velleman.eu/downloads/4/vdpl1203rgbgbnlfresd.pdf"
+    ]
+  },
+  "physical": {
+    "dimensions": [1000, 60, 150],
+    "weight": 3.5,
+    "power": 47,
+    "DMXconnector": "3-pin and 5-pin",
+    "bulb": {
+      "type": "LED",
+      "lumens": 1360
+    },
+    "lens": {
+      "degreesMinMax": [0, 42]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": 36,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "tri-colour LED wash effect",
+      "shortName": "RGB control via max. 36 channels",
+      "channels": [
+        "Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'velleman/smart-led-rgb'

### Fixture warnings / errors

* velleman/smart-led-rgb
  - :x: Mode 'tri-colour LED wash effect' should have 36 channels according to its shortName but actually has 1.
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.
  - :x: Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.


Thank you **Rocheteau**!