### PR TITLE
Add fixture 'dedolight/dled7-1-bi'

### DIFF
--- a/fixtures/dedolight/dled7-1-bi.json
+++ b/fixtures/dedolight/dled7-1-bi.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "DLED7.1 Bi",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Yuichi Kato"],
+    "createDate": "2022-06-23",
+    "lastModifyDate": "2022-06-23"
+  },
+  "links": {
+    "manual": [
+      "https://www.dedoweigertfilm.de/dwf-en/home_banner_prod/turbo-series.php"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Color Temperature": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "2700K",
+        "colorTemperatureEnd": "6500K"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Bi color",
+      "channels": [
+        "Dimmer",
+        "Color Temperature"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'dedolight/dled7-1-bi'

### Fixture warnings / errors

* dedolight/dled7-1-bi
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.


Thank you **Yuichi Kato**!