### PR TITLE
Fix PanTiltSpeed on rogue-r1-wash

### DIFF
--- a/fixtures/chauvet-professional/rogue-r1-wash.json
+++ b/fixtures/chauvet-professional/rogue-r1-wash.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Ken Harris", "Flo Edelmann"],
     "createDate": "2022-03-07",
-    "lastModifyDate": "2022-03-17"
+    "lastModifyDate": "2022-07-16"
   },
   "links": {
     "manual": [
@@ -54,8 +54,8 @@
     "Pan/Tilt Speed": {
       "capability": {
         "type": "PanTiltSpeed",
-        "speedStart": "slow",
-        "speedEnd": "fast"
+        "speedStart": "fast",
+        "speedEnd": "slow"
       }
     },
     "Dimmer": {


### PR DESCRIPTION
It turns out that speed=0 is fast, and speed=255 is slow.
(In hindsight, this shouldn't be surprising: the default/easiest value is the fastest.)
Note that the user manual from Chauvet is wrong.