### PR TITLE
Add fixture 'elation/fuze-par-z60ip'

### DIFF
--- a/fixtures/elation/fuze-par-z60ip.json
+++ b/fixtures/elation/fuze-par-z60ip.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "FUZE PAR Z60IP",
+  "shortName": "FUZE Z60IP",
+  "categories": ["Barrel Scanner", "Color Changer", "Dimmer", "Effect"],
+  "meta": {
+    "authors": ["Natsuna"],
+    "createDate": "2022-07-31",
+    "lastModifyDate": "2022-07-31"
+  },
+  "links": {
+    "manual": [
+      "https://www.soundhouse.co.jp/download/elation/fuzeparz60ip.pdf"
+    ],
+    "productPage": [
+      "https://www.soundhouse.co.jp/products/detail/item/226442/"
+    ]
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "4ch RGBW",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'elation/fuze-par-z60ip'

### Fixture warnings / errors

* elation/fuze-par-z60ip
  - :x: Category 'Barrel Scanner' invalid since there are no pan or tilt channels.


Thank you **Natsuna**!