### PR TITLE
Add fixture 'henli/led-par-24-x-5-in-1'

### DIFF
--- a/fixtures/henli/led-par-24-x-5-in-1.json
+++ b/fixtures/henli/led-par-24-x-5-in-1.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED PAR 24 x 5 in 1",
+  "shortName": "Wash PAR Light (HL-028)",
+  "categories": ["Matrix"],
+  "meta": {
+    "authors": ["Anonymus"],
+    "createDate": "2022-09-01",
+    "lastModifyDate": "2022-09-01"
+  },
+  "links": {
+    "productPage": [
+      "https://henlilighting.en.made-in-china.com/product/hvYQqCJOnKca/China-5in1-15W-24PCS-LED-Wash-PAR-Light-HL-028-.html"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=2h4jJpJlSQM"
+    ]
+  },
+  "physical": {
+    "dimensions": [370, 230, 290],
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [45, 45]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "0Hz",
+        "speedEnd": "20Hz"
+      }
+    },
+    "Program_color": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    },
+    "Color Presets": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "24 x 5 in 1",
+      "shortName": "LED PAR 24 x 5 in 1",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "Strobe",
+        "Color Presets"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -239,6 +239,11 @@
     "name": "Hazebase",
     "website": "https://hazebase.com/"
   },
+  "henli": {
+    "name": "HENLI",
+    "comment": "24pcs 4in1 waterproof wash light of stage lighting (HL-028)",
+    "rdmId": 0
+  },
   "hive": {
     "name": "Hive Lighting",
     "website": "https://hivelighting.com"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture 'henli/led-par-24-x-5-in-1'

### Fixture warnings / errors

* henli/led-par-24-x-5-in-1
  - :x: Category 'Matrix' invalid since fixture does not define a matrix.
  - :warning: Unused channel(s): program_color
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Anonymus**!