### PR TITLE
Add fixture 'starway/parkolor-120-hd'

### DIFF
--- a/fixtures/starway/parkolor-120-hd.json
+++ b/fixtures/starway/parkolor-120-hd.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "PARKOLOR 120 HD",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["LOLO"],
+    "createDate": "2022-09-19",
+    "lastModifyDate": "2022-09-19"
+  },
+  "links": {
+    "manual": [
+      "http://ftp.technique.freevox.fr/STARWAY/225465_PARKOLOR120HD/225465_PARKOLOR120HDV3_FR.pdf"
+    ]
+  },
+  "physical": {
+    "lens": {
+      "degreesMinMax": [7, 40]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "DMX 7",
+      "channels": [
+        "Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'starway/parkolor-120-hd'

### Fixture warnings / errors

* starway/parkolor-120-hd
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.


Thank you **LOLO**!