### PR TITLE
Add fixture 'generic/oxo-color-beam-18'

### DIFF
--- a/fixtures/generic/oxo-color-beam-18.json
+++ b/fixtures/generic/oxo-color-beam-18.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Oxo color beam 18",
+  "shortName": "Colorbeam 18",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["ert"],
+    "createDate": "2022-10-13",
+    "lastModifyDate": "2022-10-13"
+  },
+  "links": {
+    "manual": [
+      "https://www.google.com"
+    ]
+  },
+  "availableChannels": {
+    "Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8ch",
+      "shortName": "8ch",
+      "channels": [
+        "Intensity",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Shutter / Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'generic/oxo-color-beam-18'

### Fixture warnings / errors

* generic/oxo-color-beam-18
  - :x: Mode '8ch' should have 8 channels according to its name but actually has 6.
  - :x: Mode '8ch' should have 8 channels according to its shortName but actually has 6.


Thank you **ert**!