### PR TITLE
Fix short links

### DIFF
--- a/fixtures/eurolite/led-bar-6-qcl-rgbw.json
+++ b/fixtures/eurolite/led-bar-6-qcl-rgbw.json
@@ -19,7 +19,7 @@
     "productPage": [
       "https://www.thomann.de/gb/eurolite_led_bar_6_qcl_rgbw.htm"
     ],
-    "video": ["https://youtu.be/tXEgjiP5YWA"]
+    "video": ["https://www.youtube.com/watch?v=tXEgjiP5YWA"]
   },
   "physical": {
     "dimensions": [585, 65, 100],

--- a/fixtures/flash-professional/led-par-64-cob-300w-rgbwauv.json
+++ b/fixtures/flash-professional/led-par-64-cob-300w-rgbwauv.json
@@ -15,7 +15,7 @@
       "https://flash-butrym.pl/en_US/p/LED-PAR-64-300W-6in1-COB-RGBWA-UV-BARNDOOR/406"
     ],
     "video": [
-      "https://www.youtube.com/watch?v=TJtqvw6y7ss&feature=youtu.be"
+      "https://www.youtube.com/watch?v=TJtqvw6y7ss"
     ]
   },
   "physical": {

--- a/fixtures/varytec/giga-bar-frost-pix-8-rgb.json
+++ b/fixtures/varytec/giga-bar-frost-pix-8-rgb.json
@@ -19,7 +19,7 @@
     "productPage": [
       "https://www.thomann.de/gb/varytec_giga_bar_frost_pix_8_rgb.htm"
     ],
-    "video": ["https://youtu.be/PixpS09Mc-I"]
+    "video": ["https://www.youtube.com/watch?v=PixpS09Mc-I"]
   },
   "physical": {
     "dimensions": [1020, 80, 65],


### PR DESCRIPTION
It seems like the bot doesn't like [YouTube's short URLs](https://blog.youtube/news-and-events/make-way-for-youtube-links/). This PR replaces the URLs.
Found by #999.