### PR TITLE
Add fixture 'showtec/spectral'

### DIFF
--- a/fixtures/showtec/spectral.json
+++ b/fixtures/showtec/spectral.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Spectral",
+  "shortName": "1800Z",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Dropzone"],
+    "createDate": "2022-10-19",
+    "lastModifyDate": "2022-10-19"
+  },
+  "links": {
+    "manual": [
+      "https://highlite./fr/43552-spectral-pc-1200z.html"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speed": "25Hz"
+      }
+    },
+    "Zoom": {
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "narrow",
+        "angleEnd": "wide"
+      }
+    },
+    "Focus": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "SSP",
+      "shortName": "9CH",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe",
+        "Zoom",
+        "Focus",
+        "Intensity"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'showtec/spectral'

### Fixture warnings / errors

* showtec/spectral
  - :warning: Mode 'SSP' should have shortName '9ch' instead of '9CH'.


Thank you **Dropzone**!