### PR TITLE
Add fixture 'shehds/led-gobo-60w'

### DIFF
--- a/fixtures/shehds/led-gobo-60w.json
+++ b/fixtures/shehds/led-gobo-60w.json
@@ -1,0 +1,412 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED GOBO 60W",
+  "shortName": "LED-GOBO-60E",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["nn23"],
+    "createDate": "2022-11-03",
+    "lastModifyDate": "2022-11-03"
+  },
+  "links": {
+    "productPage": [
+      "https://www.shehds.com/products/good-technology-led-60w-gobos-moving-head-lighting-for-dmx512-stage-effect-dj-festivals-disco-home-entertainments-in-9-11-channels"
+    ]
+  },
+  "physical": {
+    "dimensions": [14.4, 27.2, 19.8],
+    "weight": 3.2,
+    "power": 60,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "slots": [
+        {
+          "type": "Gobo",
+          "name": "Solid"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rose"
+        },
+        {
+          "type": "Gobo",
+          "name": "Radial dots"
+        },
+        {
+          "type": "Gobo",
+          "name": "Triangle"
+        },
+        {
+          "type": "Gobo",
+          "name": "Hexagon"
+        },
+        {
+          "type": "Gobo",
+          "name": "Swirl-1"
+        },
+        {
+          "type": "Gobo",
+          "name": "Swirl-2"
+        },
+        {
+          "type": "Gobo",
+          "name": "Jigsaw"
+        },
+        {
+          "type": "Gobo",
+          "name": "Solid"
+        },
+        {
+          "type": "Gobo",
+          "name": "Rose Jitter"
+        },
+        {
+          "type": "Gobo",
+          "name": "Radial Dots Jitter"
+        },
+        {
+          "type": "Gobo",
+          "name": "Triangle Jitter"
+        },
+        {
+          "type": "Gobo",
+          "name": "Hexagon Jitter"
+        },
+        {
+          "type": "Gobo",
+          "name": "Swirl 1 Jitter"
+        },
+        {
+          "type": "Gobo",
+          "name": "Swirl 2 Jitter"
+        },
+        {
+          "type": "Gobo",
+          "name": "Jigsaw Jiter"
+        },
+        {
+          "type": "Gobo",
+          "name": "Automatic"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "X-axis": {
+      "fineChannelAliases": ["X-axis fine"],
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "360deg"
+      }
+    },
+    "Y-axis": {
+      "fineChannelAliases": ["Y-axis fine"],
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "360deg"
+      }
+    },
+    "X-axis 2": {
+      "name": "X-axis",
+      "fineChannelAliases": ["X-axis 2 fine"],
+      "defaultValue": 0,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "360deg"
+      }
+    },
+    "Y-axis 2": {
+      "name": "Y-axis",
+      "fineChannelAliases": ["Y-axis 2 fine"],
+      "defaultValue": 0,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "360deg"
+      }
+    },
+    "Color Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [1, 9],
+          "type": "ColorPreset",
+          "comment": "White"
+        },
+        {
+          "dmxRange": [10, 19],
+          "type": "ColorPreset",
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [20, 29],
+          "type": "ColorPreset",
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [30, 39],
+          "type": "ColorPreset",
+          "comment": "Lemon Yellow"
+        },
+        {
+          "dmxRange": [40, 49],
+          "type": "ColorPreset",
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [50, 59],
+          "type": "ColorPreset",
+          "comment": "Blue"
+        },
+        {
+          "dmxRange": [60, 69],
+          "type": "ColorPreset",
+          "comment": "Pink"
+        },
+        {
+          "dmxRange": [70, 79],
+          "type": "ColorPreset",
+          "comment": "Sky Blue"
+        },
+        {
+          "dmxRange": [80, 89],
+          "type": "ColorPreset",
+          "comment": "Sky Blue & Pink"
+        },
+        {
+          "dmxRange": [90, 99],
+          "type": "ColorPreset",
+          "comment": "Pink & Blue"
+        },
+        {
+          "dmxRange": [100, 109],
+          "type": "ColorPreset",
+          "comment": "Blue & Green"
+        },
+        {
+          "dmxRange": [110, 119],
+          "type": "ColorPreset",
+          "comment": "Green & Lemon Yellow"
+        },
+        {
+          "dmxRange": [120, 129],
+          "type": "ColorPreset",
+          "comment": "Lemon Yellow & Orange"
+        },
+        {
+          "dmxRange": [130, 139],
+          "type": "ColorPreset",
+          "comment": "Orange & Red"
+        },
+        {
+          "dmxRange": [140, 255],
+          "type": "ColorPreset",
+          "comment": "Automatic"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "WheelSlot",
+          "slotNumber": 9
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "WheelSlot",
+          "slotNumber": 10
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "WheelSlot",
+          "slotNumber": 11
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "WheelSlot",
+          "slotNumber": 12
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "WheelSlot",
+          "slotNumber": 13
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "WheelSlot",
+          "slotNumber": 14
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "WheelSlot",
+          "slotNumber": 15
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelSlot",
+          "slotNumber": 16
+        },
+        {
+          "dmxRange": [128, 255],
+          "type": "WheelSlot",
+          "slotNumber": 17
+        }
+      ]
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "0Hz",
+        "speedEnd": "20Hz"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Auto": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 48],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [49, 99],
+          "type": "Generic",
+          "comment": "Auto run mode 1"
+        },
+        {
+          "dmxRange": [100, 150],
+          "type": "Generic",
+          "comment": "Auto run mode 2"
+        },
+        {
+          "dmxRange": [151, 201],
+          "type": "SoundSensitivity",
+          "soundSensitivityStart": "0%",
+          "soundSensitivityEnd": "100%",
+          "comment": "Sound Control"
+        },
+        {
+          "dmxRange": [202, 255],
+          "type": "NoFunction"
+        }
+      ]
+    },
+    "Reset": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 249],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "Generic",
+          "comment": "Reset"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "11-channel",
+      "shortName": "11ch",
+      "channels": [
+        "X-axis 2",
+        "X-axis 2 fine",
+        "Y-axis 2",
+        "Y-axis 2 fine",
+        "Color Wheel",
+        "Gobo Wheel",
+        "Strobe",
+        "Dimmer",
+        "Pan/Tilt Speed",
+        "Auto",
+        "Reset"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'shehds/led-gobo-60w'

### Fixture warnings / errors

* shehds/led-gobo-60w
  - :warning: Unused channel(s): x-axis, x-axis fine, y-axis, y-axis fine
  - :warning: Unused wheel(s): Color Wheel
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you @yiids!