### PR TITLE
Add manual for fixture `afx/lmh460z`

### DIFF
--- a/fixtures/afx/lmh460z.json
+++ b/fixtures/afx/lmh460z.json
@@ -11,6 +11,7 @@
   "comment": "Wash Zoom LED",
   "links": {
     "manual": [
+      "https://manualzz.com/doc/18437803/afx-light-lmh460z-2-afx--led-moving-head-wash-36x10w-4-in",
       "https://manual-hub.com/manuals/afx-lmh460z-01-pdf-manual/"
     ],
     "video": [


### PR DESCRIPTION
It's not ideal, but its's better than the existing manual link. I've had a brief look and can't see a product page or official manual links.

Closes #2901