### PR TITLE
Add fixture `shehds/mini-led-spot-beam-10w-lighting`

### DIFF
--- a/fixtures/shehds/mini-led-spot-beam-10w-lighting.json
+++ b/fixtures/shehds/mini-led-spot-beam-10w-lighting.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Mini LED Spot Beam 10W Lighting",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Mosse"],
+    "createDate": "2022-11-24",
+    "lastModifyDate": "2022-11-24",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2022-11-24",
+      "comment": "created by Q Light Controller Plus (version 4.12.6)"
+    }
+  },
+  "physical": {
+    "power": 10,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "name": "PC"
+    }
+  },
+  "matrix": {
+    "pixelCount": [
+      null,
+      null,
+      1
+    ]
+  },
+  "availableChannels": {
+    "X-axis, move": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "BeamPosition",
+        "horizontalAngleStart": "left",
+        "horizontalAngleEnd": "right",
+        "helpWanted": "Is this the correct direction? Can you provide exact angles?"
+      }
+    },
+    "X-axis,Fine-tuning": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Y-axis, move": {
+      "defaultValue": 127,
+      "capability": {
+        "type": "BeamPosition",
+        "verticalAngleStart": "top",
+        "verticalAngleEnd": "bottom",
+        "helpWanted": "Is this the correct direction? Can you provide exact angles?"
+      }
+    },
+    "Y-axis,Fine-tuning": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Axis ,Slow to Fast": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "Are the automatically added speed values correct?"
+      }
+    },
+    "Total dimmer, linear dimming-Dark to Bright": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe,Slow to Fast": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX values is strobe disabled?"
+      }
+    },
+    "Red light color control, channel value of 0 for the closedlight,": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green color control, channel value of 0 for the closedlight": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue light color control, channel value of 0 for closed light": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White light color control, the channel value of 0 for the closed light": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "AUTO Run Mode - \nSound Mode": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 249],
+          "type": "Effect",
+          "effectName": "AUTO Run mode"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "Effect",
+          "effectName": "Sound mode",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Rest": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Speed"
+      }
+    }
+  },
+  "templateChannels": {},
+  "modes": [
+    {
+      "name": "11-channel",
+      "shortName": "11ch",
+      "channels": [
+        "X-axis, move",
+        "X-axis,Fine-tuning",
+        "Y-axis, move",
+        "Y-axis,Fine-tuning",
+        "Axis ,Slow to Fast",
+        "Total dimmer, linear dimming-Dark to Bright",
+        "Strobe,Slow to Fast",
+        "Red light color control, channel value of 0 for the closedlight,",
+        "Green color control, channel value of 0 for the closedlight",
+        "Blue light color control, channel value of 0 for closed light",
+        "White light color control, the channel value of 0 for the closed light"
+      ]
+    },
+    {
+      "name": "13-channel",
+      "shortName": "13ch",
+      "channels": [
+        "X-axis, move",
+        "X-axis,Fine-tuning",
+        "Y-axis, move",
+        "Y-axis,Fine-tuning",
+        "Axis ,Slow to Fast",
+        "Total dimmer, linear dimming-Dark to Bright",
+        "Strobe,Slow to Fast",
+        "Red light color control, channel value of 0 for the closedlight,",
+        "Green color control, channel value of 0 for the closedlight",
+        "Blue light color control, channel value of 0 for closed light",
+        "White light color control, the channel value of 0 for the closed light",
+        "AUTO Run Mode - \nSound Mode",
+        "Rest"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'shehds/mini-led-spot-beam-10w-lighting'

### Fixture warnings / errors

* shehds/mini-led-spot-beam-10w-lighting
  - :x: File does not match schema: fixture/matrix/pixelCount/0 -Infinity must be >= 1
  - :x: File does not match schema: fixture/matrix/pixelCount/1 -Infinity must be >= 1
  - :x: File does not match schema: fixture/availableChannels property name 'AUTO Run Mode - \nSound Mode' is invalid (must match pattern "^[^$\n]+$")
  - :x: File does not match schema: fixture/availableChannels/Rest/capability (type: Speed) must have required property 'speed'
  - :x: File does not match schema: fixture/availableChannels/Rest/capability (type: Speed) must have required property 'speedStart'
  - :x: File does not match schema: fixture/availableChannels/Rest/capability (type: Speed) must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/templateChannels must NOT have fewer than 1 properties
  - :x: File does not match schema: fixture/modes/1/channels/11 "AUTO Run Mode - \nSound Mode" must be null
  - :x: File does not match schema: fixture/modes/1/channels/11 "AUTO Run Mode - \nSound Mode" must match pattern "^[^$\n]+$"
  - :x: File does not match schema: fixture/modes/1/channels/11 "AUTO Run Mode - \nSound Mode" must be object
  - :x: File does not match schema: fixture/modes/1/channels/11 "AUTO Run Mode - \nSound Mode" must match exactly one schema in oneOf
  - :warning: Please check 16bit channel 'X-axis,Fine-tuning': The corresponding coarse channel could not be detected.
  - :warning: Please check 16bit channel 'Y-axis,Fine-tuning': The corresponding coarse channel could not be detected.
  - :warning: Please add 11-channel mode's Head #1 to the fixture's matrix. The included channels were White light color control, the channel value of 0 for the closed light.
  - :warning: Please add 11-channel mode's Head #2 to the fixture's matrix. The included channels were Blue light color control, channel value of 0 for closed light.
  - :warning: Please add 11-channel mode's Head #3 to the fixture's matrix. The included channels were Green color control, channel value of 0 for the closedlight.
  - :warning: Please add 11-channel mode's Head #4 to the fixture's matrix. The included channels were Red light color control, channel value of 0 for the closedlight,.
  - :warning: Please add 11-channel mode's Head #5 to the fixture's matrix. The included channels were Strobe,Slow to Fast.
  - :warning: Please add 11-channel mode's Head #6 to the fixture's matrix. The included channels were Total dimmer, linear dimming-Dark to Bright.
  - :warning: Please add 11-channel mode's Head #7 to the fixture's matrix. The included channels were Axis ,Slow to Fast.
  - :warning: Please add 11-channel mode's Head #8 to the fixture's matrix. The included channels were Y-axis,Fine-tuning.
  - :warning: Please add 11-channel mode's Head #9 to the fixture's matrix. The included channels were Y-axis, move.
  - :warning: Please add 11-channel mode's Head #10 to the fixture's matrix. The included channels were X-axis,Fine-tuning.
  - :warning: Please add 11-channel mode's Head #11 to the fixture's matrix. The included channels were X-axis, move.
  - :warning: Please add 13-channel mode's Head #1 to the fixture's matrix. The included channels were Rest.
  - :warning: Please add 13-channel mode's Head #2 to the fixture's matrix. The included channels were Blue light color control, channel value of 0 for closed light.
  - :warning: Please add 13-channel mode's Head #3 to the fixture's matrix. The included channels were AUTO Run Mode - 
Sound Mode.
  - :warning: Please add 13-channel mode's Head #4 to the fixture's matrix. The included channels were White light color control, the channel value of 0 for the closed light.
  - :warning: Please add 13-channel mode's Head #5 to the fixture's matrix. The included channels were Green color control, channel value of 0 for the closedlight.
  - :warning: Please add 13-channel mode's Head #6 to the fixture's matrix. The included channels were Red light color control, channel value of 0 for the closedlight,.
  - :warning: Please add 13-channel mode's Head #7 to the fixture's matrix. The included channels were Strobe,Slow to Fast.
  - :warning: Please add 13-channel mode's Head #8 to the fixture's matrix. The included channels were Total dimmer, linear dimming-Dark to Bright.
  - :warning: Please add 13-channel mode's Head #9 to the fixture's matrix. The included channels were Axis ,Slow to Fast.
  - :warning: Please add 13-channel mode's Head #10 to the fixture's matrix. The included channels were Y-axis,Fine-tuning.
  - :warning: Please add 13-channel mode's Head #11 to the fixture's matrix. The included channels were Y-axis, move.
  - :warning: Please add 13-channel mode's Head #12 to the fixture's matrix. The included channels were X-axis,Fine-tuning.
  - :warning: Please add 13-channel mode's Head #13 to the fixture's matrix. The included channels were X-axis, move.


Thank you **Mosse**!