### PR TITLE
Add fixture 'starway/parkollor120hd'

### DIFF
--- a/fixtures/starway/parkollor120hd.json
+++ b/fixtures/starway/parkollor120hd.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "parKollor120HD",
+  "shortName": "parkolor",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["nico plat"],
+    "createDate": "2023-01-18",
+    "lastModifyDate": "2023-01-18"
+  },
+  "links": {
+    "other": [
+      "https://www.star-way.com/parkolor-120hd-3"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "5-pin"
+  },
+  "availableChannels": {
+    "Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Zoom": {
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "narrow",
+        "angleEnd": "wide"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "7 channel",
+      "channels": [
+        "Intensity",
+        "Shutter / Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Zoom"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'starway/parkollor120hd'

### Fixture warnings / errors

* starway/parkollor120hd
  - :warning: Mode '7 channel' should have shortName '7ch' instead of '7 channel'.
  - :warning: Mode '7 channel' should have shortName '7ch' instead of '7 channel'.


Thank you **nico plat**!