### PR TITLE
Add fixture 'chauvet-professional/onair-ip-panel-1'

### DIFF
--- a/fixtures/chauvet-professional/onair-ip-panel-1.json
+++ b/fixtures/chauvet-professional/onair-ip-panel-1.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "onAir IP Panel 1",
+  "categories": ["Other"],
+  "meta": {
+    "authors": ["Anthony Dempsey"],
+    "createDate": "2023-01-26",
+    "lastModifyDate": "2023-01-26"
+  },
+  "links": {
+    "manual": [
+      "https://www.chauvetprofessional.com/wp-content/uploads/2021/05/onAir_IP_Panel_1_UM_Rev2.pdf"
+    ],
+    "productPage": [
+      "https://www.chauvetprofessional.com/products/onair-ip-panel-1/"
+    ],
+    "video": [
+      "https://www.youtube.com/channel/UCjCmnR8ejIE4bjqj6RZL8UA"
+    ]
+  },
+  "availableChannels": {
+    "Red": {
+      "fineChannelAliases": ["Red fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Red 2": {
+      "name": "Red",
+      "fineChannelAliases": ["Red 2 fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "fineChannelAliases": ["Green fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "fineChannelAliases": ["Blue fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "fineChannelAliases": ["White fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Red 2 2": {
+      "name": "Red 2",
+      "fineChannelAliases": ["Red 2 2 fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 2": {
+      "fineChannelAliases": ["Green 2 fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 2": {
+      "fineChannelAliases": ["Blue 2 fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White 2": {
+      "fineChannelAliases": ["White 2 fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Red 3": {
+      "name": "Red",
+      "fineChannelAliases": ["Red 3 fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "16ch",
+      "channels": [
+        "Red 3",
+        "Red 3 fine",
+        "Green",
+        "Green fine",
+        "Blue",
+        "Blue fine",
+        "White",
+        "White fine",
+        "Red 2 2",
+        "Red 2 2 fine",
+        "Green 2",
+        "Green 2 fine",
+        "Blue 2",
+        "Blue 2 fine",
+        "White 2",
+        "White 2 fine"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'chauvet-professional/onair-ip-panel-1'

### Fixture warnings / errors

* chauvet-professional/onair-ip-panel-1
  - :warning: Unused channel(s): red, red fine, red 2, red 2 fine
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Anthony Dempsey**!