### PR TITLE
Change email address

### DIFF
--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at florian-edelmann@online.de. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at flo@open-fixture-library.org. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "open-fixture-library",
   "version": "1.0.0",
   "description": "An open source library for lighting technology's fixture definition files",
-  "author": "Florian Edelmann <florian-edelmann@online.de>",
+  "author": "Florian Edelmann <flo@open-fixture-library.org>",
   "contributors": [
     "Felix Edelmann <fxedel@gmail.com>"
   ],

--- a/ui/components/HelpWantedDialog.vue
+++ b/ui/components/HelpWantedDialog.vue
@@ -177,7 +177,7 @@ export default {
         return `${key}:${separator}${value}`;
       }).join(`\n`);
 
-      return `mailto:florian-edelmann@online.de?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+      return `mailto:flo@open-fixture-library.org?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
     },
   },
   mounted() {

--- a/ui/components/HelpWantedMessage.vue
+++ b/ui/components/HelpWantedMessage.vue
@@ -157,7 +157,7 @@ export default {
 
       const body = bodyLines.join(`\n`);
 
-      return `mailto:florian-edelmann@online.de?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+      return `mailto:flo@open-fixture-library.org?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
     },
   },
 };

--- a/ui/pages/_manufacturerKey/_fixtureKey.vue
+++ b/ui/pages/_manufacturerKey/_fixtureKey.vue
@@ -240,7 +240,7 @@ export default {
     },
     mailtoUrl() {
       const subject = `Feedback for fixture '${this.manufacturerKey}/${this.fixtureKey}'`;
-      return `mailto:florian-edelmann@online.de?subject=${encodeURIComponent(subject)}`;
+      return `mailto:flo@open-fixture-library.org?subject=${encodeURIComponent(subject)}`;
     },
   },
   mounted() {

--- a/ui/pages/about/index.vue
+++ b/ui/pages/about/index.vue
@@ -24,7 +24,7 @@
     <p>See the <a href="https://github.com/OpenLightingProject/open-fixture-library#contribute">project page on GitHub</a> to see how you can help.</p>
 
     <h2 id="contact">Contact</h2>
-    <p><a href="mailto:florian-edelmann@online.de">florian-edelmann@online.de</a> or via <a href="https://github.com/FloEdelmann">GitHub</a></p>
+    <p><a href="mailto:flo@open-fixture-library.org">flo@open-fixture-library.org</a> or via <a href="https://github.com/FloEdelmann">GitHub</a></p>
 
     <h2>Privacy</h2>
     <p>We respect users' privacy and thus collect as few data as possible. No personal data about our visitors is stored on our server or sent to other sites without users' consent. The communication between users' browsers and our server is encrypted via HTTPS. Videos are embetted with <a href="https://github.com/heiseonline/embetty">embetty</a>, so no information is sent from users' browsers to the video hosting platform (e.g. YouTube) until the video is played. The fixture editor only uses the entered data to open a pull request in our public GitHub repository; this means that the chosen author name and GitHub username – the only personal data – will be made public. Unfinished fixtures and the last submitted author name / GitHub username are saved locally in users' browsers. Other technical measures to improve privacy and security <a href="https://observatory.mozilla.org/analyze/open-fixture-library.org">are implemented</a>.</p>


### PR DESCRIPTION
<florian-edelmann@online.de> will not be reachable anymore later this year. This pull request changes all mentions of the email address to a new OFL-specific email address: <flo@open-fixture-library.org>