### PR TITLE
Add fixture 'prolights/arcpar7'

### DIFF
--- a/fixtures/prolights/arcpar7.json
+++ b/fixtures/prolights/arcpar7.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "ARCPAR7",
+  "shortName": "ARCPAR7",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["joannes"],
+    "createDate": "2023-02-05",
+    "lastModifyDate": "2023-02-05"
+  },
+  "links": {
+    "manual": [
+      "https://shop.esl-france.com/projecteurs-en-saillie/22956-projecteur-wash-leds-ip65-arcpar7-7x8w-rgbw-fc-15-archwork.html"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "30Hz"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "6CH",
+      "shortName": "mode1",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture 'prolights/arcpar7'

### Fixture warnings / errors

* prolights/arcpar7
  - :x: File does not match schema: fixture/modes/0/shortName "mode1" must match pattern "^((?!mode)(?!Mode).)*$"


Thank you **joannes**!