### PR TITLE
Update links

### DIFF
--- a/fixtures/chauvet-professional/colorado-1-solo.json
+++ b/fixtures/chauvet-professional/colorado-1-solo.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Da Graca Neves Eric", "Ken Harris"],
     "createDate": "2022-04-19",
-    "lastModifyDate": "2023-02-28"
+    "lastModifyDate": "2022-04-19"
   },
   "links": {
     "productPage": [

--- a/fixtures/chauvet-professional/colorado-1-solo.json
+++ b/fixtures/chauvet-professional/colorado-1-solo.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Da Graca Neves Eric", "Ken Harris"],
     "createDate": "2022-04-19",
-    "lastModifyDate": "2022-04-19"
+    "lastModifyDate": "2023-02-28"
   },
   "links": {
     "productPage": [

--- a/fixtures/chauvet-professional/colorado-1-solo.json
+++ b/fixtures/chauvet-professional/colorado-1-solo.json
@@ -10,10 +10,10 @@
   },
   "links": {
     "productPage": [
-      "https://www.chauvetprofessional.eu/products/colorado-1-solo/"
+      "https://www.chauvetprofessional.com/products/colorado-1-solo/"
     ],
     "manual": [
-      "https://www.chauvetprofessional.eu/wp-content/uploads//2018/01/COLORado_1_Solo_UM_Rev8.pdf"
+      "https://www.chauvetprofessional.com/wp-content/uploads//2018/01/COLORado_1_Solo_UM_Rev8.pdf"
     ],
     "video": [
       "https://www.youtube.com/watch?v=0hqRufKRupk"


### PR DESCRIPTION
Found by #999. Replace https://www.chauvetprofessional.eu/ with https://www.chauvetprofessional.com/

![Screenshot 2023-02-28 at 21 54 41](https://user-images.githubusercontent.com/7257092/221990521-6e13aff4-eca6-47e0-bc0a-170b82621438.png)
