### PR TITLE
Add fixture `5star-systems/led-bar-48`

### DIFF
--- a/fixtures/5star-systems/led-bar-48.json
+++ b/fixtures/5star-systems/led-bar-48.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Led bar 48",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["Maxim"],
+    "createDate": "2023-04-03",
+    "lastModifyDate": "2023-04-03"
+  },
+  "links": {
+    "video": [
+      "https://www.youtube.com/watch?v=jEpczvU_JFE&ab_channel=NekitDesigner"
+    ]
+  },
+  "availableChannels": {
+    "Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "defaultValue": "100%",
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "0Hz",
+        "speedEnd": "10Hz"
+      }
+    },
+    "Cyan": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Cyan"
+      }
+    },
+    "Magenta": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Magenta"
+      }
+    },
+    "Yellow": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Yellow"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speed": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Led bar",
+      "channels": [
+        "Intensity",
+        "Strobe",
+        "Cyan",
+        "Magenta",
+        "Yellow",
+        "White",
+        "Color Macros"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `5star-systems/led-bar-48`

### Fixture warnings / errors

* 5star-systems/led-bar-48
  - :x: Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Maxim**!