### PR TITLE
Add fixture `led-bar-24x4w-rgbw/ledbar-58`

### DIFF
--- a/fixtures/led-bar-24x4w-rgbw/ledbar-58.json
+++ b/fixtures/led-bar-24x4w-rgbw/ledbar-58.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LedBar 58",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["Maxim"],
+    "createDate": "2023-04-03",
+    "lastModifyDate": "2023-04-03"
+  },
+  "links": {
+    "manual": [
+      "https://onyxfixturefinder.com/fixture/Yuer+Lighting/LED+Bar+24x4w+RGBW"
+    ]
+  },
+  "availableChannels": {
+    "Intensity": {
+      "fineChannelAliases": ["Intensity fine", "Intensity fine^2"],
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "0Hz",
+        "speedEnd": "10Hz"
+      }
+    },
+    "Cyan": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Cyan"
+      }
+    },
+    "Magenta": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Magenta"
+      }
+    },
+    "Yellow": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Yellow"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "LED Bar 24x4w RGBW",
+      "channels": [
+        "Intensity",
+        "Strobe",
+        "Cyan",
+        "Magenta",
+        "Yellow",
+        "White",
+        "Color Macros"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -283,6 +283,10 @@
     "name": "Laserworld",
     "website": "https://www.laserworld.com/en/"
   },
+  "led-bar-24x4w-rgbw": {
+    "name": "LED Bar 24x4w RGBW",
+    "rdmId": 1
+  },
   "ledj": {
     "name": "LEDJ",
     "comment": "Brand of the Prolight Concepts Group.",


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `led-bar-24x4w-rgbw/ledbar-58`

### Fixture warnings / errors

* led-bar-24x4w-rgbw/ledbar-58
  - :x: Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - :warning: Unused channel(s): intensity fine, intensity fine^2
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Maxim**!