### PR TITLE
Add fixture `led-zoom/2-0-led-19x15-wash-zoom-light`

### DIFF
--- a/fixtures/led-zoom/2-0-led-19x15-wash-zoom-light.json
+++ b/fixtures/led-zoom/2-0-led-19x15-wash-zoom-light.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "2.0 led 19x15 wash_zoom light",
+  "shortName": "2.0 ledwash",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Szabó Bence"],
+    "createDate": "2023-05-06",
+    "lastModifyDate": "2023-05-06"
+  },
+  "links": {
+    "other": [
+      "https://fenytechnikashop.hu/LED-Wash-19x15W-ROBOTLAMPA"
+    ]
+  },
+  "physical": {
+    "dimensions": [300, 400, 200],
+    "weight": 7.5,
+    "power": 350,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "colorTemperature": 8500
+    },
+    "lens": {
+      "degreesMinMax": [8, 60]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "180deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red Group1": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green Group1": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue Group1": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White Group1": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Shutter": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "fast",
+        "speedEnd": "slow reverse"
+      }
+    },
+    "Focus": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Function": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Functional mode speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Panfine": {
+      "capability": {
+        "type": "PanContinuous",
+        "speed": "fast CW"
+      }
+    },
+    "Tiltfine": {
+      "capability": {
+        "type": "TiltContinuous",
+        "speed": "fast CCW"
+      }
+    },
+    "Rest255": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Total": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Red Group2": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green Group2": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue Group2": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White Group2": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Red Group3": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green Group3": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue Group3": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White Group3": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "16 channel",
+      "shortName": "16CH",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Pan/Tilt Speed",
+        "Dimmer",
+        "Red Group1",
+        "Green Group1",
+        "Blue Group1",
+        "White Group1",
+        "Shutter",
+        "Focus",
+        "Function",
+        "Functional mode speed",
+        "Panfine",
+        "Tiltfine",
+        "Rest255",
+        "Total"
+      ]
+    },
+    {
+      "name": "24 channel",
+      "shortName": "24CH",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Pan/Tilt Speed",
+        "Dimmer",
+        "Red Group1",
+        "Green Group1",
+        "Blue Group1",
+        "White Group1",
+        "Red Group2",
+        "Green Group2",
+        "Blue Group2",
+        "White Group2",
+        "Red Group3",
+        "Green Group3",
+        "Blue Group3",
+        "White Group3",
+        "Shutter",
+        "Focus",
+        "Function",
+        "Functional mode speed",
+        "Panfine",
+        "Tiltfine",
+        "Rest255",
+        "Total"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -287,6 +287,11 @@
     "name": "Laserworld",
     "website": "https://www.laserworld.com/en/"
   },
+  "led-zoom": {
+    "name": "Led Zoom",
+    "comment": "Led Zoom",
+    "website": "https://www.made-in-china.com/price/led-light-price.html?utm_source=google&utm_medium=cpc&utm_term=dingtui&acc=4650042892&cpn=18504651814-141666572523&tgt=kwd-10431761&net=g&dev=c-&gid=Cj0KCQjw9deiBhC1ARIsAHLjR2ALuhNmZzf6rF_MpjMpSGejQpwiffBcDAV9_umn4EndCKcOQLiTF_saAuzfEALw_wcB&kwd=led%20light&mtp=p&gad=1&gclid=Cj0KCQjw9deiBhC1ARIsAHLjR2ALuhNmZzf6rF_MpjMpSGejQpwiffBcDAV9_umn4EndCKcOQLiTF_saAuzfEALw_wcB"
+  },
   "ledj": {
     "name": "LEDJ",
     "comment": "Brand of the Prolight Concepts Group.",


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `led-zoom/2-0-led-19x15-wash-zoom-light`

### Fixture warnings / errors

* led-zoom/2-0-led-19x15-wash-zoom-light
  - :x: Capability 'Strobe fast…slow reverse' (0…255) in channel 'Shutter' uses different signs (+ or –) in speed (maybe behind a keyword). Consider splitting it into several capabilities.
  - :warning: Mode '16 channel' should have shortName '16ch' instead of '16CH'.
  - :warning: Mode '16 channel' should have shortName '16ch' instead of '16CH'.
  - :warning: Mode '24 channel' should have shortName '24ch' instead of '24CH'.
  - :warning: Mode '24 channel' should have shortName '24ch' instead of '24CH'.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Szabó Bence**!