### PR TITLE
Add fixture `worldlite/rgb-patterns`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -513,5 +513,8 @@
     "name": "Venue",
     "comment": "Venue by Proline",
     "website": "https://venuelightingeffects.com/"
+  },
+  "worldlite": {
+    "name": "WorldLite"
   }
 }

--- a/fixtures/worldlite/rgb-patterns.json
+++ b/fixtures/worldlite/rgb-patterns.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "RGB patterns",
+  "categories": ["Laser"],
+  "meta": {
+    "authors": ["Totti"],
+    "createDate": "2023-05-21",
+    "lastModifyDate": "2023-05-21",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2023-05-21",
+      "comment": "created by Q Light Controller Plus (version 4.12.7)"
+    }
+  },
+  "physical": {
+    "dimensions": [252, 71, 165],
+    "weight": 2,
+    "power": 40,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Mode Selection": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 63],
+          "type": "Effect",
+          "effectName": "Closed Light mode"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "Effect",
+          "effectName": "Auto Mode"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "Effect",
+          "effectName": "Sound Mode",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Pattern selection/auto & sound mode": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 63],
+          "type": "Effect",
+          "effectName": "Auto/sound mode 1",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "Effect",
+          "effectName": "Auto/sound mode 3",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "Effect",
+          "effectName": "Auto/sound mode 4",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Angle Control": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "Rotation angle selection",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "Positive rotation speed",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "Reverse rotation speed",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        }
+      ]
+    },
+    "Horizontal angle": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "Pan",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Horizontal flip position selection"
+        },
+        {
+          "dmxRange": [128, 255],
+          "type": "Pan",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Horizontal flip speed selection"
+        }
+      ]
+    },
+    "Vertical angle": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 124],
+          "type": "Tilt",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Vertical flip position"
+        },
+        {
+          "dmxRange": [125, 255],
+          "type": "Tilt",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Vertical flip speed selection"
+        }
+      ]
+    },
+    "Horizontal position": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "Pan",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Horizontal position selection"
+        },
+        {
+          "dmxRange": [128, 255],
+          "type": "Pan",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Horizontal movement speed"
+        }
+      ]
+    },
+    "Vertical position": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "Tilt",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Vertical position selection"
+        },
+        {
+          "dmxRange": [128, 255],
+          "type": "Tilt",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Vertical movement speed selection"
+        }
+      ]
+    },
+    "Patern sisze control": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 63],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "Fixed size"
+        },
+        {
+          "dmxRange": [64, 127],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Small to large speed"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Large to small speed"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Size zoom speed"
+        }
+      ]
+    },
+    "Color control": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 63],
+          "type": "ColorPreset",
+          "comment": "Monochrome color selection"
+        },
+        {
+          "dmxRange": [64, 127],
+          "type": "ColorPreset",
+          "comment": "Color selection"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "ColorPreset",
+          "comment": "Monochrome auto"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "ColorPreset",
+          "comment": "Color mixing"
+        }
+      ]
+    },
+    "Node control": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "Generic",
+          "comment": "Pattern has dots and lines"
+        },
+        {
+          "dmxRange": [128, 255],
+          "type": "Generic",
+          "comment": "Dotted pattern, wireless strip"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "1",
+      "channels": [
+        "Mode Selection",
+        "Pattern selection/auto & sound mode",
+        "Angle Control",
+        "Horizontal angle",
+        "Vertical angle",
+        "Horizontal position",
+        "Vertical position",
+        "Patern sisze control",
+        "Color control",
+        "Node control"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `worldlite/rgb-patterns`

### Fixture warnings / errors

* worldlite/rgb-patterns
  - :x: dmxRanges must be adjacent in capabilities 'Closed Light mode' (0…63) and 'Auto Mode' (128…191) in channel 'Mode Selection'.
  - :x: dmxRanges must be adjacent in capabilities 'Auto/sound mode 1' (0…63) and 'Auto/sound mode 3' (128…191) in channel 'Pattern selection/auto & sound mode'.
  - :x: Capability 'Unknown wheel slot (Fixed size)' (0…63) in channel 'Patern sisze control' does not explicitly reference any wheel, but the default wheel 'Patern sisze control' (through the channel name) does not exist.
  - :x: Capability 'Unknown wheel slot (Small to large speed)' (64…127) in channel 'Patern sisze control' does not explicitly reference any wheel, but the default wheel 'Patern sisze control' (through the channel name) does not exist.
  - :x: Capability 'Unknown wheel slot (Large to small speed)' (128…191) in channel 'Patern sisze control' does not explicitly reference any wheel, but the default wheel 'Patern sisze control' (through the channel name) does not exist.
  - :x: Capability 'Unknown wheel slot (Size zoom speed)' (192…255) in channel 'Patern sisze control' does not explicitly reference any wheel, but the default wheel 'Patern sisze control' (through the channel name) does not exist.
  - :warning: Please check if manufacturer is correct and add manufacturer URL.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.
  - :warning: Category 'Moving Head' suggested since there are pan and tilt channels.
  - :warning: Category 'Scanner' suggested since there are pan and tilt channels.
  - :warning: Category 'Barrel Scanner' suggested since there are pan and tilt channels.


### User comment

https://www.amazon.com/-/es/escenario-WorldLite-discotecas-escenarios-iluminaci%C3%B3n/dp/B09LSFH5CQ/ref=sr_1_9?__mk_es_US=%C3%85M%C3%85%C5%BD%C3%95%C3%91&crid=4QH551UOPB0&keywords=dj+laser+rgb&qid=1670421458&sprefix=dj+laser+rgb%2Caps%2C324&sr=8-9

Thank you **Totti**!