### PR TITLE
Update some fixtures' author name

### DIFF
--- a/docs/fixture-format.md
+++ b/docs/fixture-format.md
@@ -63,6 +63,8 @@ A fixture's `shortName` must be unique amongst all fixtures.
 
 The `physical` section describes properties not directly used in the DMX protocol, but often in lighting control software to display a preview of the fixtures in action.
 
+The `lastModifyDate` should *NOT* be updated when updating fixture data that is not related to the fixtures capabilities or attributes. This includes things such as changing an author's names, updating links, or updating the order of channel modes.
+
 
 ### Modes
 
@@ -70,7 +72,7 @@ A fixture can have multiple *modes* (also sometimes called *personalities*) like
 
 A mode can contain the `physical` property to override specific physical data of the fixture. E.g. one mode could set the `power` value different than the fixture default.
 
-A mode's `shortName` must be unique amongst all modes of the respective fixture.
+A mode's `shortName` must be unique amongst all modes of the respective fixture. The `shortname` should be similar to what is displayed on the device's LCD/LED displays if that information is known (e.g. from the manual). If not known, the standard `1-ch` format should be followed.
 
 
 ### Channels

--- a/fixtures/american-dj/mega-tripar-profile.json
+++ b/fixtures/american-dj/mega-tripar-profile.json
@@ -3,9 +3,9 @@
   "name": "Mega TRIPAR Profile",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["Glenn Meder"],
+    "authors": ["Glenn Meder", "Ryan Goodwin"],
     "createDate": "2019-07-13",
-    "lastModifyDate": "2019-07-13"
+    "lastModifyDate": "2023-05-15"
   },
   "links": {
     "manual": [
@@ -413,14 +413,14 @@
   "modes": [
     {
       "name": "1-channel",
-      "shortName": "Ch.01",
+      "shortName": "1ch",
       "channels": [
         "Color macros"
       ]
     },
     {
       "name": "2-channel",
-      "shortName": "Ch.02",
+      "shortName": "2ch",
       "channels": [
         "Color macros",
         "Dimmer"
@@ -428,7 +428,7 @@
     },
     {
       "name": "3-channel",
-      "shortName": "Ch.03",
+      "shortName": "3ch",
       "channels": [
         "Red",
         "Green",
@@ -437,7 +437,7 @@
     },
     {
       "name": "4-channel",
-      "shortName": "Ch.04",
+      "shortName": "4ch",
       "channels": [
         "Red",
         "Green",
@@ -447,7 +447,7 @@
     },
     {
       "name": "5-channel",
-      "shortName": "CH.05",
+      "shortName": "5ch",
       "channels": [
         "Red",
         "Green",
@@ -458,7 +458,7 @@
     },
     {
       "name": "6-channel",
-      "shortName": "Ch.06",
+      "shortName": "6ch",
       "channels": [
         "Red",
         "Green",
@@ -470,7 +470,7 @@
     },
     {
       "name": "7-channel",
-      "shortName": "Ch.07",
+      "shortName": "7ch",
       "channels": [
         "Red",
         "Green",

--- a/fixtures/american-dj/mega-tripar-profile.json
+++ b/fixtures/american-dj/mega-tripar-profile.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Glenn Meder", "Ryan Goodwin"],
     "createDate": "2019-07-13",
-    "lastModifyDate": "2023-05-15"
+    "lastModifyDate": "2023-05-25"
   },
   "links": {
     "manual": [

--- a/fixtures/american-dj/mega-tripar-profile.json
+++ b/fixtures/american-dj/mega-tripar-profile.json
@@ -3,9 +3,9 @@
   "name": "Mega TRIPAR Profile",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["Glenn Meder"],
+    "authors": ["Glenn Meder", "Ryan Goodwin"],
     "createDate": "2019-07-13",
-    "lastModifyDate": "2019-07-13"
+    "lastModifyDate": "2023-05-25"
   },
   "links": {
     "manual": [

--- a/fixtures/american-dj/mega-tripar-profile.json
+++ b/fixtures/american-dj/mega-tripar-profile.json
@@ -3,9 +3,9 @@
   "name": "Mega TRIPAR Profile",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["Glenn Meder", "Ryan Goodwin"],
+    "authors": ["Glenn Meder"],
     "createDate": "2019-07-13",
-    "lastModifyDate": "2023-05-25"
+    "lastModifyDate": "2019-07-13"
   },
   "links": {
     "manual": [
@@ -413,14 +413,14 @@
   "modes": [
     {
       "name": "1-channel",
-      "shortName": "1ch",
+      "shortName": "Ch.01",
       "channels": [
         "Color macros"
       ]
     },
     {
       "name": "2-channel",
-      "shortName": "2ch",
+      "shortName": "Ch.02",
       "channels": [
         "Color macros",
         "Dimmer"
@@ -428,7 +428,7 @@
     },
     {
       "name": "3-channel",
-      "shortName": "3ch",
+      "shortName": "Ch.03",
       "channels": [
         "Red",
         "Green",
@@ -437,7 +437,7 @@
     },
     {
       "name": "4-channel",
-      "shortName": "4ch",
+      "shortName": "Ch.04",
       "channels": [
         "Red",
         "Green",
@@ -447,7 +447,7 @@
     },
     {
       "name": "5-channel",
-      "shortName": "5ch",
+      "shortName": "Ch.05",
       "channels": [
         "Red",
         "Green",
@@ -458,7 +458,7 @@
     },
     {
       "name": "6-channel",
-      "shortName": "6ch",
+      "shortName": "Ch.06",
       "channels": [
         "Red",
         "Green",
@@ -470,7 +470,7 @@
     },
     {
       "name": "7-channel",
-      "shortName": "7ch",
+      "shortName": "Ch.07",
       "channels": [
         "Red",
         "Green",

--- a/fixtures/american-dj/mod-hex100.json
+++ b/fixtures/american-dj/mod-hex100.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["K", "Ryan Goodwin"],
     "createDate": "2023-04-24",
-    "lastModifyDate": "2023-05-25"
+    "lastModifyDate": "2023-04-24"
   },
   "links": {
     "manual": [

--- a/fixtures/american-dj/mod-hex100.json
+++ b/fixtures/american-dj/mod-hex100.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["K", "Ryan Goodwin"],
     "createDate": "2023-04-24",
-    "lastModifyDate": "2023-05-24"
+    "lastModifyDate": "2023-05-25"
   },
   "links": {
     "manual": [

--- a/fixtures/american-dj/mod-hex100.json
+++ b/fixtures/american-dj/mod-hex100.json
@@ -3,9 +3,9 @@
   "name": "MOD HEX100",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["K", "CGBassPlayer"],
+    "authors": ["K", "Ryan Goodwin"],
     "createDate": "2023-04-24",
-    "lastModifyDate": "2023-04-24"
+    "lastModifyDate": "2023-05-24"
   },
   "links": {
     "manual": [
@@ -15,7 +15,7 @@
       "https://www.adj.com/mod-hex100"
     ],
     "video": [
-      "https://youtu.be/-X430bUWt50"
+      "https://www.youtube.com/watch?v=-X430bUWt50"
     ]
   },
   "physical": {

--- a/fixtures/bitfocus/companion-v2.json
+++ b/fixtures/bitfocus/companion-v2.json
@@ -4,9 +4,9 @@
   "shortName": "B-Companion",
   "categories": ["Other"],
   "meta": {
-    "authors": ["CGBassPlayer"],
+    "authors": ["Ryan Goodwin"],
     "createDate": "2023-05-06",
-    "lastModifyDate": "2023-05-06"
+    "lastModifyDate": "2023-05-24"
   },
   "comment": "Fixture to control Companion software via Artnet/DMX",
   "links": {

--- a/fixtures/bitfocus/companion-v2.json
+++ b/fixtures/bitfocus/companion-v2.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
   "name": "Companion v2.0",
-  "shortName": "B-Companion",
   "categories": ["Other"],
   "meta": {
     "authors": ["Ryan Goodwin"],

--- a/fixtures/bitfocus/companion-v2.json
+++ b/fixtures/bitfocus/companion-v2.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Ryan Goodwin"],
     "createDate": "2023-05-06",
-    "lastModifyDate": "2023-05-25"
+    "lastModifyDate": "2023-05-06"
   },
   "comment": "Fixture to control Companion software via Artnet/DMX",
   "links": {

--- a/fixtures/bitfocus/companion-v2.json
+++ b/fixtures/bitfocus/companion-v2.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Ryan Goodwin"],
     "createDate": "2023-05-06",
-    "lastModifyDate": "2023-05-24"
+    "lastModifyDate": "2023-05-25"
   },
   "comment": "Fixture to control Companion software via Artnet/DMX",
   "links": {

--- a/fixtures/briteq/beamspot1-dmx-fc.json
+++ b/fixtures/briteq/beamspot1-dmx-fc.json
@@ -193,7 +193,7 @@
   "modes": [
     {
       "name": "RGB + Functions",
-      "shortName": "04CH RGB+DIM",
+      "shortName": "4ch-RGB",
       "channels": [
         "Red",
         "Green",
@@ -203,7 +203,7 @@
     },
     {
       "name": "RGBW",
-      "shortName": "04CH RGBW",
+      "shortName": "4ch-RGBW",
       "channels": [
         "Red",
         "Green",
@@ -213,7 +213,7 @@
     },
     {
       "name": "RGBW + Functions",
-      "shortName": "05CH RGBW+DIM",
+      "shortName": "5ch-RGBW",
       "channels": [
         "Red",
         "Green",
@@ -224,7 +224,7 @@
     },
     {
       "name": "RGBW + Master + Sound/Strobe",
-      "shortName": "06CH",
+      "shortName": "6ch-sound",
       "channels": [
         "Red",
         "Green",
@@ -236,7 +236,7 @@
     },
     {
       "name": "RGBW + Master + Strobe",
-      "shortName": "06CH+",
+      "shortName": "6ch",
       "channels": [
         "Red",
         "Green",
@@ -248,7 +248,7 @@
     },
     {
       "name": "Master + Strobe + Programs + RGBW",
-      "shortName": "07CH",
+      "shortName": "7ch",
       "channels": [
         "Master Dimmer",
         "Extended Strobe",

--- a/fixtures/briteq/beamspot1-dmx-fc.json
+++ b/fixtures/briteq/beamspot1-dmx-fc.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Aleksey Khoroshev", "Ryan Goodwin"],
     "createDate": "2020-01-14",
-    "lastModifyDate": "2023-05-15"
+    "lastModifyDate": "2023-05-25"
   },
   "links": {
     "manual": [

--- a/fixtures/briteq/beamspot1-dmx-fc.json
+++ b/fixtures/briteq/beamspot1-dmx-fc.json
@@ -3,9 +3,9 @@
   "name": "BEAMSPOT1-DMX FC",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["Aleksey Khoroshev", "Ryan Goodwin"],
+    "authors": ["Aleksey Khoroshev"],
     "createDate": "2020-01-14",
-    "lastModifyDate": "2023-05-25"
+    "lastModifyDate": "2020-01-14"
   },
   "links": {
     "manual": [
@@ -193,7 +193,7 @@
   "modes": [
     {
       "name": "RGB + Functions",
-      "shortName": "4ch-RGB",
+      "shortName": "04CH RGB+DIM",
       "channels": [
         "Red",
         "Green",
@@ -203,7 +203,7 @@
     },
     {
       "name": "RGBW",
-      "shortName": "4ch-RGBW",
+      "shortName": "04CH RGBW",
       "channels": [
         "Red",
         "Green",
@@ -213,7 +213,7 @@
     },
     {
       "name": "RGBW + Functions",
-      "shortName": "5ch-RGBW",
+      "shortName": "05CH RGBW+DIM",
       "channels": [
         "Red",
         "Green",
@@ -224,7 +224,7 @@
     },
     {
       "name": "RGBW + Master + Sound/Strobe",
-      "shortName": "6ch-sound",
+      "shortName": "06CH",
       "channels": [
         "Red",
         "Green",
@@ -236,7 +236,7 @@
     },
     {
       "name": "RGBW + Master + Strobe",
-      "shortName": "6ch",
+      "shortName": "06CH+",
       "channels": [
         "Red",
         "Green",
@@ -248,7 +248,7 @@
     },
     {
       "name": "Master + Strobe + Programs + RGBW",
-      "shortName": "7ch",
+      "shortName": "07CH",
       "channels": [
         "Master Dimmer",
         "Extended Strobe",

--- a/fixtures/briteq/beamspot1-dmx-fc.json
+++ b/fixtures/briteq/beamspot1-dmx-fc.json
@@ -3,9 +3,9 @@
   "name": "BEAMSPOT1-DMX FC",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["Aleksey Khoroshev"],
+    "authors": ["Aleksey Khoroshev", "Ryan Goodwin"],
     "createDate": "2020-01-14",
-    "lastModifyDate": "2020-01-14"
+    "lastModifyDate": "2023-05-15"
   },
   "links": {
     "manual": [

--- a/fixtures/contest/irled64-18x12six.json
+++ b/fixtures/contest/irled64-18x12six.json
@@ -3,9 +3,9 @@
   "name": "irLED64 18x12SIX",
   "categories": ["Dimmer", "Color Changer"],
   "meta": {
-    "authors": ["Edrig", "CGBassPlayer"],
+    "authors": ["Edrig", "Ryan Goodwin"],
     "createDate": "2023-04-24",
-    "lastModifyDate": "2023-04-24"
+    "lastModifyDate": "2023-05-24"
   },
   "links": {
     "manual": [

--- a/fixtures/contest/irled64-18x12six.json
+++ b/fixtures/contest/irled64-18x12six.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Edrig", "Ryan Goodwin"],
     "createDate": "2023-04-24",
-    "lastModifyDate": "2023-05-25"
+    "lastModifyDate": "2023-04-24"
   },
   "links": {
     "manual": [

--- a/fixtures/contest/irled64-18x12six.json
+++ b/fixtures/contest/irled64-18x12six.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Edrig", "Ryan Goodwin"],
     "createDate": "2023-04-24",
-    "lastModifyDate": "2023-05-24"
+    "lastModifyDate": "2023-05-25"
   },
   "links": {
     "manual": [

--- a/fixtures/eurolite/led-z-200-tcl.json
+++ b/fixtures/eurolite/led-z-200-tcl.json
@@ -3,9 +3,9 @@
   "name": "LED Z-200 TCL",
   "categories": ["Effect"],
   "meta": {
-    "authors": ["Heiko Fanieng", "CGBassPlayer"],
+    "authors": ["Heiko Fanieng", "Ryan Goodwin"],
     "createDate": "2023-05-07",
-    "lastModifyDate": "2023-05-07"
+    "lastModifyDate": "2023-05-24"
   },
   "links": {
     "manual": [

--- a/fixtures/eurolite/led-z-200-tcl.json
+++ b/fixtures/eurolite/led-z-200-tcl.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Heiko Fanieng", "Ryan Goodwin"],
     "createDate": "2023-05-07",
-    "lastModifyDate": "2023-05-25"
+    "lastModifyDate": "2023-05-07"
   },
   "links": {
     "manual": [

--- a/fixtures/eurolite/led-z-200-tcl.json
+++ b/fixtures/eurolite/led-z-200-tcl.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Heiko Fanieng", "Ryan Goodwin"],
     "createDate": "2023-05-07",
-    "lastModifyDate": "2023-05-24"
+    "lastModifyDate": "2023-05-25"
   },
   "links": {
     "manual": [

--- a/fixtures/generic/rgbwauv-fader.json
+++ b/fixtures/generic/rgbwauv-fader.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Shuichi", "Flo Edelmann", "Ryan Goodwin"],
     "createDate": "2021-09-19",
-    "lastModifyDate": "2023-05-24"
+    "lastModifyDate": "2023-04-20"
   },
   "availableChannels": {
     "Red": {

--- a/fixtures/generic/rgbwauv-fader.json
+++ b/fixtures/generic/rgbwauv-fader.json
@@ -4,9 +4,9 @@
   "shortName": "RGBWAUV",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["Shuichi", "Flo Edelmann", "CGBassPlayer"],
+    "authors": ["Shuichi", "Flo Edelmann", "Ryan Goodwin"],
     "createDate": "2021-09-19",
-    "lastModifyDate": "2023-04-20"
+    "lastModifyDate": "2023-05-24"
   },
   "availableChannels": {
     "Red": {

--- a/fixtures/showtec/performer-2500.json
+++ b/fixtures/showtec/performer-2500.json
@@ -3,9 +3,9 @@
   "name": "Performer 2500",
   "categories": ["Dimmer"],
   "meta": {
-    "authors": ["purple", "Luke Nelson", "Ryan Goodwin"],
+    "authors": ["purple", "Luke Nelson"],
     "createDate": "2022-10-19",
-    "lastModifyDate": "2023-05-25"
+    "lastModifyDate": "2022-10-19"
   },
   "links": {
     "productPage": [
@@ -159,23 +159,23 @@
   },
   "modes": [
     {
-      "name": "UNO",
-      "shortName": "1ch",
+      "name": "1-channel",
+      "shortName": "UNO",
       "channels": [
         "Master Dimmer"
       ]
     },
     {
-      "name": "DOS",
-      "shortName": "2ch",
+      "name": "2-channel",
+      "shortName": "DOS",
       "channels": [
         "Master Dimmer",
         "Master Dimmer fine"
       ]
     },
     {
-      "name": "VW.D",
-      "shortName": "3ch",
+      "name": "3-channel",
+      "shortName": "VW.D",
       "channels": [
         "Master Dimmer",
         "Warm White",
@@ -183,8 +183,8 @@
       ]
     },
     {
-      "name": "VW.F",
-      "shortName": "6ch",
+      "name": "6-channel",
+      "shortName": "VW.F",
       "channels": [
         "Master Dimmer",
         "Master Dimmer fine",
@@ -195,8 +195,8 @@
       ]
     },
     {
-      "name": "STD.P",
-      "shortName": "8ch",
+      "name": "8-channel",
+      "shortName": "STD.P",
       "channels": [
         "Master Dimmer",
         "Master Dimmer fine",

--- a/fixtures/showtec/performer-2500.json
+++ b/fixtures/showtec/performer-2500.json
@@ -3,7 +3,7 @@
   "name": "Performer 2500",
   "categories": ["Dimmer"],
   "meta": {
-    "authors": ["purple", "Luke Nelson"],
+    "authors": ["purple", "Luke Nelson", "Ryan Goodwin"],
     "createDate": "2022-10-19",
     "lastModifyDate": "2022-10-19"
   },
@@ -14,7 +14,9 @@
     "manual": [
       "https://www.highlite.com/en/mwdownloads/download/link/id/17429015/"
     ],
-    "video": ["https://vimeo.com/439925462"]
+    "video": [
+      "https://vimeo.com/439925462"
+    ]
   },
   "physical": {
     "dimensions": [450, 380, 470],
@@ -157,22 +159,32 @@
   },
   "modes": [
     {
-      "name": "8-channel",
-      "shortName": "STD.P",
+      "name": "UNO",
+      "shortName": "1ch",
       "channels": [
-        "Master Dimmer",
-        "Master Dimmer fine",
-        "Warm White",
-        "Warm White fine",
-        "Natural White",
-        "Natural White fine",
-        "CCT",
-        "Strobe"
+        "Master Dimmer"
       ]
     },
     {
-      "name": "6-channel",
-      "shortName": "VW.F",
+      "name": "DOS",
+      "shortName": "2ch",
+      "channels": [
+        "Master Dimmer",
+        "Master Dimmer fine"
+      ]
+    },
+    {
+      "name": "VW.D",
+      "shortName": "3ch",
+      "channels": [
+        "Master Dimmer",
+        "Warm White",
+        "Natural White"
+      ]
+    },
+    {
+      "name": "VW.F",
+      "shortName": "6ch",
       "channels": [
         "Master Dimmer",
         "Master Dimmer fine",
@@ -183,27 +195,17 @@
       ]
     },
     {
-      "name": "3-channel",
-      "shortName": "VW.D",
+      "name": "STD.P",
+      "shortName": "8ch",
       "channels": [
         "Master Dimmer",
+        "Master Dimmer fine",
         "Warm White",
-        "Natural White"
-      ]
-    },
-    {
-      "name": "2-channel",
-      "shortName": "DOS",
-      "channels": [
-        "Master Dimmer",
-        "Master Dimmer fine"
-      ]
-    },
-    {
-      "name": "1-channel",
-      "shortName": "UNO",
-      "channels": [
-        "Master Dimmer"
+        "Warm White fine",
+        "Natural White",
+        "Natural White fine",
+        "CCT",
+        "Strobe"
       ]
     }
   ]

--- a/fixtures/showtec/performer-2500.json
+++ b/fixtures/showtec/performer-2500.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["purple", "Luke Nelson", "Ryan Goodwin"],
     "createDate": "2022-10-19",
-    "lastModifyDate": "2022-10-19"
+    "lastModifyDate": "2023-05-25"
   },
   "links": {
     "productPage": [

--- a/fixtures/uking/zq-b20-mini-spider-light.json
+++ b/fixtures/uking/zq-b20-mini-spider-light.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Ryan Goodwin"],
     "createDate": "2023-04-24",
-    "lastModifyDate": "2023-05-24"
+    "lastModifyDate": "2023-05-25"
   },
   "links": {
     "productPage": [

--- a/fixtures/uking/zq-b20-mini-spider-light.json
+++ b/fixtures/uking/zq-b20-mini-spider-light.json
@@ -4,9 +4,9 @@
   "shortName": "ZQ-B20-MiniSpider",
   "categories": ["Effect"],
   "meta": {
-    "authors": ["CGBassPlayer"],
+    "authors": ["Ryan Goodwin"],
     "createDate": "2023-04-24",
-    "lastModifyDate": "2023-04-24"
+    "lastModifyDate": "2023-05-24"
   },
   "links": {
     "productPage": [

--- a/fixtures/uking/zq-b20-mini-spider-light.json
+++ b/fixtures/uking/zq-b20-mini-spider-light.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Ryan Goodwin"],
     "createDate": "2023-04-24",
-    "lastModifyDate": "2023-05-25"
+    "lastModifyDate": "2023-04-24"
   },
   "links": {
     "productPage": [


### PR DESCRIPTION
- Updated fixtures I have worked on to use `Ryan Goodwin` instead of `CGBassPlayer`
- Add note for dealing with `shortName` on fixture modes and `lastModifyDate`
- Remove short-name for Bitfocus/Companion-v2
- Update MOD HEX 100 video link to be embedded on the site