### PR TITLE
Add fixture `uking/zq-b54a`

### DIFF
--- a/fixtures/uking/zq-b54a.json
+++ b/fixtures/uking/zq-b54a.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "ZQ-B54A",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Florian"],
+    "createDate": "2023-05-26",
+    "lastModifyDate": "2023-05-26"
+  },
+  "links": {
+    "video": [
+      "https://notexistent.de"
+    ]
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "220deg"
+      }
+    },
+    "Color Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 149],
+          "type": "ColorPreset",
+          "comment": "White"
+        },
+        {
+          "dmxRange": [150, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "0Hz",
+        "speedEnd": "10Hz"
+      }
+    },
+    "No function": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Sound Sensitivity": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 30],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [31, 150],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [151, 180],
+          "type": "SoundSensitivity",
+          "soundSensitivityStart": "low",
+          "soundSensitivityEnd": "high"
+        },
+        {
+          "dmxRange": [181, 255],
+          "type": "NoFunction"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "7ch",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Dimmer",
+        "Strobe",
+        "Color Wheel",
+        "No function",
+        "Sound Sensitivity"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `uking/zq-b54a`

### Fixture warnings / errors

* uking/zq-b54a
  - :x: Capability 'Wheel rotation CW slow…fast' (150…255) in channel 'Color Wheel' does not explicitly reference any wheel, but the default wheel 'Color Wheel' (through the channel name) does not exist.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Florian**!