### PR TITLE
Use plain "2" for "H2O" in `eurolite/led-h2o` fixture name

### DIFF
--- a/fixtures/eurolite/led-h2o.json
+++ b/fixtures/eurolite/led-h2o.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "LED H²O",
+  "name": "LED H2O",
   "shortName": "ELH2O",
   "categories": ["Effect", "Color Changer"],
   "meta": {


### PR DESCRIPTION
Eurolite refers to this product in various places as "H₂O", "H²O" [sic], and (most commonly) "H2O".  I propose that, in the absence of a strong need to use a superscript (or subscript), we simply call it by the plain "H2O", as it's easiest to type, easiest to search for, and not obviously wrong (in terms of either brand or science).