### PR TITLE
Make Link Checker only run on upstream OFL repo

### DIFF
--- a/.github/workflows/external-links-checker.yaml
+++ b/.github/workflows/external-links-checker.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   external-links:
     name: Check external links
+    if: github.repository == 'OpenLightingProject/open-fixture-library'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
I get a notification everyday that my fork tries to run the link checker job and fails. This change updates the link checker action to make sure it is only running on the OpenLightingProject's repo.