### PR TITLE
Add fixture `smoke-factory/data-ii`

### DIFF
--- a/fixtures/smoke-factory/data-ii.json
+++ b/fixtures/smoke-factory/data-ii.json
@@ -25,7 +25,8 @@
   "availableChannels": {
     "Pump": {
       "capability": {
-        "type": "FogOutput",
+        "type": "Fog",
+        "fogType": "Fog",
         "fogOutputStart": "weak",
         "fogOutputEnd": "strong"
       }

--- a/fixtures/smoke-factory/data-ii.json
+++ b/fixtures/smoke-factory/data-ii.json
@@ -11,6 +11,9 @@
   "links": {
     "manual": [
       "http://smoke-factory.de/pdf/datenblatt_data_ii.pdf"
+    ],
+    "productPage": [
+      "https://smoke-factory.de/produkt/data-ii/?lang=en"
     ]
   },
   "physical": {

--- a/fixtures/smoke-factory/data-ii.json
+++ b/fixtures/smoke-factory/data-ii.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Data II",
+  "shortName": "Data2",
+  "categories": ["Smoke"],
+  "meta": {
+    "authors": ["WaldperlachFabi"],
+    "createDate": "2023-07-10",
+    "lastModifyDate": "2023-07-10"
+  },
+  "links": {
+    "manual": [
+      "http://smoke-factory.de/pdf/datenblatt_data_ii.pdf"
+    ]
+  },
+  "physical": {
+    "dimensions": [58.5, 23, 24.7],
+    "weight": 12.8,
+    "power": 2600,
+    "DMXconnector": "5-pin"
+  },
+  "availableChannels": {
+    "Pump": {
+      "capability": {
+        "type": "FogOutput",
+        "fogOutputStart": "weak",
+        "fogOutputEnd": "strong"
+      }
+    },
+    "Fan": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "2ch",
+      "channels": [
+        "Pump",
+        "Fan"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `smoke-factory/data-ii`

### Fixture warnings / errors

* smoke-factory/data-ii
  - :warning: Category 'Hazer' suggested since there are Fog/FogType capabilities with no fogType or fogType 'Haze'.


Thank you @WaldperlachFabi!