### PR TITLE
Add fixture `chauvet-dj/hurricane-haze-1dx`

### DIFF
--- a/fixtures/chauvet-dj/hurricane-haze-1dx.json
+++ b/fixtures/chauvet-dj/hurricane-haze-1dx.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Hurricane Haze 1DX",
+  "categories": ["Hazer"],
+  "meta": {
+    "authors": ["David Oleniacz"],
+    "createDate": "2023-07-11",
+    "lastModifyDate": "2023-07-11"
+  },
+  "links": {
+    "manual": [
+      "https://www.chauvetdj.com/wp-content/uploads/2017/01/Hurricane_Haze_1DX_UM_Rev3.pdf"
+    ],
+    "productPage": [
+      "https://www.chauvetdj.com/products/hurricane-haze-1dx/"
+    ]
+  },
+  "physical": {
+    "dimensions": [150, 223, 278],
+    "weight": 3.3,
+    "power": 303,
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "Haze": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction",
+          "comment": "OFF"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "FogOutput",
+          "fogOutputStart": "weak",
+          "fogOutputEnd": "strong"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "1 Channel",
+      "shortName": "1ch",
+      "channels": [
+        "Haze"
+      ]
+    }
+  ]
+}

--- a/fixtures/chauvet-dj/hurricane-haze-1dx.json
+++ b/fixtures/chauvet-dj/hurricane-haze-1dx.json
@@ -26,12 +26,14 @@
       "capabilities": [
         {
           "dmxRange": [0, 10],
-          "type": "NoFunction",
-          "comment": "OFF"
+          "type": "Fog",
+          "fogType": "Haze",
+          "fogOutput": "off"
         },
         {
           "dmxRange": [11, 255],
-          "type": "FogOutput",
+          "type": "Fog",
+          "fogType": "Haze",
           "fogOutputStart": "weak",
           "fogOutputEnd": "strong"
         }


### PR DESCRIPTION
* Add fixture `chauvet-dj/hurricane-haze-1dx`

### Fixture warnings / errors

* chauvet-dj/hurricane-haze-1dx
  - :warning: Category 'Smoke' suggested since there are Fog/FogType capabilities with no fogType or fogType 'Fog'.


Thank you @DavidOpgh!