### PR TITLE
Add fixture `cameo/ts-60-w-rgbw`

### DIFF
--- a/fixtures/cameo/ts-60-w-rgbw.json
+++ b/fixtures/cameo/ts-60-w-rgbw.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "TS 60 W RGBW",
+  "categories": ["Dimmer"],
+  "meta": {
+    "authors": ["Florian"],
+    "createDate": "2023-07-16",
+    "lastModifyDate": "2023-07-16"
+  },
+  "links": {
+    "manual": [
+      "https://www.cameolight.com/de/downloads/file/id/1201324186"
+    ],
+    "productPage": [
+      "https://www.cameolight.com/de/loesungen/dj-musiker/statisches-licht/theaterscheinwerfer/11911/ts-60-w-rgbw#detail-upper"
+    ]
+  },
+  "physical": {
+    "dimensions": [145, 205, 240],
+    "weight": 3.6,
+    "power": 65,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "name": "plano-convex lens",
+      "degreesMinMax": [9, 41]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "fineChannelAliases": ["Dimmer fine"],
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [6, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "1Hz",
+          "speedEnd": "20Hz"
+        }
+      ]
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "7ch",
+      "channels": [
+        "Dimmer",
+        "Dimmer fine",
+        "Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `cameo/ts-60-w-rgbw`

### Fixture warnings / errors

* cameo/ts-60-w-rgbw
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Florian**!