### PR TITLE
Add fixture `shehds/movingehad`

### DIFF
--- a/fixtures/shehds/movingehad.json
+++ b/fixtures/shehds/movingehad.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "movingehad",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Marnix"],
+    "createDate": "2023-07-17",
+    "lastModifyDate": "2023-07-17"
+  },
+  "links": {
+    "manual": [
+      "http://www.nos.nl"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 134],
+          "type": "Intensity"
+        },
+        {
+          "dmxRange": [135, 239],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0Hz",
+          "speedEnd": "25Hz"
+        },
+        {
+          "dmxRange": [240, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "10ch",
+      "channels": [
+        "Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `shehds/movingehad`

### Fixture warnings / errors

* shehds/movingehad
  - :x: Mode '10ch' should have 10 channels according to its name but actually has 1.
  - :x: Mode '10ch' should have 10 channels according to its shortName but actually has 1.
  - :x: Category 'Moving Head' invalid since there are not both pan and tilt channels.


Thank you **Marnix**!