### PR TITLE
Add fixture `delibang/14pcs-rgbw-4in1-par-light`

### DIFF
--- a/fixtures/delibang/14pcs-rgbw-4in1-par-light.json
+++ b/fixtures/delibang/14pcs-rgbw-4in1-par-light.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "14pcs RGBW 4in1 Par Light",
+  "categories": ["Color Changer", "Dimmer"],
+  "meta": {
+    "authors": ["Iulian Arcus"],
+    "createDate": "2023-07-19",
+    "lastModifyDate": "2023-07-19"
+  },
+  "comment": "Generic RGBW PAR fixed light with sound control, IR remote",
+  "links": {
+    "productPage": [
+      "https://www.amazon.co.uk/DELIBANG-Lighting-Wireless-Adjustable-Birthday/dp/B0B4N9ZHL5"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [8, 8]
+    }
+  },
+  "wheels": {
+    "Color Macros": {
+      "slots": [
+        {
+          "type": "Color"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Color Macros": {
+      "precedence": "HTP",
+      "capabilities": [
+        {
+          "dmxRange": [0, 3],
+          "type": "NoFunction",
+          "comment": "DMX Control Channel 1-6"
+        },
+        {
+          "dmxRange": [4, 127],
+          "type": "ColorPreset",
+          "colors": ["#ff0000", "#00ff00", "#0000ff", "#ffffff", "#ffff99", "#ffff00", "#ff9900", "#aaaaff"]
+        },
+        {
+          "dmxRange": [128, 169],
+          "type": "Effect",
+          "effectPreset": "ColorJump"
+        },
+        {
+          "dmxRange": [170, 210],
+          "type": "Effect",
+          "effectPreset": "ColorFade",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [211, 229],
+          "type": "Effect",
+          "effectPreset": "ColorJump",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [230, 255],
+          "type": "Effect",
+          "effectPreset": "ColorJump",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "duration": "short",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Effect Speed": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8 Channel",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe",
+        "Color Macros",
+        "Effect Speed"
+      ]
+    },
+    {
+      "name": "4 Channel",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -128,6 +128,10 @@
     "name": "Dedolight",
     "website": "https://www.dedoweigertfilm.de/dwf-en/brands/dedolight_overview.php"
   },
+  "delibang": {
+    "name": "Delibang",
+    "comment": "Amazon Generic Lights Manufacturer"
+  },
   "dmg-lumiere": {
     "name": "DMG Lumière",
     "website": "https://emea.rosco.com/en/products/brand/dmg-lighting",


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `delibang/14pcs-rgbw-4in1-par-light`

### Fixture warnings / errors

* delibang/14pcs-rgbw-4in1-par-light
  - :x: File does not match schema: fixture/wheels/Color Macros/slots must NOT have fewer than 2 items
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedStart "slow CW" must be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedStart "slow CW" must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedEnd "fast CW" must be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - :x: File does not match schema: fixture/availableChannels/Color Macros/capabilities/3/speedEnd "fast CW" must match exactly one schema in oneOf


Thank you @Ilidur!