### PR TITLE
Add fixture `beamz/mhl36`

### DIFF
--- a/fixtures/beamz/mhl36.json
+++ b/fixtures/beamz/mhl36.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "MHL36",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["an"],
+    "createDate": "2023-07-29",
+    "lastModifyDate": "2023-07-29"
+  },
+  "links": {
+    "manual": [
+      "https://www.manua.ls/beamz/mhl36/manual"
+    ],
+    "productPage": [
+      "https://www.beamzlighting.com/product/mhl36-moving-head-set-of-2-pieces-in-bag/"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=2ik6vSUiZ6w&ab_channel=FIREFIGHT1520"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "180deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speed": "20Hz"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Program Duration": {
+      "capability": {
+        "type": "EffectDuration",
+        "durationStart": "short",
+        "durationEnd": "long"
+      }
+    },
+    "Pan/Tilt Speed 2": {
+      "name": "Pan/Tilt Speed",
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "14chanel",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Pan/Tilt Speed",
+        "Dimmer",
+        "Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Program Duration",
+        "Pan/Tilt Speed 2"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `beamz/mhl36`

### Fixture warnings / errors

* beamz/mhl36
  - :x: Mode '14chanel' should have 14 channels according to its name but actually has 11.
  - :x: Mode '14chanel' should have 14 channels according to its shortName but actually has 11.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **an**!