### PR TITLE
Add fixture `generic/led-light-g3013a`

### DIFF
--- a/fixtures/generic/led-light-g3013a.json
+++ b/fixtures/generic/led-light-g3013a.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED LIGHT G3013A",
+  "shortName": "Prolight 30",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Anonymos"],
+    "createDate": "2023-07-29",
+    "lastModifyDate": "2023-07-29"
+  },
+  "links": {
+    "other": [
+      "https://www.ricardo.ch/de/a/led-spot-30w-led-light-g3013a-defekt-1227628464/"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "360deg"
+      }
+    },
+    "Pan 2": {
+      "name": "Pan",
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "360deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "360deg"
+      }
+    },
+    "Tilt 2": {
+      "name": "Tilt",
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "360deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    },
+    "Focus": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Color Wheel": {
+      "capability": {
+        "type": "WheelSlot",
+        "slotNumber": 16
+      }
+    },
+    "Gobo Wheel": {
+      "capability": {
+        "type": "WheelSlot",
+        "slotNumber": 8
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Prolight 30",
+      "channels": [
+        "Pan",
+        "Pan 2",
+        "Tilt",
+        "Tilt 2",
+        "Pan/Tilt Speed",
+        "Dimmer",
+        "Shutter / Strobe",
+        "Focus",
+        "Color Wheel",
+        "Gobo Wheel"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `generic/led-light-g3013a`

### Fixture warnings / errors

* generic/led-light-g3013a
  - :warning: Unused wheel slot(s): Color Wheel (slot 1), Color Wheel (slot 2), Color Wheel (slot 3), Color Wheel (slot 4), Color Wheel (slot 5), Color Wheel (slot 6), Color Wheel (slot 7), Color Wheel (slot 8), Color Wheel (slot 9), Color Wheel (slot 10), Color Wheel (slot 11), Color Wheel (slot 12), Color Wheel (slot 13), Color Wheel (slot 14), Color Wheel (slot 15), Gobo Wheel (slot 1), Gobo Wheel (slot 2), Gobo Wheel (slot 3), Gobo Wheel (slot 4), Gobo Wheel (slot 5), Gobo Wheel (slot 6), Gobo Wheel (slot 7), Gobo Wheel (slot 9), Gobo Wheel (slot 10), Gobo Wheel (slot 11), Gobo Wheel (slot 12), Gobo Wheel (slot 13), Gobo Wheel (slot 14)
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Anonymos**!