### PR TITLE
Add fixture `tecshow/moving-head-dino`

### DIFF
--- a/fixtures/tecshow/moving-head-dino.json
+++ b/fixtures/tecshow/moving-head-dino.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "moving head dino",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["marco"],
+    "createDate": "2023-08-05",
+    "lastModifyDate": "2023-08-05"
+  },
+  "links": {
+    "manual": [
+      "https://open-fixture-library.org/fixture-editor"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "standard",
+      "channels": [
+        "Intensity",
+        "Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `tecshow/moving-head-dino`

### Fixture warnings / errors

* tecshow/moving-head-dino
  - :x: Category 'Moving Head' invalid since there are not both pan and tilt channels.


Thank you **marco**!