### PR TITLE
Add fixture `chauvet-professional/ovation-reve-e3`

### DIFF
--- a/fixtures/chauvet-professional/ovation-reve-e3.json
+++ b/fixtures/chauvet-professional/ovation-reve-e3.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Ovation reve e3",
+  "categories": ["Dimmer", "Scanner"],
+  "meta": {
+    "authors": ["P"],
+    "createDate": "2023-08-29",
+    "lastModifyDate": "2023-08-29"
+  },
+  "links": {
+    "manual": [
+      "https://www.chauvetprofessional.com/products/ovation-reve-e-3/"
+    ],
+    "productPage": [
+      "https://www.chauvetprofessional.com/products/ovation-reve-e-3/"
+    ],
+    "video": [
+      "https://www.chauvetprofessional.com/products/ovation-reve-e-3/"
+    ]
+  },
+  "physical": {
+    "dimensions": [12, 121, 133]
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "Mint": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "6",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Amber",
+        "Mint"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `chauvet-professional/ovation-reve-e3`

### Fixture warnings / errors

* chauvet-professional/ovation-reve-e3
  - :x: Category 'Scanner' invalid since there are no pan or tilt channels.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **P**!