### PR TITLE
Add fixture `american-dj/ub-9h`

### DIFF
--- a/fixtures/american-dj/ub-9h.json
+++ b/fixtures/american-dj/ub-9h.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "ub 9h",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["valerio"],
+    "createDate": "2023-09-04",
+    "lastModifyDate": "2023-09-04"
+  },
+  "links": {
+    "video": [
+      "https://www.youtube.com/watch?v=pId7tOk_D2I"
+    ]
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "UV": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "ub 9h",
+      "shortName": "fixture",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `american-dj/ub-9h`

### Fixture warnings / errors

* american-dj/ub-9h
  - :x: Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **valerio**!