### PR TITLE
Add fixture `generic/balls-on-moter`

### DIFF
--- a/fixtures/generic/balls-on-moter.json
+++ b/fixtures/generic/balls-on-moter.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Balls on Moter",
+  "shortName": "Ghost",
+  "categories": ["Effect"],
+  "meta": {
+    "authors": ["THIS FUCKING SUCKS"],
+    "createDate": "2023-09-04",
+    "lastModifyDate": "2023-09-04"
+  },
+  "links": {
+    "manual": [
+      "https://drive.google.com/file/d/10f9VI4yKIK4qCxxfZaySqBlMrdIGxsKF/view"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "Red Dimmer": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green Dimmer": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue dimmer": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    },
+    "Light Height": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "6 channel",
+      "channels": [
+        "Red Dimmer",
+        "Green Dimmer",
+        "Blue dimmer",
+        "Dimmer",
+        "Strobe",
+        "Light Height"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `generic/balls-on-moter`

### Fixture warnings / errors

* generic/balls-on-moter
  - :warning: Mode '6 channel' should have shortName '6ch' instead of '6 channel'.
  - :warning: Mode '6 channel' should have shortName '6ch' instead of '6 channel'.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **THIS FUCKING SUCKS**!