### PR TITLE
External Link Checker: Open in new tab

### DIFF
--- a/tests/external-links.js
+++ b/tests/external-links.js
@@ -382,7 +382,8 @@ async function updateGithubIssue(urlResults) {
           return `<a href="${status.jobUrl}" title="${message}">${emoji}</a>`;
         }).join(`&nbsp;`);
 
-        return `| ${url} <td nowrap>${statusIcons}</td>`;
+        const link = `<a href="${url}" target="_blank">${url}</a>`;
+        return `| ${link} <td nowrap>${statusIcons}</td>`;
       }),
     ];
 


### PR DESCRIPTION
When checking the links from #999, I thought it might be nicer for the links to open in a new tab (since they are external to GitHub). 

I was also wondering if it's worth truncating the length of the URL to prevent the table from extending past the width of the comment?