### PR TITLE
Fix external links parser

### DIFF
--- a/tests/external-links.js
+++ b/tests/external-links.js
@@ -269,9 +269,11 @@ async function updateGithubIssue(urlResults) {
 
     try {
       const lines = body.split(/\r?\n/); // support both \n and \r\n newline types
-      const firstContentLine = lines.indexOf(`<table>`) + 2;
-      lines.splice(0, firstContentLine); // delete first lines which only hold general data
       for (const line of lines) {
+        if (!line.startsWith(`<tr><td nowrap>`) {
+          continue;
+        }
+
         const [, lastResults, url] = line.match(/<tr><td nowrap>(.*?)<\/td><td><a href="(.*?)"/);
 
         linkData[url] = lastResults.split(`&nbsp;`).map(item => {
@@ -294,7 +296,9 @@ async function updateGithubIssue(urlResults) {
       }
     }
     catch (error) {
-      throw `Unable to retrieve link data from issue body: ${error}`;
+      throw new Error(`Unable to retrieve link data from issue body`, {
+        cause: error,
+      });
     }
 
     return linkData;

--- a/tests/external-links.js
+++ b/tests/external-links.js
@@ -270,7 +270,7 @@ async function updateGithubIssue(urlResults) {
     try {
       const lines = body.split(/\r?\n/); // support both \n and \r\n newline types
       for (const line of lines) {
-        if (!line.startsWith(`<tr><td nowrap>`) {
+        if (!line.startsWith(`<tr><td nowrap>`)) {
           continue;
         }
 


### PR DESCRIPTION
Follow-up to #3517: Just removing the first few lines isn't enough anymore, we now also have to strip the final `</table>` line.