### PR TITLE
Prepare Vue 3 migration

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -195,9 +195,6 @@ const enabledRuleParameters = {
   'vue/max-attributes-per-line': [{ singleline: 3 }],
   'vue/next-tick-style': [],
   'vue/no-boolean-default': [`default-false`],
-  'vue/no-deprecated-scope-attribute': [],
-  'vue/no-deprecated-slot-attribute': [],
-  'vue/no-deprecated-slot-scope-attribute': [],
   'vue/no-empty-component-block': [],
   'vue/no-undef-components': [{
     ignorePatterns: [
@@ -221,6 +218,38 @@ const enabledRuleParameters = {
   'vue/v-for-delimiter-style': [`of`],
   'vue/v-on-handler-style': [`inline`],
   'vue/v-slot-style': [`shorthand`],
+
+  // Vue 3 migration
+  'vue/no-deprecated-data-object-declaration': [],
+  // 'vue/no-deprecated-destroyed-lifecycle': [], // impossible to fix in Vue 2 (without Composition API)
+  'vue/no-deprecated-dollar-listeners-api': [],
+  'vue/no-deprecated-dollar-scopedslots-api': [],
+  'vue/no-deprecated-events-api': [],
+  'vue/no-deprecated-filter': [],
+  'vue/no-deprecated-functional-template': [],
+  'vue/no-deprecated-html-element-is': [],
+  'vue/no-deprecated-inline-template': [],
+  'vue/no-deprecated-model-definition': [{
+    allowVue3Compat: true,
+  }],
+  'vue/no-deprecated-props-default-this': [],
+  'vue/no-deprecated-router-link-tag-prop': [],
+  'vue/no-deprecated-scope-attribute': [],
+  'vue/no-deprecated-slot-attribute': [],
+  'vue/no-deprecated-slot-scope-attribute': [],
+  'vue/no-deprecated-v-bind-sync': [],
+  'vue/no-deprecated-v-is': [],
+  'vue/no-deprecated-v-on-native-modifier': [],
+  'vue/no-deprecated-v-on-number-modifiers': [],
+  'vue/no-deprecated-vue-config-keycodes': [],
+  'vue/no-expose-after-await': [],
+  'vue/no-lifecycle-after-await': [],
+  'vue/no-watch-after-await': [],
+  'vue/prefer-import-from-vue': [],
+  'vue/require-explicit-emits': [],
+  'vue/require-slots-as-functions': [],
+  'vue/require-toggle-inside-transition': [],
+  'vue/v-on-event-hyphenation': [],
 
   // already included in presets, but needed here because we reduce severity to `warn`
   'sonarjs/cognitive-complexity': [],

--- a/ui/components/A11yDialog.vue
+++ b/ui/components/A11yDialog.vue
@@ -122,6 +122,10 @@ export default {
     title: stringProp().required,
     wide: booleanProp().withDefault(false),
   },
+  emits: {
+    show: () => true,
+    hide: () => true,
+  },
   data() {
     return {
       dialog: null,

--- a/ui/components/CategoryBadge.vue
+++ b/ui/components/CategoryBadge.vue
@@ -77,6 +77,12 @@ export default {
             this.$emit(`click`);
             $event.preventDefault();
           },
+          focus: () => {
+            this.$emit(`focus`);
+          },
+          blur: $event => {
+            this.$emit(`blur`, $event);
+          },
         },
       }, children);
     }

--- a/ui/components/CategoryBadge.vue
+++ b/ui/components/CategoryBadge.vue
@@ -50,6 +50,11 @@ export default {
     selected: booleanProp().withDefault(false),
     selectable: booleanProp().withDefault(false),
   },
+  emits: {
+    click: () => true,
+    focus: () => true,
+    blur: event => true,
+  },
   render(createElement) {
     const classes = {
       'category-badge': true,

--- a/ui/components/ChannelTypeIcon.vue
+++ b/ui/components/ChannelTypeIcon.vue
@@ -1,3 +1,7 @@
+<template>
+  <OflSvg v-bind="iconProperties" />
+</template>
+
 <script>
 import { instanceOfProp } from 'vue-ts-types';
 import AbstractChannel from '../../lib/model/AbstractChannel.js';
@@ -6,14 +10,13 @@ import NullChannel from '../../lib/model/NullChannel.js';
 import SwitchingChannel from '../../lib/model/SwitchingChannel.js';
 
 export default {
-  functional: true,
   props: {
     channel: instanceOfProp(AbstractChannel).required,
   },
-  render(createElement, context) {
-    return createElement(`OflSvg`, Object.assign({}, context.data, {
-      props: getIconProperties(context.props.channel),
-    }));
+  computed: {
+    iconProperties() {
+      return getIconProperties(this.channel);
+    },
   },
 };
 

--- a/ui/components/ConditionalDetails.vue
+++ b/ui/components/ConditionalDetails.vue
@@ -1,24 +1,16 @@
-<!-- Usage:
+<template>
+  <details v-if="$slots.default">
+    <summary>
+      <slot name="summary" />
+    </summary>
 
-1. with content
-  <ConditionalDetails>
-    <template slot="summary">Hello</template>
+    <slot />
+  </details>
 
-    World
-  </ConditionalDetails>
-
-  renders:
-  <details><summary>Hello</summary>World</details>
-
-2. without content
-  <ConditionalDetails>
-    <template slot="summary">Hello</template>
-  </ConditionalDetails>
-
-  renders:
-  <div class="summary">Hello</div>
-
--->
+  <div v-else class="summary">
+    <slot name="summary" />
+  </div>
+</template>
 
 <style lang="scss" scoped>
 summary {
@@ -73,20 +65,3 @@ details {
   }
 }
 </style>
-
-<script>
-export default {
-  render(createElement) {
-    if (this.$slots.default) {
-      return createElement(`details`, [
-        createElement(`summary`, this.$slots.summary),
-        this.$slots.default,
-      ]);
-    }
-
-    return createElement(`div`, {
-      class: `summary`,
-    }, this.$slots.summary);
-  },
-};
-</script>

--- a/ui/components/HeaderBar.vue
+++ b/ui/components/HeaderBar.vue
@@ -1,14 +1,14 @@
 <template>
   <header>
-    <nav>
+    <!-- eslint-disable vuejs-accessibility/click-events-have-key-events vuejs-accessibility/no-static-element-interactions -->
+    <nav @click="focusContent($event)">
       <div class="left-nav">
         <NuxtLink
           class="home-logo"
           :class="{ 'hidden-by-search-field': searchFieldFocused }"
           to="/"
           exact
-          title="Home"
-          @click.native="focusContent()">
+          title="Home">
           Open Fixture Library
         </NuxtLink>
 
@@ -33,34 +33,30 @@
       <div class="right-nav">
         <NuxtLink
           to="/fixture-editor"
-          title="Fixture editor"
-          @click.native="focusContent()">
+          title="Fixture editor">
           Add fixture
         </NuxtLink>
 
         <NuxtLink
           to="/manufacturers"
-          title="Browse fixtures by manufacturer"
-          @click.native="focusContent()">
+          title="Browse fixtures by manufacturer">
           Manufacturers
         </NuxtLink>
 
         <NuxtLink
           to="/categories"
-          title="Browse fixtures by category"
-          @click.native="focusContent()">
+          title="Browse fixtures by category">
           Categories
         </NuxtLink>
 
         <NuxtLink
           to="/about"
-          title="About the project"
-          @click.native="focusContent()">
+          title="About the project">
           About
         </NuxtLink>
 
         <ClientOnly>
-          <ThemeSwitcher class="theme-switcher" @click.native="focusContent()" />
+          <ThemeSwitcher class="theme-switcher" />
         </ClientOnly>
       </div>
     </nav>
@@ -251,8 +247,10 @@ export default {
     updateSearchQuery() {
       this.searchQuery = this.$router.history.current.query.q || ``;
     },
-    focusContent() {
-      this.$emit(`focus-content`);
+    focusContent(event) {
+      if (event.target?.closest(`a`)) {
+        this.$emit(`focus-content`);
+      }
     },
     search() {
       this.$router.push({

--- a/ui/components/HeaderBar.vue
+++ b/ui/components/HeaderBar.vue
@@ -234,6 +234,9 @@ export default {
   components: {
     ThemeSwitcher,
   },
+  emits: {
+    'focus-content': () => true,
+  },
   data() {
     return {
       searchQuery: this.$router.history.current.query.q || ``,

--- a/ui/components/HelpWantedDialog.vue
+++ b/ui/components/HelpWantedDialog.vue
@@ -3,20 +3,20 @@
     id="help-wanted-dialog"
     ref="dialog"
     :is-alert-dialog="state === `loading`"
-    :shown="context !== undefined"
+    :shown="modelValue !== undefined"
     :title="title"
     @hide="onHide()">
 
-    <form v-if="state === `ready` && context !== undefined" action="#" @submit.prevent="onSubmit()">
+    <form v-if="state === `ready` && modelValue !== undefined" action="#" @submit.prevent="onSubmit()">
       <LabeledValue
         v-if="location !== null"
         :value="location"
         label="Location" />
 
       <LabeledValue
-        v-if="context.helpWanted !== null"
+        v-if="modelValue.helpWanted !== null"
         label="Problem description">
-        <span v-html="context.helpWanted" />
+        <span v-html="modelValue.helpWanted" />
       </LabeledValue>
 
       <LabeledInput name="message" label="Message">
@@ -82,14 +82,15 @@ export default {
     LabeledValue,
   },
   model: {
-    prop: `context`,
+    prop: `model-value`,
+    event: `update:model-value`,
   },
   props: {
     type: stringProp().required,
-    context: objectProp().optional,
+    modelValue: objectProp().optional,
   },
   emits: {
-    input: value => true,
+    'update:model-value': value => true,
   },
   data: () => {
     return {
@@ -122,7 +123,7 @@ export default {
     },
     location() {
       if (this.type === `capability`) {
-        const capability = this.context;
+        const capability = this.modelValue;
         const channel = capability._channel;
         return `Channel "${channel.key}" → Capability "${capability.name}" (${capability.rawDmxRange})`;
       }
@@ -131,11 +132,11 @@ export default {
     },
     fixture() {
       if (this.type === `fixture`) {
-        return this.context;
+        return this.modelValue;
       }
 
       if (this.type === `capability`) {
-        return this.context._channel.fixture;
+        return this.modelValue._channel.fixture;
       }
 
       return null;
@@ -144,13 +145,13 @@ export default {
       const sendObject = {
         type: this.type,
         location: this.location,
-        helpWanted: this.context.helpWanted,
+        helpWanted: this.modelValue.helpWanted,
         message: this.message,
         githubUsername: this.githubUsername === `` ? null : this.githubUsername,
       };
 
       if (this.type === `plugin`) {
-        sendObject.context = this.context.key;
+        sendObject.context = this.modelValue.key;
       }
       else {
         const manufacturerKey = this.fixture.manufacturer.key;
@@ -165,11 +166,11 @@ export default {
       return `${JSON.stringify(this.sendObject, null, 2)}\n\n${this.error}`;
     },
     mailtoUrl() {
-      const subject = `Feedback for ${this.sendObject.type} '${this.sendObject.context}'`;
+      const subject = `Feedback for ${this.sendObject.type} '${this.sendObject.modelValue}'`;
 
       const mailBodyData = {
         'Problem location': this.location,
-        'Problem description': this.context.helpWanted,
+        'Problem description': this.modelValue.helpWanted,
         'Message': this.message,
       };
 
@@ -220,7 +221,7 @@ export default {
       this.state = `ready`;
       this.issueUrl = null;
       this.error = null;
-      this.$emit(`input`, undefined);
+      this.$emit(`update:model-value`, undefined);
     },
   },
 };

--- a/ui/components/HelpWantedDialog.vue
+++ b/ui/components/HelpWantedDialog.vue
@@ -88,6 +88,9 @@ export default {
     type: stringProp().required,
     context: objectProp().optional,
   },
+  emits: {
+    input: value => true,
+  },
   data: () => {
     return {
       state: `ready`,

--- a/ui/components/HelpWantedMessage.vue
+++ b/ui/components/HelpWantedMessage.vue
@@ -93,6 +93,9 @@ export default {
     type: oneOfProp([`fixture`, `capability`, `plugin`]).required,
     context: objectProp().required,
   },
+  emits: {
+    'help-wanted-clicked': payload => true,
+  },
   computed: {
     location() {
       if (this.type === `capability`) {

--- a/ui/components/LabeledValue.vue
+++ b/ui/components/LabeledValue.vue
@@ -1,16 +1,11 @@
-<template functional>
-  <section
-    :ref="data.ref"
-    :class="[data.class, data.staticClass, props.name]"
-    :style="[data.style, data.staticStyle]"
-    v-bind="data.attrs"
-    v-on="listeners">
+<template>
+  <section :class="name">
     <div class="label">
-      <template v-if="props.label">{{ props.label }}</template>
+      <template v-if="label">{{ label }}</template>
       <slot name="label" />
     </div>
     <div class="value">
-      <template v-if="props.value">{{ props.value }}</template>
+      <template v-if="value">{{ value }}</template>
       <slot />
     </div>
   </section>

--- a/ui/components/PropertyInputBoolean.vue
+++ b/ui/components/PropertyInputBoolean.vue
@@ -20,6 +20,9 @@ export default {
     name: stringProp().required,
     label: stringProp().required,
   },
+  emits: {
+    input: value => true,
+  },
   computed: {
     localValue: {
       get() {

--- a/ui/components/PropertyInputDimensions.vue
+++ b/ui/components/PropertyInputDimensions.vue
@@ -8,8 +8,8 @@
         :schema-property="schemaProperty.items"
         :required="required || dimensionsSpecified"
         :hint="hints[0]"
-        @focus.native="onFocus()"
-        @blur.native="onBlur($event)" />
+        @focus="onFocus()"
+        @blur="onBlur($event)" />
     </Validate>
     &times;
     <Validate :state="formstate" tag="span">
@@ -19,8 +19,8 @@
         :schema-property="schemaProperty.items"
         :required="required || dimensionsSpecified"
         :hint="hints[1]"
-        @focus.native="onFocus()"
-        @blur.native="onBlur($event)" />
+        @focus="onFocus()"
+        @blur="onBlur($event)" />
     </Validate>
     &times;
     <Validate :state="formstate" tag="span">
@@ -30,8 +30,8 @@
         :schema-property="schemaProperty.items"
         :required="required || dimensionsSpecified"
         :hint="hints[2]"
-        @focus.native="onFocus()"
-        @blur.native="onBlur($event)" />
+        @focus="onFocus()"
+        @blur="onBlur($event)" />
     </Validate>
     {{ unit }}
   </span>

--- a/ui/components/PropertyInputDimensions.vue
+++ b/ui/components/PropertyInputDimensions.vue
@@ -46,10 +46,11 @@ export default {
     PropertyInputNumber,
   },
   model: {
-    prop: `dimensions`,
+    prop: `model-value`,
+    event: `update:model-value`,
   },
   props: {
-    dimensions: arrayProp().withDefault(null),
+    modelValue: arrayProp().withDefault(null),
     hints: arrayProp().withDefault(() => [`x`, `y`, `z`]),
     schemaProperty: objectProp().required,
     unit: stringProp().optional,
@@ -58,7 +59,7 @@ export default {
     formstate: objectProp().required,
   },
   emits: {
-    input: dimensions => true,
+    'update:model-value': dimensions => true,
     focus: () => true,
     blur: () => true,
     'vf:validate': validationData => true,
@@ -73,30 +74,30 @@ export default {
   computed: {
     x: {
       get() {
-        return this.dimensions ? this.dimensions[0] : null;
+        return this.modelValue ? this.modelValue[0] : null;
       },
       set(xInput) {
-        this.$emit(`input`, getDimensionsArray(xInput, this.y, this.z));
+        this.$emit(`update:model-value`, getDimensionsArray(xInput, this.y, this.z));
       },
     },
     y: {
       get() {
-        return this.dimensions ? this.dimensions[1] : null;
+        return this.modelValue ? this.modelValue[1] : null;
       },
       set(yInput) {
-        this.$emit(`input`, getDimensionsArray(this.x, yInput, this.z));
+        this.$emit(`update:model-value`, getDimensionsArray(this.x, yInput, this.z));
       },
     },
     z: {
       get() {
-        return this.dimensions ? this.dimensions[2] : null;
+        return this.modelValue ? this.modelValue[2] : null;
       },
       set(zInput) {
-        this.$emit(`input`, getDimensionsArray(this.x, this.y, zInput));
+        this.$emit(`update:model-value`, getDimensionsArray(this.x, this.y, zInput));
       },
     },
     dimensionsSpecified() {
-      return this.dimensions !== null;
+      return this.modelValue !== null;
     },
   },
   mounted() {

--- a/ui/components/PropertyInputDimensions.vue
+++ b/ui/components/PropertyInputDimensions.vue
@@ -57,6 +57,12 @@ export default {
     name: stringProp().required,
     formstate: objectProp().required,
   },
+  emits: {
+    input: dimensions => true,
+    focus: () => true,
+    blur: () => true,
+    'vf:validate': validationData => true,
+  },
   data() {
     return {
       validationData: {

--- a/ui/components/PropertyInputEntity.vue
+++ b/ui/components/PropertyInputEntity.vue
@@ -11,8 +11,8 @@
         :minimum="minNumber !== undefined ? minNumber : `invalid`"
         :maximum="maxNumber !== undefined ? maxNumber : `invalid`"
         :name="name ? `${name}-number` : null"
-        @focus.native="onFocus()"
-        @blur.native="onBlur($event)" />
+        @focus="onFocus()"
+        @blur="onBlur($event)" />
     </Validate>
 
     <select

--- a/ui/components/PropertyInputEntity.vue
+++ b/ui/components/PropertyInputEntity.vue
@@ -98,6 +98,13 @@ export default {
     name: stringProp().required,
     wide: booleanProp().withDefault(false),
   },
+  emits: {
+    input: value => true,
+    focus: () => true,
+    blur: () => true,
+    'unit-selected': unitString => true,
+    'vf:validate': validationData => true,
+  },
   data() {
     return {
       validationData: {

--- a/ui/components/PropertyInputNumber.vue
+++ b/ui/components/PropertyInputNumber.vue
@@ -9,7 +9,9 @@
     :placeholder="hint"
     :value="value === `invalid` ? `` : value"
     type="number"
-    v-on="lazy ? { change: update } : { input: update }">
+    v-on="lazy ? { change: update } : { input: update }"
+    @focus="$emit('focus', $event)"
+    @blur="$emit('blur', $event)">
 </template>
 
 <script>

--- a/ui/components/PropertyInputNumber.vue
+++ b/ui/components/PropertyInputNumber.vue
@@ -27,6 +27,12 @@ export default {
     value: anyProp().required,
     lazy: booleanProp().withDefault(false),
   },
+  emits: {
+    input: value => true,
+    focus: () => true,
+    blur: () => true,
+    'vf:validate': validationData => true,
+  },
   computed: {
     min() {
       if (this.minimum !== undefined && this.minimum !== `invalid`) {

--- a/ui/components/PropertyInputRange.vue
+++ b/ui/components/PropertyInputRange.vue
@@ -11,8 +11,8 @@
         :required="required || rangeIncomplete"
         :hint="startHint"
         lazy
-        @focus.native="onFocus($event)"
-        @blur.native="onBlur($event)" />
+        @focus="onFocus($event)"
+        @blur="onBlur($event)" />
     </Validate>
     …
     <Validate :state="formstate" tag="span">
@@ -25,8 +25,8 @@
         :required="required || rangeIncomplete"
         :hint="endHint"
         lazy
-        @focus.native="onFocus($event)"
-        @blur.native="onBlur($event)" />
+        @focus="onFocus($event)"
+        @blur="onBlur($event)" />
     </Validate>
     {{ unit }}
   </span>

--- a/ui/components/PropertyInputRange.vue
+++ b/ui/components/PropertyInputRange.vue
@@ -41,10 +41,11 @@ export default {
     PropertyInputNumber,
   },
   model: {
-    prop: `range`,
+    prop: `model-value`,
+    event: `update:model-value`,
   },
   props: {
-    range: arrayProp().withDefault(null),
+    modelValue: arrayProp().withDefault(null),
     name: stringProp().required,
     startHint: stringProp().withDefault(`start`),
     endHint: stringProp().withDefault(`end`),
@@ -56,7 +57,7 @@ export default {
     formstate: objectProp().required,
   },
   emits: {
-    input: range => true,
+    'update:model-value': range => true,
     'start-updated': () => true,
     'end-updated': () => true,
     focus: () => true,
@@ -74,24 +75,24 @@ export default {
   computed: {
     start: {
       get() {
-        return this.range ? this.range[0] : null;
+        return this.modelValue ? this.modelValue[0] : null;
       },
       set(startInput) {
-        this.$emit(`input`, getRange(startInput, this.end));
+        this.$emit(`update:model-value`, getRange(startInput, this.end));
         this.$emit(`start-updated`);
       },
     },
     end: {
       get() {
-        return this.range ? this.range[1] : null;
+        return this.modelValue ? this.modelValue[1] : null;
       },
       set(endInput) {
-        this.$emit(`input`, getRange(this.start, endInput));
+        this.$emit(`update:model-value`, getRange(this.start, endInput));
         this.$emit(`end-updated`);
       },
     },
     rangeIncomplete() {
-      return this.range && (this.start === null || this.end === null);
+      return this.modelValue && (this.start === null || this.end === null);
     },
   },
   mounted() {

--- a/ui/components/PropertyInputRange.vue
+++ b/ui/components/PropertyInputRange.vue
@@ -55,6 +55,14 @@ export default {
     required: booleanProp().withDefault(false),
     formstate: objectProp().required,
   },
+  emits: {
+    input: range => true,
+    'start-updated': () => true,
+    'end-updated': () => true,
+    focus: () => true,
+    blur: () => true,
+    'vf:validate': validationData => true,
+  },
   data() {
     return {
       validationData: {

--- a/ui/components/PropertyInputSelect.vue
+++ b/ui/components/PropertyInputSelect.vue
@@ -24,6 +24,9 @@ export default {
     additionHint: stringProp().optional,
     value: anyProp().required,
   },
+  emits: {
+    input: value => true,
+  },
   computed: {
     localValue: {
       get() {

--- a/ui/components/PropertyInputText.vue
+++ b/ui/components/PropertyInputText.vue
@@ -21,6 +21,11 @@ export default {
     hint: stringProp().optional,
     value: anyProp().required,
   },
+  emits: {
+    input: value => true,
+    blur: value => true,
+    'vf:validate': validationData => true,
+  },
   data() {
     return {
       localValue: ``,

--- a/ui/components/PropertyInputTextarea.vue
+++ b/ui/components/PropertyInputTextarea.vue
@@ -18,6 +18,10 @@ export default {
     hint: stringProp().optional,
     value: anyProp().required,
   },
+  emits: {
+    input: value => true,
+    'vf:validate': validationData => true,
+  },
   data() {
     return {
       localValue: ``,

--- a/ui/components/editor/EditorCapability.vue
+++ b/ui/components/editor/EditorCapability.vue
@@ -42,7 +42,7 @@
 
       <EditorCapabilityTypeData
         ref="capabilityTypeData"
-        v-model="capability"
+        :capability="capability"
         :channel="channel"
         :formstate="formstate"
         required />

--- a/ui/components/editor/EditorCapability.vue
+++ b/ui/components/editor/EditorCapability.vue
@@ -108,6 +108,10 @@ export default {
     resolution: numberProp().required,
     formstate: objectProp().required,
   },
+  emits: {
+    'insert-capability-before': () => true,
+    'insert-capability-after': () => true,
+  },
   data() {
     return {
       dmxMin: 0,

--- a/ui/components/editor/EditorCapabilityTypeData.vue
+++ b/ui/components/editor/EditorCapabilityTypeData.vue
@@ -128,9 +128,6 @@ export default {
     CapabilityMaintenance,
     CapabilityGeneric,
   },
-  model: {
-    prop: `capability`,
-  },
   props: {
     capability: objectProp().required,
     channel: objectProp().required,

--- a/ui/components/editor/EditorCapabilityWizard.vue
+++ b/ui/components/editor/EditorCapabilityWizard.vue
@@ -164,6 +164,9 @@ export default {
     resolution: numberProp().required,
     wizard: objectProp().required,
   },
+  emits: {
+    close: insertIndex => true,
+  },
   computed: {
     capabilities() {
       return this.channel.capabilities;

--- a/ui/components/editor/EditorCapabilityWizard.vue
+++ b/ui/components/editor/EditorCapabilityWizard.vue
@@ -44,7 +44,7 @@
     </section>
 
     <EditorCapabilityTypeData
-      v-model="wizard.templateCapability"
+      :capability="wizard.templateCapability"
       :channel="channel" />
 
     <table class="capabilities-table">

--- a/ui/components/editor/EditorCategoryChooser.vue
+++ b/ui/components/editor/EditorCategoryChooser.vue
@@ -8,8 +8,8 @@
         selected
         selectable
         @click="deselect(cat)"
-        @focus.native="onFocus()"
-        @blur.native="onBlur($event)" />
+        @focus="onFocus()"
+        @blur="onBlur($event)" />
     </Draggable>
 
     <CategoryBadge
@@ -18,8 +18,8 @@
       :category="cat"
       selectable
       @click="select(cat)"
-      @focus.native="onFocus()"
-      @blur.native="onBlur($event)" />
+      @focus="onFocus()"
+      @blur="onBlur($event)" />
   </div>
 </template>
 

--- a/ui/components/editor/EditorCategoryChooser.vue
+++ b/ui/components/editor/EditorCategoryChooser.vue
@@ -39,6 +39,11 @@ export default {
     value: arrayProp().required,
     allCategories: arrayProp().required,
   },
+  emits: {
+    input: value => true,
+    focus: () => true,
+    blur: () => true,
+  },
   computed: {
     selectedCategories: {
       get() {

--- a/ui/components/editor/EditorChannelDialog.vue
+++ b/ui/components/editor/EditorChannelDialog.vue
@@ -275,9 +275,6 @@ export default {
     PropertyInputSelect,
     PropertyInputText,
   },
-  model: {
-    prop: `channel`,
-  },
   props: {
     channel: objectProp().required,
     fixture: objectProp().required,

--- a/ui/components/editor/EditorChannelDialog.vue
+++ b/ui/components/editor/EditorChannelDialog.vue
@@ -282,6 +282,11 @@ export default {
     channel: objectProp().required,
     fixture: objectProp().required,
   },
+  emits: {
+    'channel-changed': () => true,
+    'remove-channel': channelId => true,
+    'reset-channel': () => true,
+  },
   data() {
     return {
       formstate: getEmptyFormState(),

--- a/ui/components/editor/EditorFileUpload.vue
+++ b/ui/components/editor/EditorFileUpload.vue
@@ -12,18 +12,19 @@ import { anyProp, booleanProp, stringProp } from 'vue-ts-types';
 
 export default {
   model: {
-    prop: `file`,
+    prop: `model-value`,
+    event: `update:model-value`,
   },
   props: {
     required: booleanProp().withDefault(false),
     name: stringProp().required,
-    file: anyProp().optional,
+    modelValue: anyProp().optional,
   },
   emits: {
-    input: value => true,
+    'update:model-value': value => true,
   },
   watch: {
-    file(newFile) {
+    modelValue(newFile) {
       if (!newFile) {
         this.$refs.fileInput.value = ``;
       }
@@ -37,11 +38,11 @@ export default {
       const file = this.$refs.fileInput.files[0];
 
       if (!file) {
-        this.$emit(`input`, undefined);
+        this.$emit(`update:model-value`, undefined);
         return;
       }
 
-      this.$emit(`input`, file);
+      this.$emit(`update:model-value`, file);
     },
   },
 };

--- a/ui/components/editor/EditorFileUpload.vue
+++ b/ui/components/editor/EditorFileUpload.vue
@@ -19,6 +19,9 @@ export default {
     name: stringProp().required,
     file: anyProp().optional,
   },
+  emits: {
+    input: value => true,
+  },
   watch: {
     file(newFile) {
       if (!newFile) {

--- a/ui/components/editor/EditorLink.vue
+++ b/ui/components/editor/EditorLink.vue
@@ -72,6 +72,11 @@ export default {
     canRemove: booleanProp().required,
     formstate: objectProp().required,
   },
+  emits: {
+    'set-type': type => true,
+    'set-url': url => true,
+    remove: () => true,
+  },
   data() {
     const { linkTypeIconNames, linkTypeNames } = fixtureLinkTypes;
     return {

--- a/ui/components/editor/EditorLinks.vue
+++ b/ui/components/editor/EditorLinks.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="links">
     <EditorLink
-      v-for="link of links"
+      v-for="link of modelValue"
       :key="link.uuid"
       ref="links"
       :link="link"
-      :can-remove="links.length > 1"
+      :can-remove="modelValue.length > 1"
       :formstate="formstate"
       @set-type="updateLinkProperty(link, `type`, $event)"
       @set-url="updateLinkProperty(link, `url`, $event)"
@@ -30,19 +30,20 @@ export default {
   },
   inheritAttrs: false,
   model: {
-    prop: `links`,
+    prop: `model-value`,
+    event: `update:model-value`,
   },
   props: {
-    links: arrayProp().required,
+    modelValue: arrayProp().required,
     formstate: objectProp().required,
   },
   emits: {
-    input: value => true,
+    'update:model-value': value => true,
   },
   methods: {
     async addLink() {
-      const newLinks = [...this.links, getEmptyLink()];
-      this.$emit(`input`, newLinks);
+      const newLinks = [...this.modelValue, getEmptyLink()];
+      this.$emit(`update:model-value`, newLinks);
 
       await this.$nextTick();
       this.$refs.links[newLinks.length - 1].focus();
@@ -53,12 +54,12 @@ export default {
         [key]: value,
       };
 
-      this.$emit(`input`, this.links.map(
+      this.$emit(`update:model-value`, this.modelValue.map(
         link => (link === updateLink ? updatedLink : link),
       ));
     },
     removeLink(removeLink) {
-      this.$emit(`input`, this.links.filter(
+      this.$emit(`update:model-value`, this.modelValue.filter(
         link => link !== removeLink,
       ));
     },

--- a/ui/components/editor/EditorLinks.vue
+++ b/ui/components/editor/EditorLinks.vue
@@ -36,6 +36,9 @@ export default {
     links: arrayProp().required,
     formstate: objectProp().required,
   },
+  emits: {
+    input: value => true,
+  },
   methods: {
     async addLink() {
       const newLinks = [...this.links, getEmptyLink()];

--- a/ui/components/editor/EditorMode.vue
+++ b/ui/components/editor/EditorMode.vue
@@ -219,9 +219,6 @@ export default {
     PropertyInputNumber,
     PropertyInputText,
   },
-  model: {
-    prop: `mode`,
-  },
   props: {
     mode: objectProp().required,
     index: numberProp().required,

--- a/ui/components/editor/EditorMode.vue
+++ b/ui/components/editor/EditorMode.vue
@@ -228,6 +228,10 @@ export default {
     fixture: objectProp().required,
     formstate: objectProp().required,
   },
+  emits: {
+    remove: () => true,
+    'open-channel-editor': payload => true,
+  },
   data() {
     return {
       schemaDefinitions,

--- a/ui/components/editor/EditorPhysical.vue
+++ b/ui/components/editor/EditorPhysical.vue
@@ -142,6 +142,9 @@ export default {
     formstate: objectProp().required,
     namePrefix: stringProp().required,
   },
+  emits: {
+    input: value => true,
+  },
   data() {
     return {
       schemaDefinitions,

--- a/ui/components/editor/EditorPhysical.vue
+++ b/ui/components/editor/EditorPhysical.vue
@@ -41,7 +41,7 @@
         :schema-property="physicalProperties.DMXconnector"
         addition-hint="other DMX connector" />
       <Validate
-        v-if="physical.DMXconnector === `[add-value]`"
+        v-if="modelValue.DMXconnector === `[add-value]`"
         :state="formstate"
         tag="span">
         <PropertyInputText
@@ -135,15 +135,16 @@ export default {
     PropertyInputText,
   },
   model: {
-    prop: `physical`,
+    prop: `model-value`,
+    event: `update:model-value`,
   },
   props: {
-    physical: objectProp().required,
+    modelValue: objectProp().required,
     formstate: objectProp().required,
     namePrefix: stringProp().required,
   },
   emits: {
-    input: value => true,
+    'update:model-value': value => true,
   },
   data() {
     return {
@@ -151,17 +152,17 @@ export default {
       physicalProperties,
       physicalBulbProperties,
       physicalLensProperties,
-      localPhysical: clone(this.physical),
+      localPhysical: clone(this.modelValue),
     };
   },
   watch: {
     localPhysical: {
       handler() {
-        this.$emit(`input`, clone(this.localPhysical));
+        this.$emit(`update:model-value`, clone(this.localPhysical));
       },
       deep: true,
     },
-    'physical.DMXconnector': async function(newValue) {
+    'modelValue.DMXconnector': async function(newValue) {
       if (newValue === `[add-value]` && this.$root._oflRestoreComplete) {
         await this.$nextTick();
         this.$refs.newDmxConnectorInput.focus();

--- a/ui/components/editor/EditorRestoreDialog.vue
+++ b/ui/components/editor/EditorRestoreDialog.vue
@@ -2,7 +2,7 @@
   <A11yDialog
     id="restore-dialog"
     is-alert-dialog
-    :shown="restoredData !== undefined"
+    :shown="modelValue !== undefined"
     title="Auto-saved fixture data found">
 
     Do you want to restore the data (auto-saved <time>{{ restoredDate }}</time>) to continue to create the fixture?
@@ -46,21 +46,22 @@ export default {
     A11yDialog,
   },
   model: {
-    prop: `restoredData`,
+    prop: `model-value`,
+    event: `update:model-value`,
   },
   props: {
-    restoredData: objectProp().optional,
+    modelValue: objectProp().optional,
   },
   emits: {
-    input: value => true,
+    'update:model-value': value => true,
     'restore-complete': () => true,
   },
   computed: {
     restoredDate() {
-      if (this.restoredData === undefined) {
+      if (this.modelValue === undefined) {
         return undefined;
       }
-      return (new Date(this.restoredData.timestamp)).toISOString().replace(/\..*$/, ``).replace(`T`, `, `);
+      return (new Date(this.modelValue.timestamp)).toISOString().replace(/\..*$/, ``).replace(`T`, `, `);
     },
   },
   methods: {
@@ -68,21 +69,21 @@ export default {
       // put all items except the last one back
       localStorage.setItem(`autoSave`, JSON.stringify(JSON.parse(localStorage.getItem(`autoSave`)).slice(0, -1)));
 
-      this.$emit(`input`, undefined);
+      this.$emit(`update:model-value`, undefined);
       this.$emit(`restore-complete`);
     },
 
     async applyRestored() {
-      const restoredData = clone(this.restoredData);
+      const modelValue = clone(this.modelValue);
 
       // closes dialog
-      this.$emit(`input`, undefined);
+      this.$emit(`update:model-value`, undefined);
 
       // restoring could open another dialog -> wait for DOM being up-to-date
       await this.$nextTick();
 
-      this.$parent.fixture = getRestoredFixture(restoredData.fixture);
-      this.$parent.channel = getRestoredChannel(restoredData.channel, true);
+      this.$parent.fixture = getRestoredFixture(modelValue.fixture);
+      this.$parent.channel = getRestoredChannel(modelValue.channel, true);
 
       await this.$nextTick();
       this.$emit(`restore-complete`);

--- a/ui/components/editor/EditorRestoreDialog.vue
+++ b/ui/components/editor/EditorRestoreDialog.vue
@@ -51,6 +51,10 @@ export default {
   props: {
     restoredData: objectProp().optional,
   },
+  emits: {
+    input: value => true,
+    'restore-complete': () => true,
+  },
   computed: {
     restoredDate() {
       if (this.restoredData === undefined) {

--- a/ui/components/editor/EditorSubmitDialog.vue
+++ b/ui/components/editor/EditorSubmitDialog.vue
@@ -239,6 +239,10 @@ export default {
     githubUsername: stringProp().optional,
     githubComment: stringProp().optional,
   },
+  emits: {
+    success: () => true,
+    reset: () => true,
+  },
   data() {
     return {
       state: `closed`,

--- a/ui/components/editor/EditorWheelSlot.vue
+++ b/ui/components/editor/EditorWheelSlot.vue
@@ -77,9 +77,6 @@ export default {
     WheelSlotOpen,
     WheelSlotPrism,
   },
-  model: {
-    prop: `capability`,
-  },
   props: {
     channel: objectProp().required,
     slotNumber: integerProp().required,

--- a/ui/components/fixture-page/FixturePage.vue
+++ b/ui/components/fixture-page/FixturePage.vue
@@ -223,6 +223,9 @@ export default {
     fixture: instanceOfProp(Fixture).required,
     loadAllModes: booleanProp().withDefault(false),
   },
+  emits: {
+    'help-wanted-clicked': payload => true,
+  },
   data() {
     const { linkTypeIconNames, linkTypeNames } = fixtureLinkTypes;
     return {

--- a/ui/components/fixture-page/FixturePageCapabilityTable.vue
+++ b/ui/components/fixture-page/FixturePageCapabilityTable.vue
@@ -144,6 +144,9 @@ export default {
     mode: instanceOfProp(Mode).required,
     resolutionInMode: numberProp().required,
   },
+  emits: {
+    'help-wanted-clicked': payload => true,
+  },
   computed: {
     capabilities() {
       return this.channel.capabilities.map(capability => {

--- a/ui/components/fixture-page/FixturePageChannel.vue
+++ b/ui/components/fixture-page/FixturePageChannel.vue
@@ -166,6 +166,9 @@ export default {
     mode: instanceOfProp(Mode).required,
     appendToHeading: stringProp().optional,
   },
+  emits: {
+    'help-wanted-clicked': payload => true,
+  },
   data() {
     return {
       CoarseChannel,

--- a/ui/components/fixture-page/FixturePageMode.vue
+++ b/ui/components/fixture-page/FixturePageMode.vue
@@ -77,6 +77,9 @@ export default {
   props: {
     mode: instanceOfProp(Mode).required,
   },
+  emits: {
+    'help-wanted-clicked': payload => true,
+  },
   data() {
     return {
       hasDetails: true,

--- a/ui/components/global/OflTime.vue
+++ b/ui/components/global/OflTime.vue
@@ -1,6 +1,6 @@
-<template functional>
-  <time :datetime="props.date.toISOString()" :title="props.date.toISOString()">{{
-    props.date.toISOString().replace(/T.*?$/, ``)
+<template>
+  <time :datetime="isoDate" :title="isoDate">{{
+    isoDate.replace(/T.*?$/, ``)
   }}</time>
 </template>
 
@@ -10,6 +10,11 @@ import { instanceOfProp } from 'vue-ts-types';
 export default {
   props: {
     date: instanceOfProp(Date).required,
+  },
+  computed: {
+    isoDate() {
+      return this.date.toISOString();
+    },
   },
 };
 </script>

--- a/ui/pages/fixture-editor.vue
+++ b/ui/pages/fixture-editor.vue
@@ -41,7 +41,7 @@
           <EditorMode
             v-for="(mode, index) of fixture.modes"
             :key="mode.uuid"
-            v-model="fixture.modes[index]"
+            :mode="fixture.modes[index]"
             :index="index"
             :fixture="fixture"
             :formstate="formstate"

--- a/ui/pages/fixture-editor.vue
+++ b/ui/pages/fixture-editor.vue
@@ -91,7 +91,7 @@
       </VueForm>
 
       <EditorChannelDialog
-        v-model="channel"
+        :channel="channel"
         :fixture="fixture"
         @reset-channel="resetChannel()"
         @channel-changed="autoSave(`channel`)"


### PR DESCRIPTION
Enable and fix Vue 3 migration ESLint rules that can also apply to Vue 2, to make the actual Vue 3 migration easier.