### PR TITLE
Add jetbrains `.idea` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ npm-debug.log
 .DS_Store
 *.sublime-*
 .vscode/
+.idea/
 
 # Docker
 Dockerfile


### PR DESCRIPTION
Adds the `.idea` folder generated from the Jetbrains' IDE to the gitignore. There have been a couple of times where I have almost committed this folder while updating fixtures :sweat_smile: 