### PR TITLE
Remove broken product link

### DIFF
--- a/fixtures/uking/mini-led-spot-25w.json
+++ b/fixtures/uking/mini-led-spot-25w.json
@@ -7,11 +7,6 @@
     "createDate": "2020-04-18",
     "lastModifyDate": "2020-04-18"
   },
-  "links": {
-    "productPage": [
-      "https://www.amazon.com/dp/B01M0QAIPU"
-    ]
-  },
   "physical": {
     "dimensions": [17.8, 25, 17.8],
     "weight": 2.8,


### PR DESCRIPTION
Removes broken Amazon link from U`King [Mini LED Spot 25W](https://open-fixture-library.org/uking/mini-led-spot-25w). No alternative is available.

Resolves #3556