### PR TITLE
Add fixture `oxo-light/pixyline-150`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -378,6 +378,11 @@
     "name": "Orion Effects Lighting",
     "website": "https://orion-fxlights.com/"
   },
+  "oxo-light": {
+    "name": "OXO Light",
+    "website": "https://www.oxolight.com/",
+    "rdmId": 0
+  },
   "panasonic": {
     "name": "Panasonic",
     "website": "https://panasonic.net/cns/projector/"

--- a/fixtures/oxo-light/pixyline-150.json
+++ b/fixtures/oxo-light/pixyline-150.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Pixyline 150",
+  "shortName": "Pixyline 150",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["Chagouli"],
+    "createDate": "2023-10-24",
+    "lastModifyDate": "2023-10-24"
+  },
+  "links": {
+    "manual": [
+      "https://docs.wixstatic.com/ugd/7e664f_c54f4245ce8d449fbb17177a7bc2eab1.pdf"
+    ],
+    "productPage": [
+      "https://www.oxolight.com/product-page/pixyline-150"
+    ],
+    "video": [
+      "https://www.facebook.com/watch/?v=389803451738198"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "5 Channels",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `oxo-light/pixyline-150`

### Fixture warnings / errors

* oxo-light/pixyline-150
  - :x: Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - :warning: Mode '5 Channels' should have shortName '5ch' instead of '5 Channels'.
  - :warning: Mode '5 Channels' should have shortName '5ch' instead of '5 Channels'.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Chagouli**!