### PR TITLE
Add fixture `beamz/mhl-74`

### DIFF
--- a/fixtures/beamz/mhl-74.json
+++ b/fixtures/beamz/mhl-74.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "MHL-74",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Helfire"],
+    "createDate": "2023-10-24",
+    "lastModifyDate": "2023-10-24"
+  },
+  "links": {
+    "manual": [
+      "https://www.manua.ls/beamz/mhl-74/manual?p=2"
+    ]
+  },
+  "physical": {
+    "dimensions": [225, 225, 27],
+    "weight": 4.2,
+    "power": 70,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "Led"
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Pan F": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt F": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Color Presets": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    },
+    "Strobe Speed": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "stop",
+        "speedEnd": "fast"
+      }
+    },
+    "Sound Sensitivity": {
+      "capability": {
+        "type": "SoundSensitivity",
+        "soundSensitivityStart": "off",
+        "soundSensitivityEnd": "high"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "7 Channels",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    },
+    {
+      "name": "12 Channels",
+      "channels": [
+        "Pan",
+        "Pan F",
+        "Tilt",
+        "Tilt F",
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Color Presets",
+        "Strobe Speed",
+        "Sound Sensitivity"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `beamz/mhl-74`

### Fixture warnings / errors

* beamz/mhl-74
  - :warning: Mode '7 Channels' should have shortName '7ch' instead of '7 Channels'.
  - :warning: Mode '7 Channels' should have shortName '7ch' instead of '7 Channels'.
  - :warning: Mode '12 Channels' should have shortName '12ch' instead of '12 Channels'.
  - :warning: Mode '12 Channels' should have shortName '12ch' instead of '12 Channels'.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Helfire**!