### PR TITLE
Add fixture `fun-generation/pico-spot-45`

### DIFF
--- a/fixtures/fun-generation/pico-spot-45.json
+++ b/fixtures/fun-generation/pico-spot-45.json
@@ -1,0 +1,214 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Pico Spot 45",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Fabian Ebert"],
+    "createDate": "2023-10-28",
+    "lastModifyDate": "2023-10-28"
+  },
+  "links": {
+    "manual": [
+      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/c_424284_v4_de_online.pdf"
+    ]
+  },
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        {
+          "type": "Color",
+          "name": "weiß"
+        },
+        {
+          "type": "Color",
+          "name": "rot"
+        },
+        {
+          "type": "Color",
+          "name": "orange"
+        },
+        {
+          "type": "Color",
+          "name": "gelb"
+        },
+        {
+          "type": "Color",
+          "name": "grün"
+        },
+        {
+          "type": "Color",
+          "name": "blau"
+        },
+        {
+          "type": "Color",
+          "name": "cyan"
+        },
+        {
+          "type": "Color",
+          "name": "lila"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Drehung pan": {
+      "fineChannelAliases": ["Drehung pan fine"],
+      "capability": {
+        "type": "Pan",
+        "angle": "0deg"
+      }
+    },
+    "Drehung tilt": {
+      "fineChannelAliases": ["Drehung tilt fine"],
+      "capability": {
+        "type": "Tilt",
+        "angle": "200deg"
+      }
+    },
+    "Motorgeschwindigkeit": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speed": "fast"
+      }
+    },
+    "Color Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [11, 21],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [22, 32],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [33, 43],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [44, 54],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [55, 65],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [66, 76],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [77, 87],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [88, 175],
+          "type": "WheelSlotRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [176, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 124],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [125, 249],
+          "type": "WheelShake"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [10, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "25Hz"
+        }
+      ]
+    },
+    "Program Duration": {
+      "capability": {
+        "type": "EffectDuration",
+        "durationStart": "short",
+        "durationEnd": "long"
+      }
+    },
+    "Program Speed": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "11",
+      "channels": [
+        "Drehung pan",
+        "Drehung tilt",
+        "Drehung pan fine",
+        "Drehung tilt fine",
+        "Motorgeschwindigkeit",
+        "Color Wheel",
+        "Gobo Wheel",
+        "Dimmer",
+        "Strobe",
+        "Program Duration",
+        "Program Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `fun-generation/pico-spot-45`

### Fixture warnings / errors

* fun-generation/pico-spot-45
  - :x: Capability 'Wheel rotation CW slow…fast' (0…124) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: File could not be imported into model. TypeError: Cannot read properties of null (reading 'name')
    at /home/flo/open-fixture-library/lib/model/Capability.js:80:115
    at Array.map (<anonymous>)
    at Object.WheelShake (/home/flo/open-fixture-library/lib/model/Capability.js:80:94)
    at get name [as name] (/home/flo/open-fixture-library/lib/model/Capability.js:339:76)
    at checkCapabilities (/home/flo/open-fixture-library/tests/fixture-valid.js:464:63)
    at checkChannel (/home/flo/open-fixture-library/tests/fixture-valid.js:429:5)
    at checkChannels (/home/flo/open-fixture-library/tests/fixture-valid.js:382:9)
    at checkFixture (/home/flo/open-fixture-library/tests/fixture-valid.js:101:5)
    at async addFixture (/home/flo/open-fixture-library/ui/api/routes/fixtures/from-editor.js:128:25)
    at async Promise.all (index 0)


Thank you **Fabian Ebert**!