### PR TITLE
Add fixture `eurolite/led-ip-t-bar-16-qlc--bar`

### DIFF
--- a/fixtures/eurolite/led-ip-t-bar-16-qlc--bar.json
+++ b/fixtures/eurolite/led-ip-t-bar-16-qlc--bar.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED IP T-BAR 16 QLC- BAR",
+  "categories": ["Other"],
+  "meta": {
+    "authors": ["Pixels en scène", "SebD"],
+    "createDate": "2023-10-30",
+    "lastModifyDate": "2023-10-30",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2023-10-30",
+      "comment": "created by Q Light Controller Plus (version 4.12.6)"
+    }
+  },
+  "physical": {
+    "dimensions": [1065, 126, 100],
+    "weight": 5.95,
+    "power": 50,
+    "DMXconnector": "5-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "comment": "Red intensity (0 - 100%)"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Brightness": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Auto Controlled programs": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [10, 29],
+          "type": "Maintenance",
+          "comment": "Auto program 1"
+        },
+        {
+          "dmxRange": [30, 49],
+          "type": "Maintenance",
+          "comment": "Auto program 2"
+        },
+        {
+          "dmxRange": [50, 69],
+          "type": "Maintenance",
+          "comment": "Auto program 3"
+        },
+        {
+          "dmxRange": [70, 89],
+          "type": "Maintenance",
+          "comment": "Auto program 4"
+        },
+        {
+          "dmxRange": [90, 109],
+          "type": "Maintenance",
+          "comment": "Auto program 5"
+        },
+        {
+          "dmxRange": [110, 129],
+          "type": "Maintenance",
+          "comment": "Auto program 6"
+        },
+        {
+          "dmxRange": [130, 149],
+          "type": "Maintenance",
+          "comment": "Auto program 7"
+        },
+        {
+          "dmxRange": [150, 169],
+          "type": "Maintenance",
+          "comment": "Auto program 8"
+        },
+        {
+          "dmxRange": [170, 255],
+          "type": "Maintenance",
+          "comment": "Auto program 9"
+        }
+      ]
+    },
+    "Strobe Effect": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [10, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "Strobe with increasing speed 0-100%",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        }
+      ]
+    },
+    "Preset Colors": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [10, 19],
+          "type": "ColorPreset",
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [20, 29],
+          "type": "ColorPreset",
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [30, 39],
+          "type": "ColorPreset",
+          "comment": "Blue"
+        },
+        {
+          "dmxRange": [40, 49],
+          "type": "ColorPreset",
+          "comment": "White"
+        },
+        {
+          "dmxRange": [50, 59],
+          "type": "ColorPreset",
+          "comment": "Yellow"
+        },
+        {
+          "dmxRange": [60, 69],
+          "type": "ColorPreset",
+          "comment": "Magenta"
+        },
+        {
+          "dmxRange": [80, 89],
+          "type": "ColorPreset",
+          "comment": "Dark orange"
+        },
+        {
+          "dmxRange": [90, 99],
+          "type": "ColorPreset",
+          "comment": "Green Yellow"
+        },
+        {
+          "dmxRange": [100, 109],
+          "type": "ColorPreset",
+          "comment": "Salmon"
+        },
+        {
+          "dmxRange": [110, 119],
+          "type": "ColorPreset",
+          "comment": "Turquoise"
+        },
+        {
+          "dmxRange": [120, 129],
+          "type": "ColorPreset",
+          "comment": "Light green"
+        },
+        {
+          "dmxRange": [130, 139],
+          "type": "ColorPreset",
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [140, 149],
+          "type": "ColorPreset",
+          "comment": "Straw"
+        },
+        {
+          "dmxRange": [150, 159],
+          "type": "ColorPreset",
+          "comment": "Lavender"
+        },
+        {
+          "dmxRange": [160, 169],
+          "type": "ColorPreset",
+          "comment": "Light Blue"
+        },
+        {
+          "dmxRange": [170, 179],
+          "type": "ColorPreset",
+          "comment": "Dark Blue"
+        },
+        {
+          "dmxRange": [180, 189],
+          "type": "ColorPreset",
+          "comment": "Pink"
+        },
+        {
+          "dmxRange": [190, 255],
+          "type": "ColorPreset",
+          "comment": "All Leds on"
+        }
+      ]
+    },
+    "Speed Internal programs": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Speed",
+        "comment": "Speed,  auto programs, (Slow>fast)",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "Are the automatically added speed values correct?"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "9-channel",
+      "shortName": "9ch",
+      "channels": [
+        "Brightness",
+        "Strobe Effect",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Preset Colors",
+        "Auto Controlled programs",
+        "Speed Internal programs"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `eurolite/led-ip-t-bar-16-qlc--bar`

### Fixture warnings / errors

* eurolite/led-ip-t-bar-16-qlc--bar
  - :x: The first dmxRange has to start at 0 in capability 'Red' (10…19) in channel 'Preset Colors'.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


### User comment

Existe aussi en 3,4,5,6 channels.
Je n'ai créé ici que le mode 9ch avec lequel je travaille.

Thank you **Pixels en scène** and **SebD**!