### PR TITLE
Add fixture `abstract/tree`

### DIFF
--- a/fixtures/abstract/tree.json
+++ b/fixtures/abstract/tree.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "tree",
+  "categories": ["Strobe", "Stand", "Flower", "Barrel Scanner"],
+  "meta": {
+    "authors": ["Amy"],
+    "createDate": "2023-10-31",
+    "lastModifyDate": "2023-10-31"
+  },
+  "links": {
+    "manual": [
+      "http://dk.com"
+    ]
+  },
+  "rdm": {
+    "modelId": 1
+  },
+  "availableChannels": {
+    "Cyan": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Cyan"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "red",
+      "channels": [
+        "Cyan"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `abstract/tree`

### Fixture warnings / errors

* abstract/tree
  - :x: Category 'Barrel Scanner' invalid since there are no pan or tilt channels.


Thank you **Amy**!