### PR TITLE
Add fixture `ibiza/light-starball-gb`

### DIFF
--- a/fixtures/ibiza/light-starball-gb.json
+++ b/fixtures/ibiza/light-starball-gb.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Light Starball Gb",
+  "categories": ["Flower"],
+  "meta": {
+    "authors": ["Daniel Köbsch"],
+    "createDate": "2023-10-31",
+    "lastModifyDate": "2023-10-31",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2023-10-31",
+      "comment": "created by Q Light Controller Plus (version 4.12.7)"
+    }
+  },
+  "physical": {
+    "dimensions": [240, 315, 240],
+    "weight": 2,
+    "power": 30,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX values is strobe disabled?"
+      }
+    },
+    "Pan": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "360deg"
+      }
+    },
+    "Auto": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Speed"
+      }
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8-channel",
+      "shortName": "8ch",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe",
+        "Pan",
+        "Auto"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -264,6 +264,9 @@
     "name": "HSL",
     "website": "https://www.amazon.com/stores/HighIightSpIendidLife/page/C6F4337A-41CC-4560-880E-06BCA9E96924"
   },
+  "ibiza": {
+    "name": "Ibiza"
+  },
   "ibiza-light": {
     "name": "Ibiza light",
     "website": "https://lotronic.net/gb/brand/16-ibiza"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `ibiza/light-starball-gb`

### Fixture warnings / errors

* ibiza/light-starball-gb
  - :x: File does not match schema: fixture/availableChannels/Auto/capability (type: Speed) must have required property 'speed'
  - :x: File does not match schema: fixture/availableChannels/Auto/capability (type: Speed) must have required property 'speedStart'
  - :x: File does not match schema: fixture/availableChannels/Auto/capability (type: Speed) must match exactly one schema in oneOf
  - :warning: Please check if manufacturer is correct and add manufacturer URL.


### User comment

Older version with 3 LED and without the laser.

Thank you @dogo77!