### PR TITLE
Add links to `gruft` fixtures

### DIFF
--- a/fixtures/gruft/pixel-tube.json
+++ b/fixtures/gruft/pixel-tube.json
@@ -7,6 +7,11 @@
     "createDate": "2018-09-24",
     "lastModifyDate": "2018-11-19"
   },
+  "links": {
+    "productPage": [
+      "https://github.com/FloEdelmann/dmx-pixel-tubes"
+    ]
+  },
   "physical": {
     "dimensions": [1000, 30, 36.5],
     "power": 10,

--- a/fixtures/gruft/ventilator.json
+++ b/fixtures/gruft/ventilator.json
@@ -9,6 +9,11 @@
     "lastModifyDate": "2018-07-21"
   },
   "comment": "(C) Görli + Edelnörd 2016",
+  "links": {
+    "productPage": [
+      "https://github.com/FloEdelmann/DMX-Ventilator"
+    ]
+  },
   "physical": {
     "dimensions": [1000, 1000, 160],
     "weight": 10.0,


### PR DESCRIPTION
I open-sourced the repositories last year, but forgot to update the fixture links.