### PR TITLE
Add fixture `futurelight/cct`

### DIFF
--- a/fixtures/futurelight/cct.json
+++ b/fixtures/futurelight/cct.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "cct",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Amy"],
+    "createDate": "2023-11-03",
+    "lastModifyDate": "2023-11-03"
+  },
+  "links": {
+    "manual": [
+      "http://www.kt.cn"
+    ]
+  },
+  "availableChannels": {
+    "Effect Speed": {
+      "capability": {
+        "type": "Effect",
+        "effectPreset": "ColorFade",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "KL": {
+      "capability": {
+        "type": "Effect",
+        "effectPreset": "ColorJump"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "red",
+      "shortName": "r",
+      "channels": [
+        "Effect Speed",
+        "KL"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `futurelight/cct`

### Fixture warnings / errors

* futurelight/cct
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.


Thank you **Amy**!