### PR TITLE
Remove HTP from non-intensity channels

### DIFF
--- a/fixtures/robe/dj-scan-250-xt.json
+++ b/fixtures/robe/dj-scan-250-xt.json
@@ -167,7 +167,6 @@
       }
     },
     "Color Wheel": {
-      "precedence": "HTP",
       "capabilities": [
         {
           "dmxRange": [0, 7],

--- a/fixtures/sun-star/g-2011-nova.json
+++ b/fixtures/sun-star/g-2011-nova.json
@@ -397,7 +397,6 @@
       }
     },
     "Effect Speed": {
-      "precedence": "HTP",
       "capability": {
         "type": "EffectSpeed",
         "speedStart": "slow",
@@ -405,7 +404,6 @@
       }
     },
     "Rotation Speed": {
-      "precedence": "HTP",
       "capability": {
         "type": "Rotation",
         "speedStart": "fast CW",


### PR DESCRIPTION
HTP doesn't really make sense for channels like color wheels and effects.