### PR TITLE
Document shutter effect `Burst`

### DIFF
--- a/docs/capability-types.md
+++ b/docs/capability-types.md
@@ -79,7 +79,7 @@ To make common percentage values more readable, one can use specific keywords to
     ShutterStrobe
   </th>
   <td valign="top">shutterEffect<br><sub>:star2: required</sub><br><sub>:feet: <a href="#must-be-stepped">must be stepped</a></sub></td>
-  <td valign="top"><code>Open</code>, <code>Closed</code>, <code>Strobe</code>, <code>Pulse</code>, <code>RampUp</code>, <code>RampDown</code>, <code>RampUpDown</code>, <code>Lightning</code>, <code>Spikes</code></td>
+  <td valign="top"><code>Open</code>, <code>Closed</code>, <code>Strobe</code>, <code>Pulse</code>, <code>RampUp</code>, <code>RampDown</code>, <code>RampUpDown</code>, <code>Lightning</code>, <code>Spikes</code>, <code>Burst</code></td>
   <td valign="top"></td>
 </tr>
 <tr>


### PR DESCRIPTION
The spec:

```
        "shutterEffect": { "enum": [
          "Open",
          "Closed",
          "Strobe",
          "Pulse",
          "RampUp",
          "RampDown",
          "RampUpDown",
          "Lightning",
          "Spikes",
          "Burst"
        ] }
```

So I align documentation to this.