### PR TITLE
Add fixture `beamz/illusion-2`

### DIFF
--- a/fixtures/beamz/illusion-2.json
+++ b/fixtures/beamz/illusion-2.json
@@ -1,0 +1,286 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "illusion 2",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Tom Mulder"],
+    "createDate": "2023-11-22",
+    "lastModifyDate": "2023-11-22"
+  },
+  "links": {
+    "manual": [
+      "https://www.manua.ls/beamz/illusion-2/manual?p=34"
+    ]
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "630deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "210deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Dimmer Lamp": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [16, 95],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [96, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Color Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 30],
+          "type": "ColorIntensity",
+          "color": "White"
+        },
+        {
+          "dmxRange": [31, 55],
+          "type": "ColorIntensity",
+          "color": "Red"
+        },
+        {
+          "dmxRange": [56, 80],
+          "type": "ColorIntensity",
+          "color": "Green"
+        },
+        {
+          "dmxRange": [81, 105],
+          "type": "ColorIntensity",
+          "color": "Blue"
+        },
+        {
+          "dmxRange": [106, 130],
+          "type": "ColorIntensity",
+          "color": "Yellow"
+        },
+        {
+          "dmxRange": [131, 155],
+          "type": "ColorIntensity",
+          "color": "Amber"
+        },
+        {
+          "dmxRange": [156, 180],
+          "type": "ColorIntensity",
+          "color": "Magenta"
+        },
+        {
+          "dmxRange": [181, 205],
+          "type": "ColorIntensity",
+          "color": "Green",
+          "brightnessStart": "off",
+          "brightnessEnd": "off",
+          "comment": "Licht groen"
+        },
+        {
+          "dmxRange": [206, 230],
+          "type": "ColorIntensity",
+          "color": "Magenta",
+          "comment": "purple"
+        },
+        {
+          "dmxRange": [231, 255],
+          "type": "ColorIntensity",
+          "color": "Cyan"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 20],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [21, 33],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [34, 46],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [47, 59],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [60, 72],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [73, 85],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [86, 98],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [99, 111],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [112, 124],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [125, 137],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [138, 150],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [151, 163],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [164, 176],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [177, 189],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [190, 202],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [203, 215],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [216, 228],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [229, 241],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [242, 255],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        }
+      ]
+    },
+    "Shutter SMD Ring": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 29],
+          "type": "Intensity"
+        },
+        {
+          "dmxRange": [30, 225],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [226, 255],
+          "type": "Intensity"
+        }
+      ]
+    },
+    "Dimmer smd ring": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Programs": {
+      "capability": {
+        "type": "EffectParameter",
+        "parameterStart": "low",
+        "parameterEnd": "high"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "12ch",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Pan/Tilt Speed",
+        "Dimmer Lamp",
+        "Strobe",
+        "Color Wheel",
+        "Gobo Wheel",
+        "Shutter SMD Ring",
+        "Dimmer smd ring",
+        "Programs"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `beamz/illusion-2`

### Fixture warnings / errors

* beamz/illusion-2
  - :x: Capability 'Wheel rotation CW slow…fast' (0…20) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (21…33) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (34…46) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (47…59) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (60…72) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (73…85) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (86…98) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (99…111) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (112…124) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (125…137) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (138…150) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (151…163) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (164…176) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (177…189) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (190…202) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (203…215) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (216…228) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (229…241) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Capability 'Wheel rotation CW slow…fast' (242…255) in channel 'Gobo Wheel' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel' (through the channel name) does not exist.
  - :x: Mode '12ch' should have 12 channels according to its name but actually has 10.
  - :x: Mode '12ch' should have 12 channels according to its shortName but actually has 10.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Tom Mulder**!