### PR TITLE
Add fixture `beamz/1`

### DIFF
--- a/fixtures/beamz/1.json
+++ b/fixtures/beamz/1.json
@@ -1,0 +1,154 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "1",
+  "categories": ["Dimmer"],
+  "meta": {
+    "authors": ["Tom Mulder"],
+    "createDate": "2023-11-22",
+    "lastModifyDate": "2023-11-22"
+  },
+  "links": {
+    "manual": [
+      "https://www.manua.ls/beamz/illusion-2/manual?p=34"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "Led"
+    }
+  },
+  "wheels": {
+    "Intensity": {
+      "slots": [
+        {
+          "type": "Color"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "630deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "210deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [16, 95],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "slow"
+        },
+        {
+          "dmxRange": [96, 175],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [176, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true
+        }
+      ]
+    },
+    "Intensity": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Gobo": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speed": "stop"
+      }
+    },
+    "Shutter / Strobe SMD Ring": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 30],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [31, 225],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [226, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true
+        }
+      ]
+    },
+    "Dimmer SMD ring": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Program": {
+      "capability": {
+        "type": "WheelRotation",
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Kleur": {
+      "constant": true,
+      "precedence": "LTP",
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "10ch",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Pan/Tilt Speed",
+        "Dimmer",
+        "Strobe",
+        "Kleur",
+        "Gobo",
+        "Shutter / Strobe SMD Ring",
+        "Dimmer SMD ring",
+        "Program"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `beamz/1`

### Fixture warnings / errors

* beamz/1
  - :x: File does not match schema: fixture/wheels/Intensity/slots must NOT have fewer than 2 items


Thank you **Tom Mulder**!