### PR TITLE
Add fixture `generic/party-light`

### DIFF
--- a/fixtures/generic/party-light.json
+++ b/fixtures/generic/party-light.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Party Light",
+  "categories": ["Laser", "Effect", "Color Changer", "Dimmer"],
+  "meta": {
+    "authors": ["Andy"],
+    "createDate": "2023-12-27",
+    "lastModifyDate": "2023-12-27"
+  },
+  "links": {
+    "video": [
+      "https://google.com"
+    ]
+  },
+  "availableChannels": {
+    "Red": {
+      "defaultValue": "100%",
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Green": {
+      "defaultValue": "100%",
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Prism Rotation": {
+      "capability": {
+        "type": "Generic"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Donner Shizzle",
+      "channels": [
+        "Red",
+        "Green",
+        "Prism Rotation"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `generic/party-light`

### Fixture warnings / errors

* generic/party-light
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.


Thank you **Andy**!