### PR TITLE
Add fixture `flash-professional/led-moving-head-36x10w-zoom`

### DIFF
--- a/fixtures/flash-professional/led-moving-head-36x10w-zoom.json
+++ b/fixtures/flash-professional/led-moving-head-36x10w-zoom.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED moving head 36x10w ZOOM",
+  "shortName": "LED głowa 36x10w",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Mikolaj"],
+    "createDate": "2024-01-03",
+    "lastModifyDate": "2024-01-03"
+  },
+  "links": {
+    "manual": [
+      "https://flash-butrym.pl/pl/p/file/fb40b3b592a4f0680b8609e5aeb1e64a/F7100494-LED-Moving-Head-36x10-Zoom.pdf"
+    ],
+    "productPage": [
+      "https://flash-butrym.pl/pl/p/LED-Glowica-Ruchoma-36x10W-ZOOM/522"
+    ]
+  },
+  "physical": {
+    "dimensions": [435, 510, 400],
+    "weight": 10,
+    "power": 307,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [0, 70]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "1deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "1deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Intensity": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Time",
+        "timeStart": "long",
+        "timeEnd": "short"
+      }
+    },
+    "Zoom": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "wide",
+        "angleEnd": "narrow"
+      }
+    },
+    "No function": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "No function 2": {
+      "name": "No function",
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Reset": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "15CH",
+      "shortName": "15CH",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Pan/Tilt Speed",
+        "Intensity",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe",
+        "Zoom",
+        "No function",
+        "No function 2",
+        "Reset"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `flash-professional/led-moving-head-36x10w-zoom`

### Fixture warnings / errors

* flash-professional/led-moving-head-36x10w-zoom
  - :x: Mode '15CH' should have 15 channels according to its name but actually has 13.
  - :x: Mode '15CH' should have 15 channels according to its shortName but actually has 13.
  - :warning: Mode '15CH' should have shortName '15ch' instead of '15CH'.
  - :warning: Mode '15CH' should have shortName '15ch' instead of '15CH'.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Mikolaj**!