### PR TITLE
Add `chauvet-professional/rogue-r1-wash` shutter speeds

### DIFF
--- a/fixtures/chauvet-professional/rogue-r1-wash.json
+++ b/fixtures/chauvet-professional/rogue-r1-wash.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Ken Harris", "Flo Edelmann"],
     "createDate": "2022-03-07",
-    "lastModifyDate": "2024-01-02"
+    "lastModifyDate": "2024-01-08"
   },
   "links": {
     "manual": [
@@ -91,7 +91,9 @@
         {
           "dmxRange": [70, 84],
           "type": "ShutterStrobe",
-          "shutterEffect": "RampDown"
+          "shutterEffect": "RampDown",
+          "speedStart": "fast",
+          "speedEnd": "slow"
         },
         {
           "dmxRange": [85, 89],
@@ -101,7 +103,9 @@
         {
           "dmxRange": [90, 104],
           "type": "ShutterStrobe",
-          "shutterEffect": "RampUp"
+          "shutterEffect": "RampUp",
+          "speedStart": "fast",
+          "speedEnd": "slow"
         },
         {
           "dmxRange": [105, 109],
@@ -112,7 +116,9 @@
           "dmxRange": [110, 124],
           "type": "ShutterStrobe",
           "shutterEffect": "Strobe",
-          "randomTiming": true
+          "randomTiming": true,
+          "speedStart": "fast",
+          "speedEnd": "slow"
         },
         {
           "dmxRange": [125, 129],
@@ -123,7 +129,9 @@
           "dmxRange": [130, 144],
           "type": "ShutterStrobe",
           "shutterEffect": "RampDown",
-          "randomTiming": true
+          "randomTiming": true,
+          "speedStart": "fast",
+          "speedEnd": "slow"
         },
         {
           "dmxRange": [145, 149],
@@ -134,7 +142,9 @@
           "dmxRange": [150, 164],
           "type": "ShutterStrobe",
           "shutterEffect": "RampUp",
-          "randomTiming": true
+          "randomTiming": true,
+          "speedStart": "fast",
+          "speedEnd": "slow"
         },
         {
           "dmxRange": [165, 169],
@@ -144,7 +154,9 @@
         {
           "dmxRange": [170, 184],
           "type": "ShutterStrobe",
-          "shutterEffect": "Pulse"
+          "shutterEffect": "Pulse",
+          "speedStart": "fast",
+          "speedEnd": "slow"
         },
         {
           "dmxRange": [185, 189],
@@ -165,7 +177,9 @@
         {
           "dmxRange": [210, 224],
           "type": "ShutterStrobe",
-          "shutterEffect": "RampUpDown"
+          "shutterEffect": "RampUpDown",
+          "speedStart": "fast",
+          "speedEnd": "slow"
         },
         {
           "dmxRange": [225, 229],
@@ -175,7 +189,9 @@
         {
           "dmxRange": [230, 244],
           "type": "ShutterStrobe",
-          "shutterEffect": "Pulse"
+          "shutterEffect": "Pulse",
+          "speedStart": "fast",
+          "speedEnd": "slow"
         },
         {
           "dmxRange": [245, 255],

--- a/fixtures/chauvet-professional/rogue-r2-wash.json
+++ b/fixtures/chauvet-professional/rogue-r2-wash.json
@@ -113,7 +113,8 @@
         {
           "dmxRange": [70, 84],
           "type": "ShutterStrobe",
-          "shutterEffect": "RampDown"
+          "shutterEffect": "RampDown",
+          "helpWanted": "Are all these shutter ranges fast...slow like the Rogue R1 Wash?"
         },
         {
           "dmxRange": [85, 89],


### PR DESCRIPTION
I played around with the shutter feature, and discovered that even though the manual only says "Fast to slow" for one range, every shutter range except fully open/closed is a fast-to-slow range.

The Rogue R2 Wash has a similar shutter channel, and likely has the same ranges, but I don't have one to check.