### PR TITLE
Update `uking/b117` switched channel

### DIFF
--- a/fixtures/uking/b117-par-can-4in1-rgbw-18-leds.json
+++ b/fixtures/uking/b117-par-can-4in1-rgbw-18-leds.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Ken Harris", "Flo Edelmann"],
     "createDate": "2022-03-13",
-    "lastModifyDate": "2024-01-09"
+    "lastModifyDate": "2024-01-10"
   },
   "comment": "This is an unbranded fixture bought online, but the appearance and user manual match the UKing B117 closely.\n\nThe B117 webpage isn't even internally consistent, so I've done the best I could here.",
   "links": {
@@ -66,7 +66,7 @@
           "dmxRange": [0, 50],
           "type": "NoFunction",
           "switchChannels": {
-            "Color Presets / Effect Speed": "None"
+            "Color Presets / Effect Speed": "No Function"
           }
         },
         {
@@ -171,9 +171,9 @@
         "speedEnd": "fast"
       }
     },
-    "None": {
+    "No Function": {
+      "defaultValue": 0,
       "capability": {
-        "defaultValue": 0,
         "type": "NoFunction"
       }
     },

--- a/fixtures/uking/b117-par-can-4in1-rgbw-18-leds.json
+++ b/fixtures/uking/b117-par-can-4in1-rgbw-18-leds.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Ken Harris", "Flo Edelmann"],
     "createDate": "2022-03-13",
-    "lastModifyDate": "2024-01-02"
+    "lastModifyDate": "2024-01-09"
   },
   "comment": "This is an unbranded fixture bought online, but the appearance and user manual match the UKing B117 closely.\n\nThe B117 webpage isn't even internally consistent, so I've done the best I could here.",
   "links": {
@@ -66,7 +66,7 @@
           "dmxRange": [0, 50],
           "type": "NoFunction",
           "switchChannels": {
-            "Color Presets / Effect Speed": "Color Presets"
+            "Color Presets / Effect Speed": "None"
           }
         },
         {
@@ -169,6 +169,12 @@
         "type": "EffectSpeed",
         "speedStart": "slow",
         "speedEnd": "fast"
+      }
+    },
+    "None": {
+      "capability": {
+        "defaultValue": 0,
+        "type": "NoFunction"
       }
     },
     "Strobe": {


### PR DESCRIPTION
Previously, the switch at value 0 selected "Color Presets", which was a channel entirely populated with ColorPreset capabilities.

My understanding is that setting Effect=0=NoFunction would thus appear (to any application/user relying on this mapping) to enable the ColorPresets, which isn't how this fixture works.

This updates the switch to point to a dead channel when a non-effect is chosen.  I've found precedent for this in OFL, e.g., `varytec/giga-bar-frost-pix-8-rgb`.

(I'm still figuring out switched channels, so please check my work here!)