### PR TITLE
Add color wheel colors to `chauvet-dj/intimidator-spot-110`

### DIFF
--- a/fixtures/chauvet-dj/intimidator-spot-110.json
+++ b/fixtures/chauvet-dj/intimidator-spot-110.json
@@ -38,25 +38,39 @@
           "type": "Open"
         },
         {
-          "type": "Color"
+          "type": "Color",
+          "name": "Color 1 (Red)",
+          "colors": ["#ff0000"]
         },
         {
-          "type": "Color"
+          "type": "Color",
+          "name": "Color 2 (Green)",
+          "colors": ["#00ff00"]
         },
         {
-          "type": "Color"
+          "type": "Color",
+          "name": "Color 3 (Blue)",
+          "colors": ["#0000ff"]
         },
         {
-          "type": "Color"
+          "type": "Color",
+          "name": "Color 4 (Yellow)",
+          "colors": ["#ffff00"]
         },
         {
-          "type": "Color"
+          "type": "Color",
+          "name": "Color 5 (Purple)",
+          "colors": ["#ff55ff"]
         },
         {
-          "type": "Color"
+          "type": "Color",
+          "name": "Color 6 (Orange)",
+          "colors": ["#ffaa00"]
         },
         {
-          "type": "Color"
+          "type": "Color",
+          "name": "Color 7 (Light Blue)",
+          "colors": ["#00aaff"]
         }
       ]
     },

--- a/fixtures/chauvet-dj/intimidator-spot-110.json
+++ b/fixtures/chauvet-dj/intimidator-spot-110.json
@@ -3,9 +3,9 @@
   "name": "Intimidator Spot 110",
   "categories": ["Moving Head", "Color Changer"],
   "meta": {
-    "authors": ["Flo Edelmann"],
+    "authors": ["Flo Edelmann", "Lance Moore", "evan"],
     "createDate": "2019-07-26",
-    "lastModifyDate": "2019-07-26"
+    "lastModifyDate": "2024-01-16"
   },
   "links": {
     "manual": [
@@ -39,37 +39,37 @@
         },
         {
           "type": "Color",
-          "name": "Color 1 (Red)",
+          "name": "Red",
           "colors": ["#ff0000"]
         },
         {
           "type": "Color",
-          "name": "Color 2 (Green)",
+          "name": "Green",
           "colors": ["#00ff00"]
         },
         {
           "type": "Color",
-          "name": "Color 3 (Blue)",
+          "name": "Blue",
           "colors": ["#0000ff"]
         },
         {
           "type": "Color",
-          "name": "Color 4 (Yellow)",
+          "name": "Yellow",
           "colors": ["#ffff00"]
         },
         {
           "type": "Color",
-          "name": "Color 5 (Purple)",
+          "name": "Purple",
           "colors": ["#ff55ff"]
         },
         {
           "type": "Color",
-          "name": "Color 6 (Orange)",
+          "name": "Orange",
           "colors": ["#ffaa00"]
         },
         {
           "type": "Color",
-          "name": "Color 7 (Light Blue)",
+          "name": "Light Blue",
           "colors": ["#00aaff"]
         }
       ]


### PR DESCRIPTION
These values came from #3672, which is otherwise redundant.  I don't see these colors in the manual, but they seem perfectly reasonable.