### PR TITLE
Add colors to `martin/mx-10-extreme`

### DIFF
--- a/fixtures/martin/mx-10-extreme.json
+++ b/fixtures/martin/mx-10-extreme.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Ken Harris", "Flo Edelmann"],
     "createDate": "2022-03-15",
-    "lastModifyDate": "2024-01-20"
+    "lastModifyDate": "2024-01-22"
   },
   "links": {
     "manual": [

--- a/fixtures/martin/mx-10-extreme.json
+++ b/fixtures/martin/mx-10-extreme.json
@@ -5,7 +5,7 @@
   "meta": {
     "authors": ["Ken Harris", "Flo Edelmann"],
     "createDate": "2022-03-15",
-    "lastModifyDate": "2022-03-15"
+    "lastModifyDate": "2024-01-20"
   },
   "links": {
     "manual": [
@@ -81,47 +81,58 @@
         },
         {
           "type": "Color",
-          "name": "Yellow 603"
+          "name": "Yellow 603",
+          "colors": ["#ffff00"]
         },
         {
           "type": "Color",
-          "name": "Blue 104"
+          "name": "Blue 104",
+          "colors": ["#5badff"]
         },
         {
           "type": "Color",
-          "name": "Pink 312"
+          "name": "Pink 312",
+          "colors": ["#ff80ca"]
         },
         {
           "type": "Color",
-          "name": "Green 206"
+          "name": "Green 206",
+          "colors": ["#00ff00"]
         },
         {
           "type": "Color",
-          "name": "Blue 108"
+          "name": "Blue 108",
+          "colors": ["#0000aa"]
         },
         {
           "type": "Color",
-          "name": "Red 301"
+          "name": "Red 301",
+          "colors": ["#ff0000"]
         },
         {
           "type": "Color",
-          "name": "Magenta 507"
+          "name": "Magenta 507",
+          "colors": ["#ff00ff"]
         },
         {
           "type": "Color",
-          "name": "Blue 101"
+          "name": "Blue 101",
+          "colors": ["#0000ff"]
         },
         {
           "type": "Color",
-          "name": "Orange 306"
+          "name": "Orange 306",
+          "colors": ["#ffaa00"]
         },
         {
           "type": "Color",
-          "name": "Dark green"
+          "name": "Dark green",
+          "colors": ["#1dff00"]
         },
         {
           "type": "Color",
-          "name": "Purple 502"
+          "name": "Purple 502",
+          "colors": ["#9200ff"]
         }
       ]
     }


### PR DESCRIPTION
The manual has names and numbers, but the numbers seem to be Martin numbers that don't correspond to anything (like Rosco or Lee), so I mostly used color values from other fixtures with similarly named colors.

For blue, I searched the web for terms like `martin "blue 101"` and found photos of the filters, and from that I guessed as to the relative colors of those three (medium/sky/dark).