### PR TITLE
Add fixture `chauvet-professional/well-fit`

### DIFF
--- a/fixtures/chauvet-professional/well-fit.json
+++ b/fixtures/chauvet-professional/well-fit.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "WELL FIT",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Anonymous"],
+    "createDate": "2024-01-23",
+    "lastModifyDate": "2024-01-23"
+  },
+  "links": {
+    "manual": [
+      "https://www.chauvetprofessional.com/wp-content/uploads/2018/01/WELL_Fit_UM_Rev7.pdf"
+    ],
+    "productPage": [
+      "https://www.chauvetprofessional.com/"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=udYpuquvPCU"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "6 channel",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "Amber",
+        "Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `chauvet-professional/well-fit`

### Fixture warnings / errors

* chauvet-professional/well-fit
  - :warning: Mode '6 channel' should have shortName '6ch' instead of '6 channel'.
  - :warning: Mode '6 channel' should have shortName '6ch' instead of '6 channel'.


Thank you **Anonymous**!