### PR TITLE
Add fixture `china/led-prefoucs-profile-light`

### DIFF
--- a/fixtures/china/led-prefoucs-profile-light.json
+++ b/fixtures/china/led-prefoucs-profile-light.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "led prefoucs profile light",
+  "shortName": "profile",
+  "categories": ["Dimmer", "Moving Head"],
+  "meta": {
+    "authors": ["LEEKYUNGEUN"],
+    "createDate": "2024-02-05",
+    "lastModifyDate": "2024-02-05"
+  },
+  "links": {
+    "manual": [
+      "http://a.co.kr"
+    ],
+    "productPage": [
+      "http://a.co.kr"
+    ],
+    "video": [
+      "http://a.co.kr"
+    ]
+  },
+  "availableChannels": {
+    "3200k dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "5600k dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "CTC": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "CTO",
+        "colorTemperatureEnd": "CTB"
+      }
+    },
+    "Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "4ch",
+      "channels": [
+        "3200k dimmer",
+        "5600k dimmer",
+        "CTC",
+        "Intensity"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -96,6 +96,9 @@
     "website": "https://www.chauvetprofessional.com/",
     "rdmId": 8612
   },
+  "china": {
+    "name": "china"
+  },
   "chroma-q": {
     "name": "Chroma-Q",
     "website": "https://chroma-q.com/",


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `china/led-prefoucs-profile-light`

### Fixture warnings / errors

* china/led-prefoucs-profile-light
  - :x: Category 'Moving Head' invalid since there are not both pan and tilt channels.


Thank you **LEEKYUNGEUN**!