### PR TITLE
Add fixture `showtec/act-flood-100-rgbw`

### DIFF
--- a/fixtures/showtec/act-flood-100-rgbw.json
+++ b/fixtures/showtec/act-flood-100-rgbw.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "ACT Flood 100 RGBW",
+  "shortName": "ACT Flood 100 RGBW",
+  "categories": ["Dimmer", "Color Changer"],
+  "meta": {
+    "authors": ["Showtec"],
+    "createDate": "2024-02-06",
+    "lastModifyDate": "2024-02-06"
+  },
+  "links": {
+    "manual": [
+      "https://www.highlite.com/it/34020-act-pc-60-rgbw.html"
+    ]
+  },
+  "availableChannels": {
+    "ACT Flood 100 RGBW": {
+      "fineChannelAliases": ["ACT Flood 100 RGBW fine"],
+      "capability": {
+        "type": "Generic"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "ACT Flood 100 RGBW",
+      "channels": [
+        "ACT Flood 100 RGBW",
+        "ACT Flood 100 RGBW fine"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `showtec/act-flood-100-rgbw`

### Fixture warnings / errors

* showtec/act-flood-100-rgbw
  - :x: Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.


Thank you **Showtec**!