### PR TITLE
Add fixture `american-dj/ultra-bar-9`

### DIFF
--- a/fixtures/american-dj/ultra-bar-9.json
+++ b/fixtures/american-dj/ultra-bar-9.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Ultra Bar 9",
+  "shortName": "UltraBar9",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["kovike"],
+    "createDate": "2024-02-18",
+    "lastModifyDate": "2024-02-18"
+  },
+  "links": {
+    "manual": [
+      "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/6929/ultra_bar_9.pdf"
+    ],
+    "productPage": [
+      "https://www.adj.com/ultra-bar-9"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=WTbwV4y_1AE"
+    ]
+  },
+  "physical": {
+    "dimensions": [1060, 63, 90],
+    "weight": 2.6,
+    "power": 35,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "constant": true,
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 100,
+      "highlightValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red 1-3": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 1-3": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 1-3": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red 4-6": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 4-6": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 4-6": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red 7-9": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 7-9": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 7-9": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "highlightValue": 0,
+      "precedence": "HTP",
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "stop",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Dimmer": {
+      "defaultValue": "0%",
+      "highlightValue": "100%",
+      "precedence": "HTP",
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "3 Channel",
+      "shortName": "3CH",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    },
+    {
+      "name": "11 Channel",
+      "shortName": "11CH",
+      "channels": [
+        "Red 1-3",
+        "Green 1-3",
+        "Blue 1-3",
+        "Red 4-6",
+        "Green 4-6",
+        "Blue 4-6",
+        "Red 7-9",
+        "Green 7-9",
+        "Blue 7-9",
+        "Strobe",
+        "Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `american-dj/ultra-bar-9`

### Fixture warnings / errors

* american-dj/ultra-bar-9
  - :x: Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - :warning: Mode '3 Channel' should have shortName '3ch' instead of '3CH'.
  - :warning: Mode '3 Channel' should have shortName '3ch' instead of '3CH'.
  - :warning: Mode '11 Channel' should have shortName '11ch' instead of '11CH'.
  - :warning: Mode '11 Channel' should have shortName '11ch' instead of '11CH'.
  - :warning: Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you @kovike88!