### PR TITLE
Add fixture `stairville/remus-hexspot-515`

### DIFF
--- a/fixtures/stairville/remus-515.json
+++ b/fixtures/stairville/remus-515.json
@@ -37,11 +37,88 @@
         "type": "Intensity"
       }
     },
+    "Color Temperature": {
+      "type": "ColorTemperature",
+      "colorTemperatureStart": "3200K",
+      "colorTemperatureEnd": "7280K"
+    },
+    "Color Temperature 2": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [6, 255],
+          "type": "ColorTemperature",
+          "colorTemperatureStart": "3200K",
+          "colorTemperatureEnd": "7280K"
+        }
+      ]
+    },
     "Shutter / Strobe": {
-      "capability": {
-        "type": "ShutterStrobe",
-        "shutterEffect": "Open"
-      }
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [6, 10],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [11, 33],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse",
+          "randomTiming": true,
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [34, 56],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUp",
+          "randomTiming": true,
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [57, 79],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampDown",
+          "randomTiming": true,
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [80, 102],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true,
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [103, 127],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Burst",
+          "helpWanted": "Is this increasing speed, too?"
+        },
+        {
+          "dmxRange": [128, 250],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "1Hz",
+          "speedEnd": "20Hz"
+        },
+        {
+          "dmxRange": [251, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
     },
     "Red": {
       "capability": {
@@ -80,12 +157,132 @@
       }
     },
     "Color Macros": {
-      "capability": {
-        "type": "NoFunction"
-      }
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "NoFunction",
+          "helpWanted": "Does this enable RGBWAUV, or is it actually a blackout?"
+        },
+        {
+          "dmxRange": [11, 13],
+          "type": "ColorPreset",
+          "colors": ["#ff0000"],
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [14, 21],
+          "type": "ColorPreset",
+          "colors": ["#ffbf00"],
+          "comment": "Amber"
+        },
+        {
+          "dmxRange": [22, 29],
+          "type": "ColorPreset",
+          "colors": ["#ffd000"],
+          "comment": "Warm yellow"
+        },
+        {
+          "dmxRange": [30, 101],
+          "type": "NoFunction",
+          "helpWanted": "What ranges/colors are here?"
+        },
+        {
+          "dmxRange": [102, 109],
+          "type": "ColorPreset",
+          "colors": ["#ffeebe"],
+          "comment": "Warm white"
+        },
+        {
+          "dmxRange": [110, 117],
+          "type": "ColorPreset",
+          "colors": ["#ffffff"],
+          "comment": "White"
+        },
+        {
+          "dmxRange": [118, 125],
+          "type": "ColorPreset",
+          "colors": ["#ccffff"],
+          "comment": "Cool white"
+        },
+        {
+          "dmxRange": [126, 127],
+          "type": "Effect",
+          "effectPreset": "ColorJump",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "Effect",
+          "effectPreset": "ColorJump",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "Effect",
+          "effectPreset": "ColorFade",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
     }
   },
+    "Dimmer Curve": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [6, 63],
+          "type": "Maintenance",
+          "comment": "Linear course"
+        },
+        {
+          "dmxRange": [64, 127],
+          "type": "Maintenance",
+          "comment": "Exponential course"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "Maintenance",
+          "comment": "Logarithmic course"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "Maintenance",
+          "comment": "S-curve shaped course"
+        }
+      ]
+    },
   "modes": [
+    {
+      "name": "2 channel",
+      "channels": [
+        "Dimmer",
+        "Color Temperature"
+      ]
+    },
+    {
+      "name": "3 channel",
+      "channels": [
+        "Dimmer",
+        "Shutter / Strobe",
+        "Color Macros"
+      ]
+    },
+    {
+      "name": "6 channel",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV"
+      ]
+    },
     {
       "name": "9 channel",
       "channels": [
@@ -98,6 +295,21 @@
         "Amber",
         "UV",
         "Color Macros"
+      ]
+    },
+    "name": "11 channel",
+      "channels": [
+        "Dimmer",
+        "Shutter / Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV",
+        "Color Macros",
+        "Color Temperature 2",
+        "Dimmer Curve"
       ]
     }
   ]

--- a/fixtures/stairville/remus-515.json
+++ b/fixtures/stairville/remus-515.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Remus 515",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["LGK"],
+    "createDate": "2024-02-26",
+    "lastModifyDate": "2024-02-26"
+  },
+  "links": {
+    "manual": [
+      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/c_531015_v2_en_online.pdf?_gl=1*h8qh7y*_ga*MTI4Mjk4NDE1Mi4xNzA4OTU3MzAx*_ga_QNTG1E3BFT*MTcwODk1NzMwMS4xLjEuMTcwODk2MjIwNi4wLjAuMA..*_fplc*WngzSGlEbWZRSXhaOHFxc01obDlRT1lLTnJaVyUyQmJRZlJOemg4RFlyQ2RTc3BFSWM3N0swMTdXJTJGNnhWeTRnb1prbml3JTJGTFZtJTJCV0RHa2I2ZnVvOEI3JTJCVkEyem5mSDdhWmoxTGVmJTJGT25FRjFWeEhZSXBPZ0FPbDh0eE9FanRnJTNEJTNE"
+    ],
+    "productPage": [
+      "https://www.thomann.de/nl/stairville_remus_hexspot_515.htm"
+    ]
+  },
+  "rdm": {
+    "modelId": 0
+  },
+  "physical": {
+    "dimensions": [225, 230, 190],
+    "weight": 2.5,
+    "power": 100,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "RGBWAUV",
+      "colorTemperature": 3500
+    },
+    "lens": {
+      "degreesMinMax": [30, 30]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "UV": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "9 channel",
+      "channels": [
+        "Dimmer",
+        "Shutter / Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV",
+        "Color Macros"
+      ]
+    }
+  ]
+}

--- a/fixtures/stairville/remus-515.json
+++ b/fixtures/stairville/remus-515.json
@@ -9,7 +9,7 @@
   },
   "links": {
     "manual": [
-      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/c_531015_v2_en_online.pdf?_gl=1*h8qh7y*_ga*MTI4Mjk4NDE1Mi4xNzA4OTU3MzAx*_ga_QNTG1E3BFT*MTcwODk1NzMwMS4xLjEuMTcwODk2MjIwNi4wLjAuMA..*_fplc*WngzSGlEbWZRSXhaOHFxc01obDlRT1lLTnJaVyUyQmJRZlJOemg4RFlyQ2RTc3BFSWM3N0swMTdXJTJGNnhWeTRnb1prbml3JTJGTFZtJTJCV0RHa2I2ZnVvOEI3JTJCVkEyem5mSDdhWmoxTGVmJTJGT25FRjFWeEhZSXBPZ0FPbDh0eE9FanRnJTNEJTNE"
+      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/c_531015_v2_en_online.pdf"
     ],
     "productPage": [
       "https://www.thomann.de/nl/stairville_remus_hexspot_515.htm"

--- a/fixtures/stairville/remus-515.json
+++ b/fixtures/stairville/remus-515.json
@@ -38,9 +38,11 @@
       }
     },
     "Color Temperature": {
-      "type": "ColorTemperature",
-      "colorTemperatureStart": "3200K",
-      "colorTemperatureEnd": "7280K"
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "3200K",
+        "colorTemperatureEnd": "7280K"
+      }
     },
     "Color Temperature 2": {
       "capabilities": [
@@ -225,8 +227,7 @@
           "speedEnd": "fast"
         }
       ]
-    }
-  },
+    },
     "Dimmer Curve": {
       "defaultValue": 0,
       "capabilities": [
@@ -255,7 +256,8 @@
           "comment": "S-curve shaped course"
         }
       ]
-    },
+    }
+  },
   "modes": [
     {
       "name": "2 channel",
@@ -297,7 +299,8 @@
         "Color Macros"
       ]
     },
-    "name": "11 channel",
+    {
+      "name": "11 channel",
       "channels": [
         "Dimmer",
         "Shutter / Strobe",

--- a/fixtures/stairville/remus-hexspot-515.json
+++ b/fixtures/stairville/remus-hexspot-515.json
@@ -158,9 +158,9 @@
     "Color Macros": {
       "capabilities": [
         {
-          "dmxRange": [0, 5],
+          "dmxRange": [0, 10],
           "type": "NoFunction",
-          "helpWanted": "Does this enable RGBWAUV, or is it actually a blackout?"
+          "helpWanted": "The manual lists 0…5 as Blackout and doesn't mention 6…10. Are these distinct capabilities?"
         },
         {
           "dmxRange": [11, 13],

--- a/fixtures/stairville/remus-hexspot-515.json
+++ b/fixtures/stairville/remus-hexspot-515.json
@@ -175,7 +175,7 @@
         },
         {
           "dmxRange": [30, 101],
-          "type": "NoFunction",
+          "type": "ColorPreset",
           "helpWanted": "What ranges/colors are here?"
         },
         {
@@ -210,7 +210,7 @@
           "speedEnd": "fast"
         },
         {
-          "dmxRange": [128, 191],
+          "dmxRange": [192, 255],
           "type": "Effect",
           "effectPreset": "ColorFade",
           "speedStart": "slow",

--- a/fixtures/stairville/remus-hexspot-515.json
+++ b/fixtures/stairville/remus-hexspot-515.json
@@ -3,9 +3,9 @@
   "name": "Remus HexSpot 515",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["LGK"],
-    "createDate": "2024-02-26",
-    "lastModifyDate": "2024-02-26"
+    "authors": ["LGK", "Ken Harris", "Flo Edelmann"],
+    "createDate": "2024-03-05",
+    "lastModifyDate": "2024-03-05"
   },
   "links": {
     "manual": [

--- a/fixtures/stairville/remus-hexspot-515.json
+++ b/fixtures/stairville/remus-hexspot-515.json
@@ -257,14 +257,16 @@
   },
   "modes": [
     {
-      "name": "2 channel",
+      "name": "2-channel",
+      "shortName": "2ch",
       "channels": [
         "Dimmer",
         "Color Temperature"
       ]
     },
     {
-      "name": "3 channel",
+      "name": "3-channel",
+      "shortName": "3ch",
       "channels": [
         "Dimmer",
         "Shutter / Strobe",
@@ -272,7 +274,8 @@
       ]
     },
     {
-      "name": "6 channel",
+      "name": "6-channel",
+      "shortName": "6ch",
       "channels": [
         "Red",
         "Green",
@@ -283,7 +286,8 @@
       ]
     },
     {
-      "name": "9 channel",
+      "name": "9-channel",
+      "shortName": "9ch",
       "channels": [
         "Dimmer",
         "Shutter / Strobe",
@@ -297,7 +301,8 @@
       ]
     },
     {
-      "name": "11 channel",
+      "name": "11-channel",
+      "shortName": "11ch",
       "channels": [
         "Dimmer",
         "Shutter / Strobe",

--- a/fixtures/stairville/remus-hexspot-515.json
+++ b/fixtures/stairville/remus-hexspot-515.json
@@ -12,7 +12,10 @@
       "https://images.static-thomann.de/pics/atg/atgdata/document/manual/c_531015_v2_en_online.pdf"
     ],
     "productPage": [
-      "https://www.thomann.de/nl/stairville_remus_hexspot_515.htm"
+      "https://www.thomann.de/intl/stairville_remus_hexspot_515.htm"
+    ],
+    "video": [
+      "https://video1.thomann.de/vidiot/02591c1c/video_i11407p10_yd59vqpa.mp4"
     ]
   },
   "physical": {

--- a/fixtures/stairville/remus-hexspot-515.json
+++ b/fixtures/stairville/remus-hexspot-515.json
@@ -35,13 +35,6 @@
       }
     },
     "Color Temperature": {
-      "capability": {
-        "type": "ColorTemperature",
-        "colorTemperatureStart": "3200K",
-        "colorTemperatureEnd": "7280K"
-      }
-    },
-    "Color Temperature 2": {
       "capabilities": [
         {
           "dmxRange": [0, 5],
@@ -313,7 +306,7 @@
         "Amber",
         "UV",
         "Color Macros",
-        "Color Temperature 2",
+        "Color Temperature",
         "Dimmer Curve"
       ]
     }

--- a/fixtures/stairville/remus-hexspot-515.json
+++ b/fixtures/stairville/remus-hexspot-515.json
@@ -15,9 +15,6 @@
       "https://www.thomann.de/nl/stairville_remus_hexspot_515.htm"
     ]
   },
-  "rdm": {
-    "modelId": 0
-  },
   "physical": {
     "dimensions": [225, 230, 190],
     "weight": 2.5,

--- a/fixtures/stairville/remus-hexspot-515.json
+++ b/fixtures/stairville/remus-hexspot-515.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
-  "name": "Remus 515",
+  "name": "Remus HexSpot 515",
   "categories": ["Color Changer"],
   "meta": {
     "authors": ["LGK"],


### PR DESCRIPTION
* Add fixture `stairville/remus-515`

### Fixture warnings / errors

* stairville/remus-515
  - :warning: Mode '9 channel' should have shortName '9ch' instead of '9 channel'.
  - :warning: Mode '9 channel' should have shortName '9ch' instead of '9 channel'.


Thank you **LGK**!