### PR TITLE
Add fixture `shehds/led-par-7x12w-rgbw`

### DIFF
--- a/fixtures/shehds/led-par-7x12w-rgbw.json
+++ b/fixtures/shehds/led-par-7x12w-rgbw.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED PAR 7x12W RGBW",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Nathan SCHWENK", "DJ NathiS"],
+    "createDate": "2024-02-29",
+    "lastModifyDate": "2024-02-29",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2024-02-29",
+      "comment": "created by Q Light Controller Plus (version 4.12.6)"
+    }
+  },
+  "physical": {
+    "dimensions": [179, 113, 178],
+    "weight": 0.9,
+    "power": 84,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX values is strobe disabled?"
+      }
+    },
+    "Function": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Speed"
+      }
+    },
+    "Function Speed Adjustment": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Speed"
+      }
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8-channel",
+      "shortName": "8ch",
+      "channels": [
+        "Dimmer",
+        "Strobe",
+        "Function",
+        "Function Speed Adjustment",
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `shehds/led-par-7x12w-rgbw`

### Fixture warnings / errors

* shehds/led-par-7x12w-rgbw
  - :x: File does not match schema: fixture/availableChannels/Function/capability (type: Speed) must have required property 'speed'
  - :x: File does not match schema: fixture/availableChannels/Function/capability (type: Speed) must have required property 'speedStart'
  - :x: File does not match schema: fixture/availableChannels/Function/capability (type: Speed) must match exactly one schema in oneOf
  - :x: File does not match schema: fixture/availableChannels/Function Speed Adjustment/capability (type: Speed) must have required property 'speed'
  - :x: File does not match schema: fixture/availableChannels/Function Speed Adjustment/capability (type: Speed) must have required property 'speedStart'
  - :x: File does not match schema: fixture/availableChannels/Function Speed Adjustment/capability (type: Speed) must match exactly one schema in oneOf


### User comment

Shehds LED PAR 7*12W RGBW fixture

Thank you **Nathan SCHWENK** and **DJ NathiS**!