### PR TITLE
Add fixture `etc/source-4wrd-color-ii`

### DIFF
--- a/fixtures/etc/source-4wrd-color-ii.json
+++ b/fixtures/etc/source-4wrd-color-ii.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Source 4WRD Color II",
+  "categories": ["Color Changer", "Strobe"],
+  "meta": {
+    "authors": ["Randy Hall"],
+    "createDate": "2024-03-02",
+    "lastModifyDate": "2024-03-02"
+  },
+  "comment": "Retrofit for Source 4 fixtures; also can be paired with custom Source 4 Par(nel) fixtures",
+  "links": {
+    "manual": [
+      "https://www.etcconnect.com/Products/Entertainment-Fixtures/S4WRD-C-II/Documentation.aspx#manuals"
+    ],
+    "productPage": [
+      "https://www.etcconnect.com/Products/Entertainment-Fixtures/S4WRD-C-II/Features.aspx"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=olWwFKsCU-o"
+    ]
+  },
+  "rdm": {
+    "modelId": 803
+  },
+  "physical": {
+    "dimensions": [178, 142, 160],
+    "weight": 1.69,
+    "power": 150,
+    "DMXconnector": "RJ45",
+    "bulb": {
+      "type": "LED",
+      "lumens": 6000
+    }
+  },
+  "availableChannels": {
+    "Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "NoFunction",
+          "comment": "Strobe Disabled"
+        },
+        {
+          "dmxRange": [1, 254],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "33Hz"
+        },
+        {
+          "dmxRange": [255, 255],
+          "type": "NoFunction",
+          "comment": "Strobe Disabled"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "Default",
+      "channels": [
+        "Intensity",
+        "Red",
+        "Green",
+        "Blue",
+        "Amber",
+        "Strobe"
+      ]
+    }
+  ]
+}

--- a/fixtures/etc/source-4wrd-color-ii.json
+++ b/fixtures/etc/source-4wrd-color-ii.json
@@ -71,7 +71,8 @@
         },
         {
           "dmxRange": [1, 254],
-          "type": "StrobeSpeed",
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
           "speedStart": "1Hz",
           "speedEnd": "33Hz"
         },

--- a/fixtures/etc/source-4wrd-color-ii.json
+++ b/fixtures/etc/source-4wrd-color-ii.json
@@ -20,7 +20,7 @@
     ]
   },
   "rdm": {
-    "modelId": 803
+    "modelId": 2051
   },
   "physical": {
     "dimensions": [178, 142, 160],

--- a/fixtures/etc/source-4wrd-color-ii.json
+++ b/fixtures/etc/source-4wrd-color-ii.json
@@ -4,8 +4,8 @@
   "categories": ["Color Changer", "Strobe"],
   "meta": {
     "authors": ["Randy Hall"],
-    "createDate": "2024-03-02",
-    "lastModifyDate": "2024-03-02"
+    "createDate": "2024-03-05",
+    "lastModifyDate": "2024-03-05"
   },
   "comment": "Retrofit for Source 4 fixtures; also can be paired with custom Source 4 Par(nel) fixtures",
   "links": {

--- a/fixtures/etc/source-4wrd-color-ii.json
+++ b/fixtures/etc/source-4wrd-color-ii.json
@@ -66,8 +66,8 @@
       "capabilities": [
         {
           "dmxRange": [0, 0],
-          "type": "NoFunction",
-          "comment": "Strobe Disabled"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
         },
         {
           "dmxRange": [1, 254],
@@ -78,15 +78,17 @@
         },
         {
           "dmxRange": [255, 255],
-          "type": "NoFunction",
-          "comment": "Strobe Disabled"
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
         }
       ]
     }
   },
   "modes": [
     {
-      "name": "Default",
+      "name": "6-channel",
+      "shortName": "6ch",
+      "rdmPersonalityIndex": 1,
       "channels": [
         "Intensity",
         "Red",


### PR DESCRIPTION
* Add fixture `etc/source-4wrd-color-ii`

### Fixture warnings / errors

* etc/source-4wrd-color-ii
  - :x: File does not match schema: fixture/physical/DMXconnector "RJ45" must be equal to one of [3-pin, 3-pin (swapped +/-), 3-pin XLR IP65, 5-pin, 5-pin XLR IP65, 3-pin and 5-pin, 3.5mm stereo jack]


Thank you @randybuildsthings!