### PR TITLE
Increase importer file size limit to 50MB

### DIFF
--- a/ui/pages/import-fixture-file.vue
+++ b/ui/pages/import-fixture-file.vue
@@ -45,12 +45,12 @@
             :formstate="formstate"
             name="file"
             label="Fixture definition file"
-            hint="Maximum file size is 5MB.">
+            hint="Maximum file size is 50MB.">
             <EditorFileUpload
               v-model="file"
               required
               name="file"
-              max-file-size="5MB" />
+              max-file-size="50MB" />
           </LabeledInput>
 
           <LabeledInput :formstate="formstate" name="githubComment" label="Comment">


### PR DESCRIPTION
Although the server accepts files upto 50MB ([see here](https://github.com/OpenLightingProject/open-fixture-library/blob/455d4bdfddbce3f060811ada836c985ec099700c/ui/api/index.js#L20)) the frontend was limited to 5MB ([see here](https://github.com/OpenLightingProject/open-fixture-library/blob/455d4bdfddbce3f060811ada836c985ec099700c/ui/pages/import-fixture-file.vue#L48-L53)). 

This PR amends the values in the UI to reflect the value on the server. 

Fixes #3818. 