### PR TITLE
Add fixture `5star-systems/temp`

### DIFF
--- a/fixtures/5star-systems/temp.json
+++ b/fixtures/5star-systems/temp.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Temp",
+  "shortName": "Short name",
+  "categories": ["Other", "Color Changer"],
+  "meta": {
+    "authors": ["Angel Parada"],
+    "createDate": "2024-03-15",
+    "lastModifyDate": "2024-03-15"
+  },
+  "comment": "This is a demo to connect things",
+  "links": {
+    "manual": [
+      "https://google.com"
+    ]
+  },
+  "availableChannels": {
+    "Fog Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "TEst",
+      "channels": [
+        "Fog Intensity"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `5star-systems/temp`

### Fixture warnings / errors

* 5star-systems/temp
  - ❌ Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.


Thank you **Angel Parada**!