### PR TITLE
Add fixture `tomoca/to-qua-18`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -517,6 +517,10 @@
     "website": "https://tmb.com/",
     "rdmId": 6906
   },
+  "tomoca": {
+    "name": "tomoca",
+    "website": "https://www.tomoca.co.jp/"
+  },
   "uking": {
     "name": "U`King",
     "website": "https://www.uking-online.com/"

--- a/fixtures/tomoca/to-qua-18.json
+++ b/fixtures/tomoca/to-qua-18.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "TO-QUA-18",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["masaki"],
+    "createDate": "2024-03-22",
+    "lastModifyDate": "2024-03-22"
+  },
+  "links": {
+    "productPage": [
+      "https://www.tomoca.co.jp/brand/tomoca-l/%E5%B1%8B%E5%A4%96%E6%BC%94%E5%87%BA%E7%94%A8led/to-qua-18bar-1m/"
+    ]
+  },
+  "availableChannels": {
+    "R": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "G": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "B": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "W": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "72ch",
+      "channels": [
+        "R",
+        "G",
+        "B",
+        "W"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `tomoca/to-qua-18`

### Fixture warnings / errors

* tomoca/to-qua-18
  - ❌ Mode '72ch' should have 72 channels according to its name but actually has 4.
  - ❌ Mode '72ch' should have 72 channels according to its shortName but actually has 4.
  - ❌ Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **masaki**!