### PR TITLE
Replace fovitec.com links

### DIFF
--- a/fixtures/fovitec/600xb.json
+++ b/fixtures/fovitec/600xb.json
@@ -9,7 +9,7 @@
   },
   "links": {
     "productPage": [
-      "https://www.fovitec.com/products/600xb-bi-color-led-panel-with-dmx"
+      "https://web.archive.org/web/20230610152318/https://www.fovitec.com/products/600xb-bi-color-led-panel-with-dmx"
     ]
   },
   "physical": {

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -199,7 +199,7 @@
   },
   "fovitec": {
     "name": "Fovitec",
-    "website": "https://www.fovitec.com/"
+    "website": "https://web.archive.org/web/20240324222208/https://www.fovitec.com/"
   },
   "fractal-lights": {
     "name": "Fractal Lights",


### PR DESCRIPTION
Looks like fovitec.com has closed down. This PR replaces their links with waybackmachine links.

Found by #999