### PR TITLE
Add fixture `varytec/led-theater-spot-120-fc`

### DIFF
--- a/fixtures/varytec/led-theater-spot-120-fc.json
+++ b/fixtures/varytec/led-theater-spot-120-fc.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED Theater Spot 120 FC",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["jean7111"],
+    "createDate": "2024-05-19",
+    "lastModifyDate": "2024-05-19"
+  },
+  "links": {
+    "manual": [
+      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/c_414220_427226_v6_fr_online.pdf"
+    ]
+  },
+  "physical": {
+    "weight": 5,
+    "power": 120,
+    "DMXconnector": "3-pin",
+    "lens": {
+      "name": "Frenel"
+    }
+  },
+  "availableChannels": {
+    "Intensity": {
+      "capability": {
+        "type": "Intensity",
+        "brightness": "off"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "6 CH",
+      "channels": [
+        "Intensity",
+        "Red"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `varytec/led-theater-spot-120-fc`

### Fixture warnings / errors

* varytec/led-theater-spot-120-fc
  - ❌ Mode '6 CH' should have 6 channels according to its name but actually has 2.
  - ❌ Mode '6 CH' should have 6 channels according to its shortName but actually has 2.
  - ❌ Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.
  - ⚠️ Mode '6 CH' should have shortName '6ch' instead of '6 CH'.
  - ⚠️ Mode '6 CH' should have shortName '6ch' instead of '6 CH'.


Thank you **jean7111**!