### PR TITLE
Fix `shehds.com` links

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -435,7 +435,7 @@
   },
   "shehds": {
     "name": "Shehds",
-    "website": "https://www.shehds.com/"
+    "website": "https://shehds.com/"
   },
   "showline": {
     "name": "Showline",

--- a/fixtures/shehds/led-flat-par-12x3w-rgbw.json
+++ b/fixtures/shehds/led-flat-par-12x3w-rgbw.json
@@ -8,11 +8,8 @@
     "lastModifyDate": "2023-02-12"
   },
   "links": {
-    "manual": [
-      "https://www.shehds.com/u_file/1809/file/3d1a81c31b.docx"
-    ],
     "productPage": [
-      "https://www.shehds.com/led-par-12x3w-rgbw-led-stage-light-par-light-with-dmx512-for-disco-dj-party-decoration-stage-lighting-p0087.html"
+      "https://web.archive.org/web/20220928042132/https://www.shehds.com/led-par-12x3w-rgbw-led-stage-light-par-light-with-dmx512-for-disco-dj-party-decoration-stage-lighting-p0087.html"
     ]
   },
   "physical": {

--- a/fixtures/shehds/led-flat-par-18x18w.json
+++ b/fixtures/shehds/led-flat-par-18x18w.json
@@ -12,7 +12,7 @@
       "https://ueeshop.ly200-cdn.com/u_file/UPAG/UPAG904/1912/file/c80fe135df.pdf"
     ],
     "productPage": [
-      "https://www.shehds.com/products/aluminum-alloy-led-flat-par-18x18w-lighting-dj-par-cans-dmx-512-light-wash-stage-lighting"
+      "https://shehds.com/products/aluminum-alloy-led-flat-par-18x18w-lighting-dj-par-cans-dmx-512-light-wash-stage-lighting"
     ],
     "video": ["https://www.youtube.com/watch?v=k7ynAEIPEuE"]
   },

--- a/fixtures/shehds/led-flat-par-54x3w.json
+++ b/fixtures/shehds/led-flat-par-54x3w.json
@@ -17,7 +17,7 @@
       "https://www.shehds.com/u_file/1908/file/4109b920cd.pdf"
     ],
     "productPage": [
-      "https://www.shehds.com/products/fast-shipping-led-54x3w-rgbw-led-flat-par-rgbw-color-mixing-dj-wash-light-stage-uplighting-ktv-disco-dj-dmx512"
+      "https://shehds.com/products/fast-shipping-led-54x3w-rgbw-led-flat-par-rgbw-color-mixing-dj-wash-light-stage-uplighting-ktv-disco-dj-dmx512"
     ],
     "video": [
       "https://www.youtube.com/watch?v=Pv0_x9BYBug"

--- a/fixtures/shehds/led-flat-par-54x3w.json
+++ b/fixtures/shehds/led-flat-par-54x3w.json
@@ -14,7 +14,7 @@
   },
   "links": {
     "manual": [
-      "https://www.shehds.com/u_file/1908/file/4109b920cd.pdf"
+      "https://web.archive.org/web/20220928033751/https://www.shehds.com/u_file/1908/file/4109b920cd.pdf"
     ],
     "productPage": [
       "https://shehds.com/products/fast-shipping-led-54x3w-rgbw-led-flat-par-rgbw-color-mixing-dj-wash-light-stage-uplighting-ktv-disco-dj-dmx512"

--- a/fixtures/shehds/led-flat-par-7x18w-rgbwa-uv-light.json
+++ b/fixtures/shehds/led-flat-par-7x18w-rgbwa-uv-light.json
@@ -18,8 +18,7 @@
       "https://shehds.com/products/led-flat-par-7x12w-7x18w-rgbwauv-lighting"
     ],
     "manual": [
-      "https://www.shehds.com/u_file/2005/file/b01e72a1b3.pdf",
-      "https://www.shehds.com/u_file/1907/file/45918ab3df.pdf"
+      "https://web.archive.org/web/20221023054132/https://www.shehds.com/u_file/1907/file/45918ab3df.pdf"
     ]
   },
   "physical": {

--- a/fixtures/shehds/led-flat-par-7x18w-rgbwa-uv-light.json
+++ b/fixtures/shehds/led-flat-par-7x18w-rgbwa-uv-light.json
@@ -15,7 +15,7 @@
   },
   "links": {
     "productPage": [
-      "https://www.shehds.com/products/led-flat-par-7x12w-7x18w-rgbwauv-lighting"
+      "https://shehds.com/products/led-flat-par-7x12w-7x18w-rgbwauv-lighting"
     ],
     "manual": [
       "https://www.shehds.com/u_file/2005/file/b01e72a1b3.pdf",

--- a/fixtures/shehds/led-par-18x18w.json
+++ b/fixtures/shehds/led-par-18x18w.json
@@ -13,7 +13,7 @@
       "https://ueeshop.ly200-cdn.com/u_file/UPAG/UPAG904/1912/file/c80fe135df.pdf"
     ],
     "productPage": [
-      "https://www.shehds.com/products/aluminum-alloy-led-flat-par-18x18w-lighting-dj-par-cans-dmx-512-light-wash-stage-lighting"
+      "https://shehds.com/products/aluminum-alloy-led-flat-par-18x18w-lighting-dj-par-cans-dmx-512-light-wash-stage-lighting"
     ],
     "video": [
       "https://www.youtube.com/watch?v=k7ynAEIPEuE"

--- a/fixtures/shehds/led-spot-60w.json
+++ b/fixtures/shehds/led-spot-60w.json
@@ -14,7 +14,7 @@
   },
   "links": {
     "productPage": [
-      "https://www.shehds.com/products/good-technology-led-60w-gobos-moving-head-lighting-for-dmx512-stage-effect-dj-festivals-disco-home-entertainments-in-9-11-channels"
+      "https://shehds.com/products/good-technology-led-60w-gobos-moving-head-lighting-for-dmx512-stage-effect-dj-festivals-disco-home-entertainments-in-9-11-channels"
     ],
     "manual": [
       "https://ueeshop.ly200-cdn.com/u_file/UPAG/UPAG904/2005/file/f56ea62fb9.pdf"


### PR DESCRIPTION
It looks like Shehds have updated their website. While some product pages still seem to work, some manuals and product pages are no longer available.

This PR fixes links to https://www.shehds.com/ found by #999. Where possible, a redirect has been followed. Next, I have looked for an archived copy. Lastly, where there is no alternative, the broken link has been removed.