### PR TITLE
Add fixture `equinox/spectra`

### DIFF
--- a/fixtures/equinox/spectra.json
+++ b/fixtures/equinox/spectra.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Spectra",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["Gax"],
+    "createDate": "2024-05-27",
+    "lastModifyDate": "2024-05-27"
+  },
+  "links": {
+    "other": [
+      "https://www.capture.se/Manual/en-UK/2024/ToolsMenu.html#Options",
+      "https://www.capture.se/Manual/en-UK/2024/ToolsMenu.html#Options",
+      "https://www.capture.se/Manual/en-UK/2024/ToolsMenu.html#Options"
+    ]
+  },
+  "physical": {
+    "dimensions": [1.3, 1, 0.2],
+    "weight": 24,
+    "power": 1200,
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "1": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Test",
+      "channels": [
+        "1"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `equinox/spectra`

### Fixture warnings / errors

* equinox/spectra
  - ❌ File does not match schema: fixture/links/other must NOT have duplicate items (items ## 1 and 2 are identical)


Thank you **Gax**!