### PR TITLE
Group dependabot version updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,17 @@ updates:
       interval: "daily"
     labels:
       - "dependencies"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "eslint-plugin-jsdoc"
         update-types:


### PR DESCRIPTION
Dependabot offers a way to [group version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups). This should make it easier to review version changes together, also cutting down on build minutes and notifications.