### PR TITLE
Add fixture `martin/auratest`

### DIFF
--- a/fixtures/martin/auratest.json
+++ b/fixtures/martin/auratest.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "AURAtest",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Argo"],
+    "createDate": "2024-06-28",
+    "lastModifyDate": "2024-06-28"
+  },
+  "links": {
+    "manual": [
+      "https://www.martin.com/en/products/mac-aura-xip"
+    ]
+  },
+  "availableChannels": {
+    "Shutter / Strobe": {
+      "defaultValue": 1,
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Compact",
+      "channels": [
+        "Shutter / Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `martin/auratest`

### Fixture warnings / errors

* martin/auratest
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.


Thank you **Argo**!