### PR TITLE
Add fixture `eurolite/sdfsdf`

### DIFF
--- a/fixtures/eurolite/sdfsdf.json
+++ b/fixtures/eurolite/sdfsdf.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "sdfsdf",
+  "shortName": "sdfsdf",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["asdfasdf"],
+    "createDate": "2024-07-06",
+    "lastModifyDate": "2024-07-06"
+  },
+  "links": {
+    "manual": [
+      "https://sdfsdf.com"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "16-channel",
+      "channels": [
+        "Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `eurolite/sdfsdf`

### Fixture warnings / errors

* eurolite/sdfsdf
  - ❌ Mode '16-channel' should have 16 channels according to its name but actually has 1.
  - ❌ Mode '16-channel' should have 16 channels according to its shortName but actually has 1.
  - ❌ Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - ⚠️ Mode '16-channel' should have shortName '16ch' instead of '16-channel'.
  - ⚠️ Mode '16-channel' should have shortName '16ch' instead of '16-channel'.


Thank you **asdfasdf**!