### PR TITLE
Add fixture `shehd/par-zoom-18x18-rgbwa-uv`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -433,6 +433,9 @@
     "website": "https://sgmlight.com/",
     "rdmId": 21319
   },
+  "shehd": {
+    "name": "SHEHD"
+  },
   "shehds": {
     "name": "Shehds",
     "website": "https://shehds.com/"

--- a/fixtures/shehd/par-zoom-18x18-rgbwa-uv.json
+++ b/fixtures/shehd/par-zoom-18x18-rgbwa-uv.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "PAR Zoom 18X18 RGBWA-UV",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Xavier Bongrand", "xavier bongrand"],
+    "createDate": "2024-07-09",
+    "lastModifyDate": "2024-07-09",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2024-07-09",
+      "comment": "created by Q Light Controller Plus (version 4.12.7)"
+    }
+  },
+  "physical": {
+    "dimensions": [220, 220, 220],
+    "weight": 3.7,
+    "power": 200,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "lumens": 128
+    },
+    "lens": {
+      "name": "PC",
+      "degreesMinMax": [23, 49]
+    }
+  },
+  "availableChannels": {
+    "Master dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX values is strobe disabled?"
+      }
+    },
+    "Auto Mode": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 50],
+          "type": "Generic",
+          "comment": "No fonction"
+        },
+        {
+          "dmxRange": [51, 100],
+          "type": "Generic",
+          "comment": "Color Selection"
+        },
+        {
+          "dmxRange": [101, 151],
+          "type": "Generic",
+          "comment": "Gradient Fast To Slow"
+        },
+        {
+          "dmxRange": [152, 200],
+          "type": "Generic",
+          "comment": "Gradient Slow To Fast"
+        },
+        {
+          "dmxRange": [201, 255],
+          "type": "Generic",
+          "comment": "Sound mode"
+        }
+      ]
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "UV": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    },
+    "Zoom": {
+      "defaultValue": 20,
+      "capability": {
+        "type": "Prism"
+      }
+    },
+    "Empty": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Zoom Speed": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "Are the automatically added speed values correct?"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "12-channelel",
+      "shortName": "12chel",
+      "channels": [
+        "Master dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV",
+        "Strobe",
+        "Auto Mode",
+        "Zoom",
+        "Zoom Speed",
+        "Empty"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `shehd/par-zoom-18x18-rgbwa-uv`

### Fixture warnings / errors

* shehd/par-zoom-18x18-rgbwa-uv
  - ⚠️ Please check if manufacturer is correct and add manufacturer URL.


### User comment

Modele 2023
12 chanel ( canal 12 is empty)

Thank you **Xavier Bongrand** and **xavier bongrand**!