### PR TITLE
Add fixture `generic/rgbw-bar-8`

### DIFF
--- a/fixtures/generic/rgbw-bar-8.json
+++ b/fixtures/generic/rgbw-bar-8.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "RGBW Bar 8",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["mui"],
+    "createDate": "2024-07-14",
+    "lastModifyDate": "2024-07-14"
+  },
+  "links": {
+    "productPage": [
+      "https://de.aliexpress.com/item/1005006989240443.html"
+    ]
+  },
+  "physical": {
+    "dimensions": [420, 100, 80],
+    "weight": 0.7,
+    "power": 45,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Master Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "stop",
+        "speedEnd": "fast"
+      }
+    },
+    "Macro": {
+      "capability": {
+        "type": "ColorPreset",
+        "comment": "tbd"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Default",
+      "channels": [
+        "Master Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe",
+        "Macro"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `generic/rgbw-bar-8`

### Fixture warnings / errors

* generic/rgbw-bar-8
  - ❌ Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **mui**!