### PR TITLE
described matrix channelOrder in more detail

### DIFF
--- a/docs/fixture-format.md
+++ b/docs/fixture-format.md
@@ -299,7 +299,7 @@ Then, either use the resolved channel keys directly in a mode's channel list, or
     {
       "insert": "matrixChannels", // static value for matrix channels
       "repeatFor": "eachPixelXYZ", // see below
-      "channelOrder": "perPixel", // or "perChannel"
+      "channelOrder": "perPixel", // see below
       "templateChannels": [
         "Red $pixelKey",
         "Green $pixelKey",
@@ -319,6 +319,16 @@ Then, either use the resolved channel keys directly in a mode's channel list, or
 * `"eachPixelGroup"`: Gets computed into an array of all pixel group keys, ordered by appearance in the JSON file.
   - For the above [matrix structure](#matrix-structure) example, this results in `["Inner ring", "Middle ring", "Outer ring"]`.
 
+`channelOrder` defines how the channels are ordered. Possible values are:
+
+* `"perPixel"`: For the above [matrix structure](#matrix-structure) example, this results in
+  - `["Red Inner ring", "Green Inner ring", "Blue Inner ring"]`
+  - `["Red Middle ring", "Green Middle ring", "Blue Middle ring"]`
+  - `["Red Outer ring", "Green Outer ring", "Blue Outer ring"]`
+* `"perChannel"`: For the above [matrix structure](#matrix-structure) example, this results in 
+  - `["Red Inner ring", " Red Middle ring", "Red Outer ring"]`
+  - `["Green Inner ring", "Green Middle ring", "Green Outer ring"]`
+  - `["Blue Inner ring", "Blue Middle ring", "Blue Outer ring"]`
 
 ### Wheels
 


### PR DESCRIPTION
Based on the documentation, it was not clear to me, what the channelOrder does exactly. I found some more information here and tried to describe it a little bit more in detail in the docs:
https://github.com/OpenLightingProject/open-fixture-library/blob/715e90ca0af667c4e936f853afec6d5befaad2e6/tests/fixture-valid.js#L789

However, I'm not sure, whether it should be the other way round. Based on the code, it should look like this, but based on the naming, I think it should be the other way round.

I found no fixture already using `perChannel` currently.