### PR TITLE
Fix DMXControl 3 export with Burst shutter effect

### DIFF
--- a/plugins/dmxcontrol3/ddf3-functions.js
+++ b/plugins/dmxcontrol3/ddf3-functions.js
@@ -83,13 +83,9 @@ export default {
 
         const typePerShutterEffect = {
           Strobe: capability.randomTiming ? `random` : `linear`,
-          Pulse: `pulse`,
           RampUp: `ramp up`,
           RampDown: `ramp down`,
           RampUpDown: `ramp up/down`,
-          Lightning: `lightning`,
-          Spikes: `spikes`,
-          Burst: `burst`,
         };
         return typePerShutterEffect[capability.shutterEffect] ?? capability.shutterEffect.toLowerCase();
       }

--- a/plugins/dmxcontrol3/ddf3-functions.js
+++ b/plugins/dmxcontrol3/ddf3-functions.js
@@ -89,8 +89,9 @@ export default {
           RampUpDown: `ramp up/down`,
           Lightning: `lightning`,
           Spikes: `spikes`,
+          Burst: `burst`,
         };
-        return typePerShutterEffect[capability.shutterEffect];
+        return typePerShutterEffect[capability.shutterEffect] ?? capability.shutterEffect.toLowerCase();
       }
     },
   },


### PR DESCRIPTION
Fixes #3637.
Needed for #3976.

Missed in #2094. I added a fallback to prevent this in the future.