### PR TITLE
Add fixture `showtec/phant-n-75-led`

### DIFF
--- a/fixtures/showtec/phant-n-75-led.json
+++ b/fixtures/showtec/phant-n-75-led.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "phantón 75 led",
+  "shortName": "14 channel phantón 75 led",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["logela"],
+    "createDate": "2024-08-26",
+    "lastModifyDate": "2024-08-26"
+  },
+  "links": {
+    "manual": [
+      "https://www.showtec-lights.com/en/"
+    ],
+    "productPage": [
+      "https://www.showtec-lights.com/en/"
+    ],
+    "video": [
+      "https://www.showtec-lights.com/en/"
+    ]
+  },
+  "rdm": {
+    "modelId": 0
+  },
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        null,
+        {
+          "type": "Color"
+        },
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        {
+          "type": "Color"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "255deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "255deg"
+      }
+    },
+    "Pan 2": {
+      "name": "Pan",
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "255deg"
+      }
+    },
+    "Tilt 2": {
+      "name": "Tilt",
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "255deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Color Wheel": {
+      "capability": {
+        "type": "WheelSlot",
+        "slotNumber": 20
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Gobo Wheel Rotation": {
+      "capability": {
+        "type": "WheelRotation",
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Gobo Wheel Rotation 2": {
+      "name": "Gobo Wheel Rotation",
+      "capability": {
+        "type": "WheelRotation",
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Dimmer 2": {
+      "name": "Dimmer",
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Program Speed": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Prism": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Focus": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "PHANTOM 14 channel",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Pan 2",
+        "Tilt 2",
+        "Pan/Tilt Speed",
+        "Color Wheel",
+        "Shutter / Strobe",
+        "Dimmer",
+        "Gobo Wheel Rotation",
+        "Gobo Wheel Rotation 2",
+        "Dimmer 2",
+        "Program Speed",
+        "Prism",
+        "Focus"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `showtec/phant-n-75-led`

### Fixture warnings / errors

* showtec/phant-n-75-led
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/0 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/2 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/3 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/4 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/5 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/6 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/7 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/8 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/9 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/10 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/11 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/12 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/13 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/14 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/15 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/16 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/17 null must be object
  - ❌ File does not match schema: fixture/wheels/Color Wheel/slots/18 null must be object


Thank you **logela**!