### PR TITLE
Add fixture `eurolite/led-pr-100-32`

### DIFF
--- a/fixtures/eurolite/led-pr-100-32.json
+++ b/fixtures/eurolite/led-pr-100-32.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED PR-100/32",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["M Ganné"],
+    "createDate": "2024-08-26",
+    "lastModifyDate": "2024-08-26"
+  },
+  "links": {
+    "manual": [
+      "https://ert.com"
+    ],
+    "productPage": [
+      "https://ert.com"
+    ],
+    "video": [
+      "https://ert.com"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8ch",
+      "shortName": "8ch",
+      "channels": [
+        "Dimmer",
+        "Strobe",
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `eurolite/led-pr-100-32`

### Fixture warnings / errors

* eurolite/led-pr-100-32
  - ❌ Mode '8ch' should have 8 channels according to its name but actually has 5.
  - ❌ Mode '8ch' should have 8 channels according to its shortName but actually has 5.
  - ❌ Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **M Ganné**!