### PR TITLE
Remove windows-build-tools from README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,8 +45,6 @@ Make sure you have these dependencies installed:
 
 * [Git](https://gitforwindows.org/)
 * [Node.js](https://nodejs.org/en/download/)
-* [windows-build-tools](https://www.npmjs.com/package/windows-build-tools)
-  - [Open a Terminal as Administrator](https://www.howtogeek.com/194041/how-to-open-the-command-prompt-as-administrator-in-windows-8.1/) and run `npm install --global windows-build-tools --vs2015`
 
 Choose a project path that only contains ASCII characters and no spaces. Open a Terminal and run
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Make sure you have these dependencies installed:
 
 * [Git](https://gitforwindows.org/)
 * [Node.js](https://nodejs.org/en/download/)
+  * On the *Tools for Native Modules* page, activate the checkbox *Automatically install the necessary tools. [...]*
 
 Choose a project path that only contains ASCII characters and no spaces. Open a Terminal and run
 


### PR DESCRIPTION
The windows-build-tools are now a part of the Node.js installer, see https://github.com/felixrieseberg/windows-build-tools for more information.

Associated installer page:

![grafik](https://github.com/user-attachments/assets/bfa68d00-4862-487e-8450-c9383f1341ef)
