### PR TITLE
Add fixture `beamz/lcb366-hybrid-led-panel`

### DIFF
--- a/fixtures/beamz/lcb366-hybrid-led-panel.json
+++ b/fixtures/beamz/lcb366-hybrid-led-panel.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LCB366 Hybrid LED Panel",
+  "shortName": "LCB366",
+  "categories": ["Matrix"],
+  "meta": {
+    "authors": ["BeamZ"],
+    "createDate": "2024-09-23",
+    "lastModifyDate": "2024-09-23"
+  },
+  "links": {
+    "manual": [
+      "https://www.tronios.nl/lcb366-hybrid-led-panel-pixel-control/"
+    ],
+    "productPage": [
+      "https://www.tronios.nl/lcb366-hybrid-led-panel-pixel-control/"
+    ],
+    "video": [
+      "https://www.tronios.nl/lcb366-hybrid-led-panel-pixel-control/"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "LCB366",
+      "shortName": "LCB366",
+      "channels": [
+        "Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `beamz/lcb366-hybrid-led-panel`

### Fixture warnings / errors

* beamz/lcb366-hybrid-led-panel
  - ❌ Category 'Matrix' invalid since fixture does not define a matrix.


Thank you **BeamZ**!