### PR TITLE
Add fixture `generic/mini-led-moving-head-light-150w-beam-spot`

### DIFF
--- a/fixtures/generic/mini-led-moving-head-light-150w-beam-spot.json
+++ b/fixtures/generic/mini-led-moving-head-light-150w-beam-spot.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Mini LED Moving Head Light 150W Beam + Spot",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Loudspaker"],
+    "createDate": "2024-09-26",
+    "lastModifyDate": "2024-09-26"
+  },
+  "links": {
+    "productPage": [
+      "https://it.aliexpress.com/item/1005005448724388.html"
+    ]
+  },
+  "physical": {
+    "dimensions": [34.5, 26, 25.5],
+    "weight": 4.2,
+    "power": 150,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "colorTemperature": 5000,
+      "lumens": 2500
+    },
+    "lens": {
+      "degreesMinMax": [1.5, 1.5]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "180deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Shutter / Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "60Hz",
+          "speedEnd": "440Hz"
+        }
+      ]
+    },
+    "Color Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "ColorPreset",
+          "comment": "10000ff"
+        },
+        {
+          "dmxRange": [10, 19],
+          "type": "ColorPreset",
+          "comment": "#ff0000"
+        },
+        {
+          "dmxRange": [20, 29],
+          "type": "ColorPreset",
+          "comment": "#0000ff"
+        },
+        {
+          "dmxRange": [30, 39],
+          "type": "ColorPreset",
+          "comment": "#f2ff00"
+        },
+        {
+          "dmxRange": [40, 49],
+          "type": "ColorPreset",
+          "comment": "#00ff00"
+        },
+        {
+          "dmxRange": [50, 59],
+          "type": "ColorPreset",
+          "comment": "#0000ff"
+        },
+        {
+          "dmxRange": [60, 69],
+          "type": "ColorPreset",
+          "comment": "#ff00ff"
+        },
+        {
+          "dmxRange": [70, 79],
+          "type": "ColorPreset",
+          "comment": "#00ddff"
+        },
+        {
+          "dmxRange": [80, 89],
+          "type": "ColorPreset",
+          "comment": "#ff0000,#ffffff"
+        },
+        {
+          "dmxRange": [90, 99],
+          "type": "ColorPreset",
+          "comment": "#ff8000,#ff0000"
+        },
+        {
+          "dmxRange": [100, 109],
+          "type": "ColorPreset",
+          "comment": "#ffff00,#ff8000"
+        },
+        {
+          "dmxRange": [110, 119],
+          "type": "ColorPreset",
+          "comment": "#00ff00,#ffff00"
+        },
+        {
+          "dmxRange": [120, 129],
+          "type": "ColorPreset",
+          "comment": "#0000ff,#00ff00"
+        },
+        {
+          "dmxRange": [130, 255],
+          "type": "NoFunction"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "12 channel",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Pan/Tilt Speed",
+        "Dimmer",
+        "Shutter / Strobe",
+        "Color Wheel"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `generic/mini-led-moving-head-light-150w-beam-spot`

### Fixture warnings / errors

* generic/mini-led-moving-head-light-150w-beam-spot
  - ❌ Mode '12 channel' should have 12 channels according to its name but actually has 8.
  - ❌ Mode '12 channel' should have 12 channels according to its shortName but actually has 8.
  - ⚠️ Mode '12 channel' should have shortName '12ch' instead of '12 channel'.
  - ⚠️ Mode '12 channel' should have shortName '12ch' instead of '12 channel'.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Loudspaker**!