### PR TITLE
Add fixture `varytec/event-par-ip65-4in1-14x8w`

### DIFF
--- a/fixtures/varytec/event-par-ip65-4in1-14x8w.json
+++ b/fixtures/varytec/event-par-ip65-4in1-14x8w.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Event Par IP65 4in1 14x8W",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Anonymous"],
+    "createDate": "2024-09-26",
+    "lastModifyDate": "2024-09-26"
+  },
+  "links": {
+    "manual": [
+      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/c_452127_435626_r4_en_online.pdf"
+    ],
+    "productPage": [
+      "https://www.thomann.de/de/varytec_event_par_ip65_4in1_14x8w.htm"
+    ],
+    "video": [
+      "https://www.thomann.de/de/thomanntv_video_varytec_event_par_ip65_4in1_14x8w_7776.html"
+    ]
+  },
+  "physical": {
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe Speed": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUp",
+          "speedStart": "1Hz",
+          "speedEnd": "1000Hz"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "7 Channel",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Dimmer",
+        "Strobe Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `varytec/event-par-ip65-4in1-14x8w`

### Fixture warnings / errors

* varytec/event-par-ip65-4in1-14x8w
  - ❌ Mode '7 Channel' should have 7 channels according to its name but actually has 6.
  - ❌ Mode '7 Channel' should have 7 channels according to its shortName but actually has 6.
  - ⚠️ Mode '7 Channel' should have shortName '7ch' instead of '7 Channel'.
  - ⚠️ Mode '7 Channel' should have shortName '7ch' instead of '7 Channel'.


Thank you **Anonymous**!