### PR TITLE
Fix `Strobe` channel for CLPFLAT1TRI3WIR

### DIFF
--- a/fixtures/cameo/flat-par-can-tri-7x-3w-ir.json
+++ b/fixtures/cameo/flat-par-can-tri-7x-3w-ir.json
@@ -87,23 +87,17 @@
     "Shutter / Strobe": {
       "capabilities": [
         {
-          "dmxRange": [
-            0,
-            0
-          ],
+          "dmxRange": [0, 0],
           "type": "ShutterStrobe",
           "shutterEffect": "Open"
         },
         {
-          "dmxRange": [
-            1,
-            255
-          ],
-        "type": "ShutterStrobe",
-        "shutterEffect": "Strobe",
-        "speedStart": "0%",
+          "dmxRange": [1, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0%",
           "speedEnd": "100%"
-      }
+        }
       ]
     },
     "Color Macro Advanced": {

--- a/fixtures/cameo/flat-par-can-tri-7x-3w-ir.json
+++ b/fixtures/cameo/flat-par-can-tri-7x-3w-ir.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Fabian"],
     "createDate": "2018-09-22",
-    "lastModifyDate": "2018-09-22"
+    "lastModifyDate": "2024-09-30"
   },
   "links": {
     "manual": [

--- a/fixtures/cameo/flat-par-can-tri-7x-3w-ir.json
+++ b/fixtures/cameo/flat-par-can-tri-7x-3w-ir.json
@@ -84,14 +84,27 @@
         }
       ]
     },
-    "Strobe": {
-      "capability": {
+    "Shutter / Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [
+            0,
+            0
+          ],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [
+            1,
+            255
+          ],
         "type": "ShutterStrobe",
         "shutterEffect": "Strobe",
         "speedStart": "0%",
-        "speedEnd": "100%",
-        "helpWanted": "At which DMX values is strobe disabled? That should be a separate capability."
+          "speedEnd": "100%"
       }
+      ]
     },
     "Color Macro Advanced": {
       "name": "Color Macro",
@@ -200,7 +213,7 @@
       "shortName": "3ch1",
       "channels": [
         "Master Dimmer",
-        "Strobe",
+        "Shutter / Strobe",
         "Color Macro Advanced"
       ]
     },
@@ -218,7 +231,7 @@
       "shortName": "6ch",
       "channels": [
         "Master Dimmer",
-        "Strobe",
+        "Shutter / Strobe",
         "Red",
         "Green",
         "Blue",


### PR DESCRIPTION
- `Strobe` channel is renamed to `Shutter / Strobe`
- Separate capability for open shutter