### PR TITLE
Improve fixture `cameo/flat-par-can-rgb-10-ir`

### DIFF
--- a/fixtures/cameo/flat-par-can-rgb-10-ir.json
+++ b/fixtures/cameo/flat-par-can-rgb-10-ir.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Felix Edelmann"],
     "createDate": "2019-03-06",
-    "lastModifyDate": "2019-03-06"
+    "lastModifyDate": "2024-10-01"
   },
   "links": {
     "manual": [
@@ -84,14 +84,21 @@
         }
       ]
     },
-    "Strobe": {
-      "capability": {
-        "type": "ShutterStrobe",
-        "shutterEffect": "Strobe",
-        "speedStart": "0%",
-        "speedEnd": "100%",
-        "helpWanted": "At which DMX values is strobe disabled? That should be a separate capability."
-      }
+    "Shutter / Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [1, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
     },
     "Color Macro Advanced": {
       "name": "Color Macro",
@@ -200,7 +207,7 @@
       "shortName": "3ch1",
       "channels": [
         "Master Dimmer",
-        "Strobe",
+        "Shutter / Strobe",
         "Color Macro Advanced"
       ]
     },
@@ -218,7 +225,7 @@
       "shortName": "6ch",
       "channels": [
         "Master Dimmer",
-        "Strobe",
+        "Shutter / Strobe",
         "Red",
         "Green",
         "Blue",


### PR DESCRIPTION
Fix "Strobe" channel of `cameo/flat-par-can-rgb-10-ir`