### PR TITLE
Fix matrix pixel highlighting

### DIFF
--- a/ui/components/LabeledValue.vue
+++ b/ui/components/LabeledValue.vue
@@ -1,5 +1,12 @@
+<!-- eslint-disable vuejs-accessibility/no-static-element-interactions -- use more accessible way of highlighting -->
+
 <template>
-  <section :class="name">
+  <section
+    :class="name"
+    @focusin="$emit('focusin', $event)"
+    @focusout="$emit('focusout', $event)"
+    @mouseover="$emit('mouseover', $event)"
+    @mouseout="$emit('mouseout', $event)">
     <div class="label">
       <template v-if="label">{{ label }}</template>
       <slot name="label" />
@@ -49,6 +56,12 @@ export default {
     name: stringProp().optional,
     label: stringProp().optional,
     value: stringProp().optional,
+  },
+  emits: {
+    focusin: event => true,
+    focusout: event => true,
+    mouseover: event => true,
+    mouseout: event => true,
   },
 };
 </script>


### PR DESCRIPTION
It broke in [`6598407` (#3549)](https://github.com/OpenLightingProject/open-fixture-library/pull/3549/commits/659840779666adb39c2b2fe6ff10c8da35d3fb82), where the `<LabeledValue>` component was changed from a functional component to a stateful one. Functional components emitted all DOM events as Vue events, now they manually have to be emitted.