### PR TITLE
Fix IP65 DmxConnector mapping in QLC+ export

### DIFF
--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -104,7 +104,7 @@
     "qlcplus_4.12.2": {
       "name": "QLC+ 4.12.2",
       "importPluginVersion": "1.1.1",
-      "exportPluginVersion": "1.3.0",
+      "exportPluginVersion": "1.3.1",
       "exportTests": [
         "fixture-tool-validation",
         "xsd-schema-conformity"

--- a/plugins/qlcplus_4.12.2/export.js
+++ b/plugins/qlcplus_4.12.2/export.js
@@ -17,7 +17,7 @@ import {
   getFineChannelPreset,
 } from './presets.js';
 
-export const version = `1.3.0`;
+export const version = `1.3.1`;
 
 /**
  * @param {Fixture[]} fixtures An array of Fixture objects.
@@ -436,11 +436,23 @@ function addPhysical(xmlParentNode, physical, fixture, mode) {
       // add whitespace
       let connector = physical.DMXconnector;
 
-      if (connector === `3.5mm stereo jack`) {
-        connector = `3.5 mm stereo jack`;
-      }
-      else if (connector === `RJ45`) {
-        connector = `Other`;
+      switch (connector) {
+        case `3.5mm stereo jack`: {
+          connector = `3.5 mm stereo jack`;
+          break;
+        }
+        case `3-pin XLR IP65`: {
+          connector = `3-pin IP65`;
+          break;
+        }
+        case `5-pin XLR IP65`: {
+          connector = `5-pin IP65`;
+          break;
+        }
+        case `RJ45`: {
+          connector = `Other`;
+          break;
+        }
       }
 
       return {


### PR DESCRIPTION
Found in #4308:

> ![grafik](https://github.com/user-attachments/assets/0441297f-5213-46d9-92bb-eb15ec32de10)
