### PR TITLE
Add fixture `lightmaxx/led-color-bar-short`

### DIFF
--- a/fixtures/lightmaxx/led-color-bar-short.json
+++ b/fixtures/lightmaxx/led-color-bar-short.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED Color Bar Short",
+  "shortName": "LED Col Bar S",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["Moritz Wirger"],
+    "createDate": "2024-11-03",
+    "lastModifyDate": "2024-11-03"
+  },
+  "links": {
+    "manual": [
+      "https://www.manualslib.com/manual/1521157/Lightmaxx-Led-Rgb-Color-Bar-Stripe.html"
+    ],
+    "productPage": [
+      "https://www.musicstore.de/de_DE/EUR/lightmaXX-LED-RGB-Color-Bar-Short-126x10mm-LED-s-DMX-Wall-Washer/art-LIG0004983-000"
+    ]
+  },
+  "physical": {
+    "dimensions": [509, 63, 87],
+    "weight": 1.5,
+    "power": 18,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Mode": {
+      "defaultValue": 1,
+      "constant": true,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "Generic",
+          "comment": "Black out"
+        },
+        {
+          "dmxRange": [1, 15],
+          "type": "Generic",
+          "comment": "3 Segments"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "NoFunction"
+        }
+      ]
+    },
+    "Dimmer": {
+      "defaultValue": 255,
+      "highlightValue": 255,
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "highlightValue": 0,
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "0.5Hz",
+        "speedEnd": "10Hz"
+      }
+    },
+    "Red 1": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Green 1": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Blue 1": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Red 2": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Green 2": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Blue 2": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Red 3": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Green 3": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Blue 3": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "3 Segments",
+      "channels": [
+        "Mode",
+        "Dimmer",
+        "Strobe",
+        "Red 1",
+        "Green 1",
+        "Blue 1",
+        "Red 2",
+        "Green 2",
+        "Blue 2",
+        "Red 3",
+        "Green 3",
+        "Blue 3"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `lightmaxx/led-color-bar-short`

### Fixture warnings / errors

* lightmaxx/led-color-bar-short
  - ❌ Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you @enwi!