### PR TITLE
Revert "Bump color-name-list from 10.28.1 to 11.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "ajv-formats": "^3.0.1",
         "chalk": "^5.3.0",
         "color-hash": "^2.0.2",
-        "color-name-list": "^11.0.0",
+        "color-name-list": "^10.28.1",
         "cookie-universal-nuxt": "^2.2.2",
         "cors": "^2.8.5",
         "embetty-vue": "^2.0.1",
@@ -7894,9 +7894,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-name-list": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/color-name-list/-/color-name-list-11.0.0.tgz",
-      "integrity": "sha512-jYouI0M+AWn30PCgmaOHkHtJy6pLHNklizgCTfj9Wx2k9zjiH2N/HxqrUhMBptCIZX16912/j4ISmW85FEF19Q==",
+      "version": "10.28.1",
+      "resolved": "https://registry.npmjs.org/color-name-list/-/color-name-list-10.28.1.tgz",
+      "integrity": "sha512-ojzUmul10ikVk4tZaLGnFBIwvL6ojFGuq+NplQ3dbltQkVmIvGnatJw0JmCSgK6scd1+Sgl1yOdT86IwcN9xbQ==",
       "funding": [
         {
           "type": "ko-fi",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ajv-formats": "^3.0.1",
     "chalk": "^5.3.0",
     "color-hash": "^2.0.2",
-    "color-name-list": "^11.0.0",
+    "color-name-list": "^10.28.1",
     "cookie-universal-nuxt": "^2.2.2",
     "cors": "^2.8.5",
     "embetty-vue": "^2.0.1",

--- a/plugins/aglight/export.js
+++ b/plugins/aglight/export.js
@@ -1,6 +1,6 @@
 /* Based on the ofl export plugin */
 
-import { colornames as colorNames } from 'color-name-list';
+import namedColors from 'color-name-list/dist/colornames.esm.mjs';
 import fixtureJsonStringify from '../../lib/fixture-json-stringify.js';
 
 import importJson from '../../lib/import-json.js';
@@ -158,7 +158,7 @@ function transformNonNumericValues(fixtureJson) {
  * @param {object} capability The capability where the color name in the color attribute should be replaced with its hex value
  */
 function processColor(capability) {
-  const namedColor = colorNames.find(color => color.name === capability.color);
+  const namedColor = namedColors.find(color => color.name === capability.color);
   if (namedColor && namedColor.hex) {
     capability.color = namedColor.hex;
   }

--- a/plugins/ecue/import.js
+++ b/plugins/ecue/import.js
@@ -1,10 +1,10 @@
-import { colornames as colorNames } from 'color-name-list';
+import colorNameList from 'color-name-list/dist/colornames.esm.mjs';
 import xml2js from 'xml2js';
 
 export const version = `0.3.1`;
 
 const colors = {};
-for (const color of colorNames) {
+for (const color of colorNameList) {
   colors[color.name.toLowerCase().replaceAll(/\s/g, ``)] = color.hex;
 }
 


### PR DESCRIPTION
Revert #4414 to fix #4415. See https://github.com/OpenLightingProject/open-fixture-library/issues/4415#issuecomment-2483774486.