### PR TITLE
Add fixture `ev-light/epro100`

### DIFF
--- a/fixtures/ev-light/epro100.json
+++ b/fixtures/ev-light/epro100.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "EPRO100",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["mkobzar", "Mikhail Kobzar"],
+    "createDate": "2024-12-11",
+    "lastModifyDate": "2024-12-11",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2024-12-11",
+      "comment": "created by Q Light Controller Plus (version 4.13.1)"
+    }
+  },
+  "physical": {
+    "dimensions": [380, 110, 110],
+    "weight": 3.25,
+    "power": 100,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "colorTemperature": 5600,
+      "lumens": 9000
+    },
+    "lens": {
+      "name": "PC",
+      "degreesMinMax": [50, 60]
+    }
+  },
+  "availableChannels": {
+    "Master dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "1-channel",
+      "shortName": "1ch",
+      "channels": [
+        "Master dimmer"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -173,6 +173,9 @@
     "name": "Eurolite",
     "website": "https://www.steinigke.de/en/Eurolite/"
   },
+  "ev-light": {
+    "name": "EV Light"
+  },
   "event-lighting": {
     "name": "Event Lighting",
     "website": "https://event-lighting.com.au/"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `ev-light/epro100`

### Fixture warnings / errors

* ev-light/epro100
  - ❌ Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.
  - ⚠️ Please check if manufacturer is correct and add manufacturer URL.


Thank you **mkobzar** and **Mikhail Kobzar**!