### PR TITLE
Add fixture `chauvet-dj/slimpar-t12-ils`

### DIFF
--- a/fixtures/chauvet-dj/slimpar-t12-ils.json
+++ b/fixtures/chauvet-dj/slimpar-t12-ils.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "SlimPAR T12 ILS",
+  "categories": ["Color Changer", "Dimmer", "Effect", "Strobe"],
+  "meta": {
+    "authors": ["Mouflon"],
+    "createDate": "2025-02-03",
+    "lastModifyDate": "2025-02-03"
+  },
+  "links": {
+    "manual": [
+      "https://fr.chauvetdj.com/wp-content/uploads/2022/05/SlimPAR_T12_ILS_QRG_ML6_Rev2.pdf"
+    ],
+    "productPage": [
+      "https://fr.chauvetdj.com/products/slimpar-t12-ils/"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=ilRPKtgWJNs"
+    ]
+  },
+  "physical": {
+    "dimensions": [224.5, 225.5, 246],
+    "weight": 1.6,
+    "power": 60,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "lumens": 1415
+    },
+    "lens": {
+      "degreesMinMax": [17, 17]
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Color Macros": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "ColorPreset"
+        }
+      ]
+    },
+    "Strobe": {
+      "defaultValue": 5,
+      "constant": true,
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Program": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 31],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [32, 63],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUp",
+          "comment": "when Ch. 1-3 are active"
+        },
+        {
+          "dmxRange": [64, 95],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampDown",
+          "comment": "when Ch. 1-3 are active"
+        },
+        {
+          "dmxRange": [96, 127],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUpDown",
+          "comment": "when Ch. 1-3 are active"
+        },
+        {
+          "dmxRange": [128, 159],
+          "type": "Effect",
+          "effectName": "Automatic fade"
+        },
+        {
+          "dmxRange": [160, 191],
+          "type": "Effect",
+          "effectName": "Automatic 3-color snap"
+        },
+        {
+          "dmxRange": [192, 223],
+          "type": "Effect",
+          "effectName": "Automatic 7-color snap"
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "Effect",
+          "effectName": "Sound-active 7-color snap",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Dimmer speed": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 51],
+          "type": "Generic",
+          "comment": "Dimmer speed set from display menu"
+        },
+        {
+          "dmxRange": [52, 101],
+          "type": "Speed",
+          "speed": "stop"
+        },
+        {
+          "dmxRange": [102, 152],
+          "type": "Speed",
+          "speed": "fast"
+        },
+        {
+          "dmxRange": [153, 203],
+          "type": "Speed",
+          "speed": "50%"
+        },
+        {
+          "dmxRange": [204, 255],
+          "type": "Speed",
+          "speed": "slow"
+        }
+      ]
+    },
+    "Sound Sensitivity": {
+      "defaultValue": 5,
+      "constant": true,
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "SoundSensitivity",
+          "soundSensitivity": "off",
+          "comment": "when Ch. 6 is 32<=>223"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "SoundSensitivity",
+          "soundSensitivityStart": "low",
+          "soundSensitivityEnd": "high",
+          "comment": "when Ch. 6 is 224<=>255"
+        }
+      ]
+    },
+    "Program Speed": {
+      "defaultValue": 5,
+      "constant": true,
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "3-channel",
+      "shortName": "3ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    },
+    {
+      "name": "8-channel",
+      "shortName": "8ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Color Macros",
+        "Strobe",
+        "Program",
+        "Dimmer",
+        "Dimmer speed",
+        "Sound Sensitivity",
+        "Program Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `chauvet-dj/slimpar-t12-ils`

### Fixture warnings / errors

* chauvet-dj/slimpar-t12-ils
  - ❌ Mode '8-channel' should have 8 channels according to its name but actually has 10.
  - ❌ Mode '8-channel' should have 8 channels according to its shortName but actually has 10.


Thank you @Mouflon23!