### PR TITLE
Add fixture `shehds/led-flat-par-18x18w-rgbwa-uv-light`

### DIFF
--- a/fixtures/shehds/led-flat-par-18x18w-rgbwa-uv-light.json
+++ b/fixtures/shehds/led-flat-par-18x18w-rgbwa-uv-light.json
@@ -1,0 +1,232 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED Flat Par 18x18W RGBWA+UV Light",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Bischop91100"],
+    "createDate": "2025-02-05",
+    "lastModifyDate": "2025-02-05",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2025-02-05",
+      "comment": "created by Q Light Controller Plus (version 4.13.1)"
+    }
+  },
+  "physical": {
+    "dimensions": [200, 200, 80],
+    "weight": 2.35,
+    "power": 324,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [0, 40]
+    }
+  },
+  "availableChannels": {
+    "Master dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "Violet": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 4],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open",
+          "comment": "Shutter open"
+        },
+        {
+          "dmxRange": [5, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0Hz",
+          "speedEnd": "20Hz",
+          "comment": "Strobe 0…20Hz"
+        }
+      ]
+    },
+    "Function": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 50],
+          "type": "NoFunction",
+          "switchChannels": {
+            "Color Presets / Function Speed": "Color Presets"
+          }
+        },
+        {
+          "dmxRange": [51, 100],
+          "type": "Effect",
+          "effectName": "Static color",
+          "switchChannels": {
+            "Color Presets / Function Speed": "Color Presets"
+          }
+        },
+        {
+          "dmxRange": [101, 150],
+          "type": "Effect",
+          "effectName": "Color jump (Random colors)",
+          "switchChannels": {
+            "Color Presets / Function Speed": "Function Speed"
+          }
+        },
+        {
+          "dmxRange": [151, 200],
+          "type": "Effect",
+          "effectName": "Color fade (Random colors)",
+          "switchChannels": {
+            "Color Presets / Function Speed": "Function Speed"
+          }
+        },
+        {
+          "dmxRange": [201, 250],
+          "type": "Effect",
+          "effectName": "Color fade (Random colors, fade to black)",
+          "switchChannels": {
+            "Color Presets / Function Speed": "Function Speed"
+          }
+        },
+        {
+          "dmxRange": [251, 255],
+          "type": "Effect",
+          "effectName": "Sound Mode (Static color flashing on beat)",
+          "soundControlled": true,
+          "switchChannels": {
+            "Color Presets / Function Speed": "Color Presets"
+          }
+        }
+      ]
+    },
+    "Color Presets": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 31],
+          "type": "ColorPreset",
+          "comment": "Red",
+          "colors": ["#ff0000"]
+        },
+        {
+          "dmxRange": [32, 63],
+          "type": "ColorPreset",
+          "comment": "Green",
+          "colors": ["#00ff00"]
+        },
+        {
+          "dmxRange": [64, 95],
+          "type": "ColorPreset",
+          "comment": "Blue",
+          "colors": ["#0000ff"]
+        },
+        {
+          "dmxRange": [96, 127],
+          "type": "ColorPreset",
+          "comment": "White",
+          "colors": ["#ffffff"]
+        },
+        {
+          "dmxRange": [128, 159],
+          "type": "ColorPreset",
+          "comment": "Amber",
+          "colors": ["#ffbf00"]
+        },
+        {
+          "dmxRange": [160, 191],
+          "type": "ColorPreset",
+          "comment": "UV",
+          "colors": ["#8800ff"]
+        },
+        {
+          "dmxRange": [192, 223],
+          "type": "ColorPreset",
+          "comment": "Cyan",
+          "colors": ["#00ffff"]
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "ColorPreset",
+          "comment": "Warm White",
+          "colors": ["#fff6da"]
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "6-channel",
+      "shortName": "6ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "Violet"
+      ]
+    },
+    {
+      "name": "10-channel",
+      "shortName": "10ch",
+      "channels": [
+        "Master dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "Violet",
+        "Strobe",
+        "Function",
+        "Color Presets / Function Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `shehds/led-flat-par-18x18w-rgbwa-uv-light`

### Fixture warnings / errors

* shehds/led-flat-par-18x18w-rgbwa-uv-light
  - ❌ Capability 'Color jump (Random colors)' (101…150) in channel 'Function' references unknown channel 'Function Speed'.
  - ❌ Capability 'Color fade (Random colors)' (151…200) in channel 'Function' references unknown channel 'Function Speed'.
  - ❌ Capability 'Color fade (Random colors, fade to black)' (201…250) in channel 'Function' references unknown channel 'Function Speed'.


### User comment

With 2 mode 6 Ch and 10 Ch

Thank you **Bischop91100**!