### PR TITLE
Add fixture `showtec/spectral-revo-tungsten`

### DIFF
--- a/fixtures/showtec/spectral-revo-tungsten.json
+++ b/fixtures/showtec/spectral-revo-tungsten.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Spectral Revo Tungsten",
+  "categories": ["Dimmer"],
+  "meta": {
+    "authors": ["Mathieu VINCENT"],
+    "createDate": "2025-02-14",
+    "lastModifyDate": "2025-02-14"
+  },
+  "links": {
+    "manual": [
+      "https://www.highlite.com/fr/marques/43642-spectral-revo-tungsten.html"
+    ]
+  },
+  "physical": {
+    "dimensions": [418, 320, 219],
+    "weight": 6.5,
+    "power": 143,
+    "DMXconnector": "5-pin XLR IP65"
+  },
+  "availableChannels": {
+    "Master Dimmer": {
+      "fineChannelAliases": ["Master Dimmer fine"],
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Warm White": {
+      "fineChannelAliases": ["Warm White fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Natural White": {
+      "fineChannelAliases": ["Natural White fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "CCT": {
+      "fineChannelAliases": ["CCT fine"],
+      "dmxValueResolution": "8bit",
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 35],
+          "type": "ColorTemperature",
+          "colorTemperature": "2700K"
+        },
+        {
+          "dmxRange": [36, 60],
+          "type": "ColorTemperature",
+          "colorTemperature": "3000K",
+          "comment": "300K"
+        },
+        {
+          "dmxRange": [61, 85],
+          "type": "ColorTemperature",
+          "colorTemperature": "3200K",
+          "comment": "3200K"
+        },
+        {
+          "dmxRange": [86, 110],
+          "type": "ColorTemperature",
+          "colorTemperature": "3400K"
+        },
+        {
+          "dmxRange": [111, 135],
+          "type": "ColorTemperature",
+          "colorTemperature": "3600K"
+        },
+        {
+          "dmxRange": [136, 160],
+          "type": "ColorTemperature",
+          "colorTemperature": "3800K"
+        },
+        {
+          "dmxRange": [161, 185],
+          "type": "ColorTemperature",
+          "colorTemperature": "4000K"
+        },
+        {
+          "dmxRange": [186, 210],
+          "type": "ColorTemperature",
+          "colorTemperature": "4200K"
+        },
+        {
+          "dmxRange": [211, 235],
+          "type": "ColorTemperature",
+          "colorTemperature": "4500K"
+        },
+        {
+          "dmxRange": [236, 255],
+          "type": "NoFunction"
+        }
+      ]
+    },
+    "Strobe": {
+      "fineChannelAliases": ["Strobe fine"],
+      "dmxValueResolution": "8bit",
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [10, 99],
+          "type": "StrobeSpeed",
+          "speedStart": "0Hz",
+          "speedEnd": "25Hz"
+        },
+        {
+          "dmxRange": [100, 109],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [110, 179],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Lightning"
+        },
+        {
+          "dmxRange": [180, 189],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [190, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampDown"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "UNO",
+      "channels": [
+        "Master Dimmer"
+      ]
+    },
+    {
+      "name": "DOS",
+      "channels": [
+        "Master Dimmer",
+        "Master Dimmer fine"
+      ]
+    },
+    {
+      "name": "VW.D",
+      "channels": [
+        "Master Dimmer",
+        "Warm White",
+        "Natural White"
+      ]
+    },
+    {
+      "name": "VW.F",
+      "channels": [
+        "Master Dimmer",
+        "Master Dimmer fine",
+        "Warm White",
+        "Warm White fine",
+        "Natural White",
+        "Natural White fine"
+      ]
+    },
+    {
+      "name": "STD.P",
+      "channels": [
+        "Master Dimmer",
+        "Master Dimmer fine",
+        "Warm White",
+        "Warm White fine",
+        "Natural White",
+        "Natural White fine",
+        "CCT",
+        "Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `showtec/spectral-revo-tungsten`

### Fixture warnings / errors

* showtec/spectral-revo-tungsten
  - ❌ Capability 'Strobe speed 0…25Hz' (10…99) in channel 'Strobe': StrobeSpeed can't be used in the same channel as ShutterStrobe. Should this rather be a ShutterStrobe capability with shutterEffect "Strobe"?
  - ⚠️ Unused channel(s): cct fine, strobe fine
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Mathieu VINCENT**!