### PR TITLE
Add fixture `prolights/ecl-panel-twc`

### DIFF
--- a/fixtures/prolights/ecl-panel-twc.json
+++ b/fixtures/prolights/ecl-panel-twc.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "ECL Panel TWC",
+  "shortName": "TWC10CH",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["ELimpia SRL"],
+    "createDate": "2025-02-19",
+    "lastModifyDate": "2025-02-19"
+  },
+  "links": {
+    "productPage": [
+      "https://www.prolights.it/it/product/ECLPANELTWC"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Color Temperature": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "cold",
+        "colorTemperatureEnd": "warm"
+      }
+    },
+    "HUE": {
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "Effect",
+        "effectName": "color",
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Program Speed": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "10ch",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Color Temperature",
+        "HUE",
+        "Shutter / Strobe",
+        "Color Macros",
+        "Program Speed"
+      ]
+    },
+    {
+      "name": "10ch",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Color Temperature",
+        "HUE",
+        "Shutter / Strobe",
+        "Color Macros",
+        "Program Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `prolights/ecl-panel-twc`

### Fixture warnings / errors

* prolights/ecl-panel-twc
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedStart "slow CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedStart "slow CW" must be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedStart "slow CW" must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?Hz$"
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?bpm$"
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedEnd "fast CW" must match pattern "^-?[0-9]+(\.[0-9]+)?%$"
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedEnd "fast CW" must be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - ❌ File does not match schema: fixture/availableChannels/Color Macros/capability/speedEnd "fast CW" must match exactly one schema in oneOf


Thank you **ELimpia SRL**!