### PR TITLE
Add fixture `silver-star/indigo1000`

### DIFF
--- a/fixtures/silver-star/indigo1000.json
+++ b/fixtures/silver-star/indigo1000.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "INDIGO1000",
+  "categories": ["Color Changer", "Moving Head"],
+  "meta": {
+    "authors": ["Test"],
+    "createDate": "2025-03-02",
+    "lastModifyDate": "2025-03-02"
+  },
+  "links": {
+    "other": [
+      "https://www.akaricenter.com/tokusyu/mirror_ball/graphica/indigo1000.htm"
+    ]
+  },
+  "availableChannels": {
+    "Pan": {
+      "defaultValue": 1,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Panfine": {
+      "defaultValue": 2,
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Pan 2": {
+      "name": "Pan",
+      "defaultValue": 1,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "defaultValue": 2,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Color": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 14],
+          "type": "ColorPreset",
+          "comment": "White"
+        },
+        {
+          "dmxRange": [15, 29],
+          "type": "ColorPreset",
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [30, 44],
+          "type": "ColorPreset",
+          "comment": "Yellow"
+        },
+        {
+          "dmxRange": [45, 59],
+          "type": "ColorPreset",
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [60, 74],
+          "type": "ColorPreset",
+          "comment": "Pink"
+        },
+        {
+          "dmxRange": [75, 89],
+          "type": "ColorPreset",
+          "comment": "Blue"
+        },
+        {
+          "dmxRange": [90, 104],
+          "type": "ColorPreset",
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [105, 119],
+          "type": "ColorPreset",
+          "comment": "Magenta"
+        },
+        {
+          "dmxRange": [120, 134],
+          "type": "ColorPreset",
+          "comment": "LightBlue"
+        },
+        {
+          "dmxRange": [135, 149],
+          "type": "ColorPreset",
+          "comment": "LightGreen"
+        },
+        {
+          "dmxRange": [150, 255],
+          "type": "ColorPreset",
+          "comment": "Rainbow"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "8ch",
+      "channels": [
+        "Pan 2",
+        "Tilt",
+        "Color"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `silver-star/indigo1000`

### Fixture warnings / errors

* silver-star/indigo1000
  - ❌ Mode '8ch' should have 8 channels according to its name but actually has 3.
  - ❌ Mode '8ch' should have 8 channels according to its shortName but actually has 3.
  - ⚠️ Unused channel(s): pan, panfine


Thank you **Test**!