### PR TITLE
Add fixture `shehds/led-moving-head-wash-7x12w-rgbw`

### DIFF
--- a/fixtures/shehds/led-moving-head-wash-7x12w-rgbw.json
+++ b/fixtures/shehds/led-moving-head-wash-7x12w-rgbw.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Led Moving Head Wash 7x12W RGBW",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Voltoxin"],
+    "createDate": "2025-03-29",
+    "lastModifyDate": "2025-03-29",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2025-03-29",
+      "comment": "created by Q Light Controller Plus (version 4.14.1-2)"
+    }
+  },
+  "physical": {
+    "dimensions": [170, 237, 185],
+    "weight": 3.1,
+    "power": 84,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [15, 15]
+    }
+  },
+  "matrix": {
+    "pixelCount": [
+      null,
+      null,
+      1
+    ]
+  },
+  "availableChannels": {
+    "PAN": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "TILT": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "STROBE": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "helpWanted": "At which DMX values is strobe disabled?"
+      }
+    },
+    "RED": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "BLUE": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "WHITE": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "MODE": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "Effect",
+          "effectName": "NF"
+        },
+        {
+          "dmxRange": [8, 140],
+          "type": "Effect",
+          "effectName": "AUTO MODE"
+        },
+        {
+          "dmxRange": [141, 255],
+          "type": "Effect",
+          "effectName": "SOUND CONTROL",
+          "soundControlled": true
+        }
+      ]
+    },
+    "P/T SPEED": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 140],
+          "type": "Speed",
+          "comment": "NF",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        },
+        {
+          "dmxRange": [141, 255],
+          "type": "Speed",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        }
+      ]
+    },
+    "REST": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 249],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "NoFunction"
+        }
+      ]
+    }
+  },
+  "templateChannels": {},
+  "modes": [
+    {
+      "name": "10-channel",
+      "shortName": "10ch",
+      "channels": [
+        "PAN",
+        "TILT",
+        "STROBE",
+        "RED",
+        "Green",
+        "BLUE",
+        "WHITE",
+        "MODE",
+        "P/T SPEED",
+        "REST"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `shehds/led-moving-head-wash-7x12w-rgbw`

### Fixture warnings / errors

* shehds/led-moving-head-wash-7x12w-rgbw
  - ❌ File does not match schema: fixture/matrix/pixelCount/0 -Infinity must be >= 1
  - ❌ File does not match schema: fixture/matrix/pixelCount/1 -Infinity must be >= 1
  - ❌ File does not match schema: fixture/templateChannels must NOT have fewer than 1 properties
  - ⚠️ Please add 10-channel mode's Head #1 to the fixture's matrix. The included channels were PAN, TILT, STROBE, RED, Green, BLUE, WHITE, MODE, P/T SPEED, REST.


Thank you **Voltoxin**!