### PR TITLE
Add fixture `betopper/lc003-hb`

### DIFF
--- a/fixtures/betopper/lc003-hb.json
+++ b/fixtures/betopper/lc003-hb.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LC003-HB",
+  "shortName": "LC003-HB",
+  "categories": ["Strobe", "Dimmer"],
+  "meta": {
+    "authors": ["LPJ LifeChurch"],
+    "createDate": "2025-03-29",
+    "lastModifyDate": "2025-03-29"
+  },
+  "links": {
+    "productPage": [
+      "https://betopperdj.com/products/betopper-120w-warm-cold-white-par-light-lc003-h"
+    ]
+  },
+  "availableChannels": {
+    "WW Warm whites": {
+      "fineChannelAliases": ["WW Warm whites fine"],
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Warm White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Cold White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "D001",
+      "shortName": "2 Channel",
+      "channels": [
+        "Warm White",
+        "Cold White"
+      ]
+    },
+    {
+      "name": "A001",
+      "shortName": "4 Channel",
+      "channels": [
+        "Dimmer",
+        "Warm White",
+        "Cold White",
+        "Strobe"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -62,6 +62,9 @@
     "comment": "Brand of the Tronios Group.",
     "website": "https://www.tronios.com/lighting/filter/brand_beamz/"
   },
+  "betopper": {
+    "name": "BeTopper"
+  },
   "big-dipper": {
     "name": "Big Dipper",
     "website": "https://bigdipper-laser.com/"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `betopper/lc003-hb`

### Fixture warnings / errors

* betopper/lc003-hb
  - ⚠️ Mode 'D001' should have shortName '2ch' instead of '2 Channel'.
  - ⚠️ Mode 'A001' should have shortName '4ch' instead of '4 Channel'.
  - ⚠️ Unused channel(s): ww warm whites, ww warm whites fine
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **LPJ LifeChurch**!