### PR TITLE
Add 0 new fixtures

### DIFF
--- a/fixtures/stairville/xbrick-full-colour.json
+++ b/fixtures/stairville/xbrick-full-colour.json
@@ -3,25 +3,14 @@
   "name": "xBrick Full-Colour",
   "categories": ["Color Changer"],
   "meta": {
-    "authors": ["fintch"],
-    "createDate": "2023-02-11",
-    "lastModifyDate": "2024-11-23",
+    "authors": ["fintch", "Anony"],
+    "createDate": "2025-05-20",
+    "lastModifyDate": "2025-05-20",
     "importPlugin": {
       "plugin": "qlcplus_4.12.1",
-      "date": "2022-06-15",
-      "comment": "created by Q Light Controller Plus (version 4.4.1)"
+      "date": "2025-05-20",
+      "comment": "created by OFL – https://open-fixture-library.org/stairville/xbrick-full-colour (version 1.3.1)"
     }
-  },
-  "links": {
-    "manual": [
-      "https://images.static-thomann.de/pics/atg/atgdata/document/manual/c_259187_v4_en_online.pdf"
-    ],
-    "productPage": [
-      "https://www.thomann.de/intl/stairville_xbrick_fullcolour_16x3w.htm"
-    ],
-    "video": [
-      "https://video2.thomann.de/vidiot/02591c1c/video_i1301p10_yd59vqpa.mp4"
-    ]
   },
   "physical": {
     "dimensions": [310, 175, 72],
@@ -36,39 +25,11 @@
     }
   },
   "matrix": {
-    "pixelKeys": [
-      [
-        ["1A", "1B", null, "2A", "2B", null, "3A", "3B", null, "4A", "4B"],
-        ["1C", "1D", null, "2C", "2D", null, "3C", "3D", null, "4C", "4D"]
-      ]
-    ],
-    "pixelGroups": {
-      "All": "all",
-      "1": { "name": ["^1[A-D]$"] },
-      "2": { "name": ["^2[A-D]$"] },
-      "3": { "name": ["^3[A-D]$"] },
-      "4": { "name": ["^4[A-D]$"] }
-    }
-  },
-  "templateChannels": {
-    "Red $pixelKey": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Red"
-      }
-    },
-    "Green $pixelKey": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Green"
-      }
-    },
-    "Blue $pixelKey": {
-      "capability": {
-        "type": "ColorIntensity",
-        "color": "Blue"
-      }
-    }
+    "pixelCount": [
+      11,
+      2,
+      1
+    ]
   },
   "availableChannels": {
     "Master Dimmer": {
@@ -83,25 +44,124 @@
         "type": "StrobeSpeed",
         "speedStart": "slow",
         "speedEnd": "fast",
-        "helpWanted": "Are the automatically added speed values correct?"
+        "comment": "Strobe speed slow…fast"
+      }
+    },
+    "Red 1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Red 2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Red 3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Red 4": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Red All": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Green 2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Green 3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Green 4": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Green All": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Blue 2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Blue 3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Blue 4": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Blue All": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
       }
     }
   },
+  "templateChannels": {},
   "modes": [
     {
       "name": "5-channel",
       "shortName": "5ch",
       "channels": [
-        {
-          "insert": "matrixChannels",
-          "repeatFor": ["All"],
-          "channelOrder": "perPixel",
-          "templateChannels": [
-            "Red $pixelKey",
-            "Green $pixelKey",
-            "Blue $pixelKey"
-          ]
-        },
+        "Red All",
+        "Green All",
+        "Blue All",
         "Master Dimmer",
         "Strobe Speed"
       ]
@@ -110,16 +170,18 @@
       "name": "13-channel",
       "shortName": "13ch",
       "channels": [
-        {
-          "insert": "matrixChannels",
-          "repeatFor": ["1", "2", "3", "4"],
-          "channelOrder": "perPixel",
-          "templateChannels": [
-            "Red $pixelKey",
-            "Green $pixelKey",
-            "Blue $pixelKey"
-          ]
-        },
+        "Red 1",
+        "Green 1",
+        "Blue 1",
+        "Red 2",
+        "Green 2",
+        "Blue 2",
+        "Red 3",
+        "Green 3",
+        "Blue 3",
+        "Red 4",
+        "Green 4",
+        "Blue 4",
         "Master Dimmer"
       ]
     }


### PR DESCRIPTION
* Update fixture `stairville/xbrick-full-colour`

### Fixture warnings / errors

* stairville/xbrick-full-colour
  - ❌ File does not match schema: fixture/templateChannels must NOT have fewer than 1 properties
  - ⚠️ Please add 5-channel mode's Head #1 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #2 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #3 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #4 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #5 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #6 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #7 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #8 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #9 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #10 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #11 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #12 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #13 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #14 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #15 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 5-channel mode's Head #16 to the fixture's matrix. The included channels were Red All, Green All, Blue All.
  - ⚠️ Please add 13-channel mode's Head #1 to the fixture's matrix. The included channels were Red 1, Green 1, Blue 1.
  - ⚠️ Please add 13-channel mode's Head #2 to the fixture's matrix. The included channels were Red 1, Green 1, Blue 1.
  - ⚠️ Please add 13-channel mode's Head #3 to the fixture's matrix. The included channels were Red 2, Green 2, Blue 2.
  - ⚠️ Please add 13-channel mode's Head #4 to the fixture's matrix. The included channels were Red 2, Green 2, Blue 2.
  - ⚠️ Please add 13-channel mode's Head #5 to the fixture's matrix. The included channels were Red 3, Green 3, Blue 3.
  - ⚠️ Please add 13-channel mode's Head #6 to the fixture's matrix. The included channels were Red 3, Green 3, Blue 3.
  - ⚠️ Please add 13-channel mode's Head #7 to the fixture's matrix. The included channels were Red 4, Green 4, Blue 4.
  - ⚠️ Please add 13-channel mode's Head #8 to the fixture's matrix. The included channels were Red 4, Green 4, Blue 4.
  - ⚠️ Please add 13-channel mode's Head #9 to the fixture's matrix. The included channels were Red 1, Green 1, Blue 1.
  - ⚠️ Please add 13-channel mode's Head #10 to the fixture's matrix. The included channels were Red 1, Green 1, Blue 1.
  - ⚠️ Please add 13-channel mode's Head #11 to the fixture's matrix. The included channels were Red 2, Green 2, Blue 2.
  - ⚠️ Please add 13-channel mode's Head #12 to the fixture's matrix. The included channels were Red 2, Green 2, Blue 2.
  - ⚠️ Please add 13-channel mode's Head #13 to the fixture's matrix. The included channels were Red 3, Green 3, Blue 3.
  - ⚠️ Please add 13-channel mode's Head #14 to the fixture's matrix. The included channels were Red 3, Green 3, Blue 3.
  - ⚠️ Please add 13-channel mode's Head #15 to the fixture's matrix. The included channels were Red 4, Green 4, Blue 4.
  - ⚠️ Please add 13-channel mode's Head #16 to the fixture's matrix. The included channels were Red 4, Green 4, Blue 4.


Thank you **fintch** and **Anony**!