### PR TITLE
Add fixture `shenzhen-liangguang-jingze/8-eye-strip-lamp`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -441,6 +441,9 @@
     "name": "Shehds",
     "website": "https://shehds.com/"
   },
+  "shenzhen-liangguang-jingze": {
+    "name": "Shenzhen Liangguang Jingze"
+  },
   "showline": {
     "name": "Showline",
     "website": "https://www.vari-lite.com/global",

--- a/fixtures/shenzhen-liangguang-jingze/8-eye-strip-lamp.json
+++ b/fixtures/shenzhen-liangguang-jingze/8-eye-strip-lamp.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "8 Eye Strip Lamp",
+  "shortName": "Long Strip",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["Tchoupi"],
+    "createDate": "2025-05-28",
+    "lastModifyDate": "2025-05-28"
+  },
+  "links": {
+    "manual": [
+      "https://cdn.shopify.com/s/files/1/0084/5230/9047/files/BETOPPER_Moving_Head_Stage_Led_Light_LM70_LM70S_Standard_User_Manual.pdf?v=1679586525"
+    ]
+  },
+  "physical": {
+    "dimensions": [420, 100, 80],
+    "weight": 0.55,
+    "power": 100,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe Speed": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [6, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Ch7": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 50],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [51, 90],
+          "type": "ColorPreset"
+        },
+        {
+          "dmxRange": [91, 130],
+          "type": "StrobeSpeed",
+          "speed": "slow",
+          "comment": "A2"
+        },
+        {
+          "dmxRange": [131, 170],
+          "type": "StrobeSpeed",
+          "speed": "slow",
+          "comment": "A3"
+        },
+        {
+          "dmxRange": [171, 210],
+          "type": "StrobeSpeed",
+          "speed": "slow",
+          "comment": "A4"
+        },
+        {
+          "dmxRange": [211, 255],
+          "type": "SoundSensitivity",
+          "soundSensitivity": "low"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "7Ch",
+      "shortName": "7Ch",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe Speed",
+        "Ch7"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `shenzhen-liangguang-jingze/8-eye-strip-lamp`

### Fixture warnings / errors

* shenzhen-liangguang-jingze/8-eye-strip-lamp
  - ❌ Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - ⚠️ Mode '7Ch' should have shortName '7ch' instead of '7Ch'.
  - ⚠️ Mode '7Ch' should have shortName '7ch' instead of '7Ch'.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Tchoupi**!