### PR TITLE
Add fixture `stairville/par-56-led-cob-rgbw-4in1`

### DIFF
--- a/fixtures/stairville/par-56-led-cob-rgbw-4in1.json
+++ b/fixtures/stairville/par-56-led-cob-rgbw-4in1.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "PAR 56 LED COB RGBW 4in1",
+  "categories": ["Color Changer", "Dimmer", "Effect", "Strobe"],
+  "meta": {
+    "authors": ["Simon PROUVEZE"],
+    "createDate": "2025-06-04",
+    "lastModifyDate": "2025-06-04"
+  },
+  "comment": "Stairville PAR LED COB 56",
+  "links": {
+    "manual": [
+      "https://images.thomann.de/pics/atg/atgdata/document/manual/c_333906_334993_334994_334995_375066_375060_375059_375061_v2_r7_fr_online.pdf"
+    ],
+    "productPage": [
+      "https://images.thomann.de/pics/atg/atgdata/document/manual/c_333906_334993_334994_334995_375066_375060_375059_375061_v2_r7_fr_online.pdf"
+    ],
+    "video": [
+      "https://images.thomann.de/pics/atg/atgdata/document/manual/c_333906_334993_334994_334995_375066_375060_375059_375061_v2_r7_fr_online.pdf"
+    ]
+  },
+  "physical": {
+    "bulb": {
+      "type": "LED COB 4-1"
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "MOTIF COLOR DEFINI": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "Effect",
+          "effectName": "Motif Color DEF"
+        }
+      ]
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Function mode": {
+      "capability": {
+        "type": "Effect",
+        "effectName": "Function mode"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8ch",
+      "shortName": "8ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "MOTIF COLOR DEFINI",
+        "Strobe",
+        "Function mode",
+        "Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `stairville/par-56-led-cob-rgbw-4in1`

### Fixture warnings / errors

* stairville/par-56-led-cob-rgbw-4in1
  - ❌ Capability 'Strobe speed slow…fast' (16…255) in channel 'Strobe': StrobeSpeed can't be used in the same channel as ShutterStrobe. Should this rather be a ShutterStrobe capability with shutterEffect "Strobe"?


Thank you @Simzinho!