### PR TITLE
Add fixture `fos/arena-haze-ip65`

### DIFF
--- a/fixtures/fos/arena-haze-ip65.json
+++ b/fixtures/fos/arena-haze-ip65.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Arena Haze IP65",
+  "categories": ["Hazer"],
+  "meta": {
+    "authors": ["anonym"],
+    "createDate": "2025-06-06",
+    "lastModifyDate": "2025-06-06"
+  },
+  "links": {
+    "other": [
+      "https://open-fixture-library.org/fixture-editor"
+    ]
+  },
+  "availableChannels": {
+    "Fan": {
+      "capability": {
+        "type": "Fog",
+        "fogType": "Haze",
+        "fogOutputStart": "off",
+        "fogOutputEnd": "strong"
+      }
+    },
+    "Fog Output": {
+      "capability": {
+        "type": "FogOutput",
+        "fogOutputStart": "weak",
+        "fogOutputEnd": "strong"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "2 Channels",
+      "channels": [
+        "Fan",
+        "Fog Output"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -197,6 +197,9 @@
     "name": "Flash Professional",
     "website": "https://flash-butrym.pl/en_US/c/Professional-Series/91"
   },
+  "fos": {
+    "name": "FOS"
+  },
   "fovitec": {
     "name": "Fovitec",
     "website": "https://web.archive.org/web/20240324222208/https://www.fovitec.com/"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `fos/arena-haze-ip65`

### Fixture warnings / errors

* fos/arena-haze-ip65
  - ⚠️ Mode '2 Channels' should have shortName '2ch' instead of '2 Channels'.
  - ⚠️ Mode '2 Channels' should have shortName '2ch' instead of '2 Channels'.


Thank you **anonym**!