### PR TITLE
Add fixture `varytec/hero-spot-wash-140`

### DIFF
--- a/fixtures/varytec/hero-spot-wash-140.json
+++ b/fixtures/varytec/hero-spot-wash-140.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Hero Spot Wash 140",
+  "shortName": "Hero Spot Wash 140",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Thomas"],
+    "createDate": "2025-06-08",
+    "lastModifyDate": "2025-06-08"
+  },
+  "links": {
+    "video": [
+      "https://www.youtube.com/watch?v=JHutwYiPmbs"
+    ]
+  },
+  "availableChannels": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0%",
+        "angleEnd": "100%"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "16 channel",
+      "channels": [
+        "Pan",
+        "Pan fine"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `varytec/hero-spot-wash-140`

### Fixture warnings / errors

* varytec/hero-spot-wash-140
  - ❌ Mode '16 channel' should have 16 channels according to its name but actually has 2.
  - ❌ Mode '16 channel' should have 16 channels according to its shortName but actually has 2.
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.
  - ⚠️ Capability 'Pan angle 0…100%' (0…65535) in channel 'Pan' defines an imprecise percentaged angle. Please to try find the value in degrees.
  - ⚠️ Mode '16 channel' should have shortName '16ch' instead of '16 channel'.
  - ⚠️ Mode '16 channel' should have shortName '16ch' instead of '16 channel'.


Thank you **Thomas**!