### PR TITLE
Fix broken links

### DIFF
--- a/fixtures/aputure/ls-1200d-pro.json
+++ b/fixtures/aputure/ls-1200d-pro.json
@@ -9,10 +9,10 @@
   },
   "links": {
     "manual": [
-      "https://www.aputure.com/wp-content/uploads/2022/06/LS1200D-Pro-DMX-Profile-Specification-V1.0-.pdf"
+      "https://aputure.com/wp-content/uploads/2022/06/LS1200D-Pro-DMX-Profile-Specification-V1.0-.pdf"
     ],
     "productPage": [
-      "https://www.aputure.com/products/ls-1200d-pro/"
+      "https://aputure.com/products/ls-1200d-pro/"
     ]
   },
   "physical": {

--- a/fixtures/aputure/ls-300x.json
+++ b/fixtures/aputure/ls-300x.json
@@ -9,13 +9,13 @@
   },
   "links": {
     "manual": [
-      "https://www.aputure.com/wp-content/uploads/2020/04/LS_300x-Product_Manual_EN.pdf"
+      "https://aputure.com/wp-content/uploads/2020/04/LS_300x-Product_Manual_EN.pdf"
     ],
     "productPage": [
-      "https://www.aputure.com/products/ls-300x/"
+      "https://aputure.com/products/ls-300x/"
     ],
     "other": [
-      "https://www.aputure.com/wp-content/uploads/2021/02/LS-300x-DMX-Table.xlsx"
+      "https://aputure.com/wp-content/uploads/2021/02/LS-300x-DMX-Table.xlsx"
     ]
   },
   "physical": {

--- a/fixtures/aputure/ls-600d-pro.json
+++ b/fixtures/aputure/ls-600d-pro.json
@@ -9,10 +9,10 @@
   },
   "links": {
     "manual": [
-      "https://www.aputure.com/wp-content/uploads/2022/06/LS-600d-Pro-DMX-Profile-Specification-V1.0-.pdf"
+      "https://aputure.com/wp-content/uploads/2022/06/LS-600d-Pro-DMX-Profile-Specification-V1.0-.pdf"
     ],
     "productPage": [
-      "https://www.aputure.com/products/ls-600d-pro/"
+      "https://aputure.com/products/ls-600d-pro/"
     ]
   },
   "physical": {

--- a/fixtures/aputure/ls-600d.json
+++ b/fixtures/aputure/ls-600d.json
@@ -9,10 +9,10 @@
   },
   "links": {
     "manual": [
-      "https://www.aputure.com/wp-content/uploads/2022/06/LS-600d-DMX-Profile-Specification-V1.0-.pdf"
+      "https://aputure.com/wp-content/uploads/2022/06/LS-600d-DMX-Profile-Specification-V1.0-.pdf"
     ],
     "productPage": [
-      "https://www.aputure.com/products/ls-600d/"
+      "https://aputure.com/products/ls-600d/"
     ]
   },
   "physical": {

--- a/fixtures/aputure/ls-600x-pro.json
+++ b/fixtures/aputure/ls-600x-pro.json
@@ -9,10 +9,10 @@
   },
   "links": {
     "manual": [
-      "https://www.aputure.com/wp-content/uploads/2022/06/LS600X-Pro-DMX-Profile-Specification-V1.0-.pdf"
+      "https://aputure.com/wp-content/uploads/2022/06/LS600X-Pro-DMX-Profile-Specification-V1.0-.pdf"
     ],
     "productPage": [
-      "https://www.aputure.com/products/ls-600x-pro/"
+      "https://aputure.com/products/ls-600x-pro/"
     ]
   },
   "physical": {

--- a/fixtures/aputure/nova-p300c.json
+++ b/fixtures/aputure/nova-p300c.json
@@ -9,16 +9,16 @@
   },
   "links": {
     "manual": [
-      "https://www.aputure.com/wp-content/uploads/2020/06/Nova_P300c_Manual_20200722-EN.pdf"
+      "https://aputure.com/wp-content/uploads/2020/06/Nova_P300c_Manual_20200722-EN.pdf"
     ],
     "productPage": [
-      "https://www.aputure.com/products/nova-p300c/"
+      "https://aputure.com/products/nova-p300c/"
     ],
     "video": [
       "https://www.youtube.com/watch?v=qr-QiRpwijI"
     ],
     "other": [
-      "https://www.aputure.com/wp-content/uploads/2021/02/Nova-P300c-DMX-Table_2020-12-09.xlsx"
+      "https://aputure.com/wp-content/uploads/2021/02/Nova-P300c-DMX-Table_2020-12-09.xlsx"
     ]
   },
   "physical": {

--- a/fixtures/event-lighting/par12x12.json
+++ b/fixtures/event-lighting/par12x12.json
@@ -12,7 +12,7 @@
       "https://cdn.shopify.com/s/files/1/0304/0549/files/PAR12_V2.1.pdf"
     ],
     "productPage": [
-      "https://event-lighting.com.au/products/par12x12"
+      "https://web.archive.org/web/20250426133413/https://eventlighting.com.au/products/par12x12"
     ],
     "video": [
       "https://www.youtube.com/watch?v=MbdnJqu0MiQ"

--- a/fixtures/event-lighting/par5x12.json
+++ b/fixtures/event-lighting/par5x12.json
@@ -12,7 +12,7 @@
       "https://cdn.shopify.com/s/files/1/0304/0549/files/PAR12_V2.1.pdf"
     ],
     "productPage": [
-      "https://event-lighting.com.au/products/par5x12"
+      "https://web.archive.org/web/20250218184018/https://event-lighting.com.au/products/par5x12"
     ],
     "video": [
       "https://www.youtube.com/watch?v=6dmSNkOVrCQ"

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -175,7 +175,7 @@
   },
   "event-lighting": {
     "name": "Event Lighting",
-    "website": "https://event-lighting.com.au/"
+    "website": "https://eventlighting.com.au/"
   },
   "evolight": {
     "name": "Evolight"

--- a/fixtures/showven/sparkular-fall.json
+++ b/fixtures/showven/sparkular-fall.json
@@ -9,7 +9,7 @@
   },
   "links": {
     "manual": [
-      "http://www.vlammen.com/sparkular/Sparkular%20fall.pdf"
+      "https://www.vlammen.com/sparkular/Sparkular%20fall.pdf"
     ],
     "productPage": [
       "https://www.sparkular-fx.com/index.php/en/unkategorisiert/sparkular/sparkular-fall-bt04-2"

--- a/fixtures/showven/sparkular.json
+++ b/fixtures/showven/sparkular.json
@@ -10,7 +10,7 @@
   },
   "links": {
     "manual": [
-      "http://www.vlammen.com/sparkular/Sparkular%20Manual.pdf"
+      "https://www.vlammen.com/sparkular/Sparkular%20Manual.pdf"
     ],
     "productPage": [
       "https://www.sparkular-fx.com/index.php/en/unkategorisiert/sparkular/sparkular-2"

--- a/fixtures/solaris/smart-36.json
+++ b/fixtures/solaris/smart-36.json
@@ -7,11 +7,6 @@
     "createDate": "2018-10-25",
     "lastModifyDate": "2018-10-25"
   },
-  "links": {
-    "manual": [
-      "https://docplayer.net/211549995-Safety-information-table-of-contents-solaris-smart-solaris-smart36-warning.html"
-    ]
-  },
   "physical": {
     "dimensions": [118, 237, 230],
     "weight": 3,

--- a/fixtures/tmb/solaris-flare.json
+++ b/fixtures/tmb/solaris-flare.json
@@ -10,7 +10,9 @@
   },
   "comment": "Flares with serial numbers that contain “14R” have RDM functionality.\nExample: xxxxxx-14R-xxxx",
   "links": {
-    "manual": ["http://pub.tmb.com/solaris/pdf/Solaris-Flare-Manual.pdf"],
+    "manual": [
+      "https://web.archive.org/web/20190219222320/http://pub.tmb.com/solaris/pdf/Solaris-Flare-Manual.pdf"
+    ],
     "video": [
       "https://www.youtube.com/watch?v=qTn9OWkmF9Y",
       "https://www.youtube.com/watch?v=dUtpecqEQRA"


### PR DESCRIPTION
Found by #999 

- http://www.vlammen.com now redirects to https.
- http://docplayer.net/ now redirects to some crypto site. It's not been archived so I've removed the link.
- Replaced http://pub.tmb.com/solaris/pdf/Solaris-Flare-Manual.pdf with archived version as the domain no longer exists.
- Updated [event-lighting.com.au](https://event-lighting.com.au/) to [https://eventlighting.com.au/](https://eventlighting.com.au/)
- Replaced discontinued event-lighting.com.au fixture manuals with archived links. The manuals for the discontinued products no longer appear to be on their website.
- https://www.aputure.com/ seem to have updated their site and dropped the `www.`. Unfortunately, many of the manual links now seem to be broken.
- Update various https://www.arri.com links to their redirects