### PR TITLE
Add fixture `sdj/smart-spot-plus`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -432,6 +432,9 @@
     "name": "Rockville",
     "website": "https://www.rockvilleaudio.com/"
   },
+  "sdj": {
+    "name": "SDJ"
+  },
   "sgm": {
     "name": "SGM",
     "website": "https://sgmlight.com/",

--- a/fixtures/sdj/smart-spot-plus.json
+++ b/fixtures/sdj/smart-spot-plus.json
@@ -1,0 +1,410 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Smart Spot Plus",
+  "shortName": "Moving Head",
+  "categories": ["Other"],
+  "meta": {
+    "authors": ["Sam782"],
+    "createDate": "2023-09-13",
+    "lastModifyDate": "2025-06-17",
+    "importPlugin": {
+      "plugin": "gdtf",
+      "date": "2025-07-02",
+      "comment": "GDTF v1.2 fixture type ID: 734DB54B-B498-46FC-ACC7-4F7FAB5224F7"
+    }
+  },
+  "comment": "SG SMTSPOTPLUS",
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        {
+          "type": "Color",
+          "name": "White",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Red",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Green",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Blue",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Yellow",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Orange",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Magenta",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Cyan",
+          "colors": ["#e4e4e4"]
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Color",
+          "name": "Gobo 1",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Gobo 2",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Gobo 3",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Gobo 4",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Gobo 5",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Gobo 6",
+          "colors": ["#e4e4e4"]
+        },
+        {
+          "type": "Color",
+          "name": "Gobo 7",
+          "colors": ["#e4e4e4"]
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "P": {
+      "fineChannelAliases": ["P fine"],
+      "capabilities": [
+        {
+          "dmxRange": [0, 32767],
+          "type": "Pan",
+          "angleStart": "0deg",
+          "angleEnd": "1deg"
+        },
+        {
+          "dmxRange": [32768, 32768],
+          "type": "Pan",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Home"
+        },
+        {
+          "dmxRange": [32769, 65535],
+          "type": "Pan",
+          "angleStart": "0deg",
+          "angleEnd": "1deg"
+        }
+      ]
+    },
+    "T": {
+      "fineChannelAliases": ["T fine"],
+      "capabilities": [
+        {
+          "dmxRange": [0, 32767],
+          "type": "Tilt",
+          "angleStart": "0deg",
+          "angleEnd": "1deg"
+        },
+        {
+          "dmxRange": [32768, 32768],
+          "type": "Tilt",
+          "angleStart": "0deg",
+          "angleEnd": "1deg",
+          "comment": "Home"
+        },
+        {
+          "dmxRange": [32769, 65535],
+          "type": "Tilt",
+          "angleStart": "0deg",
+          "angleEnd": "1deg"
+        }
+      ]
+    },
+    "Pos FX Rate": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": 0,
+        "speedEnd": 1
+      }
+    },
+    "C1": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 1,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [11, 21],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [22, 32],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [33, 43],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [44, 54],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [55, 65],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [66, 76],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [77, 87],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [88, 175],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 8,
+          "comment": "Continuous positioning of colors"
+        },
+        {
+          "dmxRange": [176, 255],
+          "type": "WheelSlot",
+          "wheel": "Color Wheel",
+          "slotNumber": 8,
+          "comment": "Rainbow from slow to fast"
+        }
+      ]
+    },
+    "G1": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [16, 31],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [32, 46],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [47, 62],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [63, 78],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [79, 93],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [94, 109],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [110, 124],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [125, 140],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 8,
+          "comment": "Shacking gobo 7 from slow to fast"
+        },
+        {
+          "dmxRange": [141, 156],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 7,
+          "comment": "Shacking gobo 6 from slow to fast"
+        },
+        {
+          "dmxRange": [157, 171],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 6,
+          "comment": "Shacking gobo 5 from slow to fast"
+        },
+        {
+          "dmxRange": [172, 187],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 5,
+          "comment": "Shacking gobo 4 from slow to fast"
+        },
+        {
+          "dmxRange": [188, 203],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 4,
+          "comment": "Shacking gobo 3 from slow to fast Channel Set"
+        },
+        {
+          "dmxRange": [204, 218],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 3,
+          "comment": "Shacking gobo 2 from slow to fast"
+        },
+        {
+          "dmxRange": [219, 234],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 2,
+          "comment": "Shacking gobo 1 from slow to fast"
+        },
+        {
+          "dmxRange": [235, 249],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 1,
+          "comment": "Shacking open from slow to fast"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "WheelSlot",
+          "wheel": "Gobo Wheel",
+          "slotNumber": 1,
+          "comment": "Rainbow from slow to fast"
+        }
+      ]
+    },
+    "Dim": {
+      "highlightValue": 255,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "Intensity",
+          "brightnessStart": 0,
+          "brightnessEnd": 1,
+          "comment": "Closed"
+        },
+        {
+          "dmxRange": [1, 254],
+          "type": "Intensity",
+          "brightnessStart": 0,
+          "brightnessEnd": 1
+        },
+        {
+          "dmxRange": [255, 255],
+          "type": "Intensity",
+          "brightnessStart": 0,
+          "brightnessEnd": 1,
+          "comment": "Open"
+        }
+      ]
+    },
+    "StrobeM Shutter": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "Unknown (StrobeModeShutter)",
+          "physicalStart": 0,
+          "physicalEnd": 1,
+          "comment": "Open"
+        },
+        {
+          "dmxRange": [10, 249],
+          "type": "Unknown (StrobeModeShutter)",
+          "physicalStart": 0,
+          "physicalEnd": 1,
+          "comment": "Strobe Slow Fast"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "Unknown (StrobeModeShutter)",
+          "physicalStart": 0,
+          "physicalEnd": 1,
+          "comment": "Open"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "Mode 1",
+      "channels": [
+        "P",
+        "P fine",
+        "T",
+        "T fine",
+        "Pos FX Rate",
+        "C1",
+        "G1",
+        "Dim",
+        "StrobeM Shutter"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `sdj/smart-spot-plus`

### Fixture warnings / errors

* sdj/smart-spot-plus
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedStart 0 must be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedStart 0 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedEnd 1 must be equal to one of [fast, slow, stop, slow reverse, fast reverse]
  - ❌ File does not match schema: fixture/availableChannels/Pos FX Rate/capability/speedEnd 1 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/0/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/0/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/0/brightnessStart 0 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/0/brightnessStart 0 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/0/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/0/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/0/brightnessEnd 1 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/0/brightnessEnd 1 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/1/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/1/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/1/brightnessStart 0 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/1/brightnessStart 0 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/1/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/1/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/1/brightnessEnd 1 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/1/brightnessEnd 1 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/2/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/2/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/2/brightnessStart 0 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/2/brightnessStart 0 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/2/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/2/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/2/brightnessEnd 1 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capabilities/2/brightnessEnd 1 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Shutter/capabilities/0 (type: Unknown (StrobeModeShutter)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Shutter/capabilities/1 (type: Unknown (StrobeModeShutter)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Shutter/capabilities/2 (type: Unknown (StrobeModeShutter)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/modes/0/name "Mode 1" must match pattern "^((?!mode)(?!Mode).)*$"
  - ⚠️ Please add manufacturer URL.
  - ⚠️ Please add fixture categories.
  - ⚠️ Please add relevant links to the fixture.
  - ⚠️ Please add physical data to the fixture.


Thank you **Sam782**!