### PR TITLE
Add fixture `macmah/silent-par-12x10w`

### DIFF
--- a/fixtures/macmah/silent-par-12x10w.json
+++ b/fixtures/macmah/silent-par-12x10w.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "SILENT PAR 12x10W",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["MAC MAH SILENTPAR 12X10"],
+    "createDate": "2025-07-09",
+    "lastModifyDate": "2025-07-09"
+  },
+  "links": {
+    "manual": [
+      "https://static.sonovente.com/pdf/manual/78/78578_silentpar12x10w6in12021.pdf"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    },
+    "UV": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "STROBE": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "MODE": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "MODE 2": {
+      "name": "MODE",
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "10CH",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV",
+        "STROBE",
+        "MODE",
+        "MODE 2"
+      ]
+    },
+    {
+      "name": "6CH",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -350,6 +350,9 @@
     "name": "Lupo",
     "website": "https://www.lupo.it/en/"
   },
+  "macmah": {
+    "name": "MACMAH"
+  },
   "magicfx": {
     "name": "MagicFX",
     "website": "https://www.magicfx.eu/",


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `macmah/silent-par-12x10w`

### Fixture warnings / errors

* macmah/silent-par-12x10w
  - ⚠️ Mode '10CH' should have shortName '10ch' instead of '10CH'.
  - ⚠️ Mode '10CH' should have shortName '10ch' instead of '10CH'.
  - ⚠️ Mode '6CH' should have shortName '6ch' instead of '6CH'.
  - ⚠️ Mode '6CH' should have shortName '6ch' instead of '6CH'.


Thank you **MAC MAH SILENTPAR 12X10**!