### PR TITLE
Add fixture `generic/mini-beam-280-moving-heads`

### DIFF
--- a/fixtures/generic/mini-beam-280-moving-heads.json
+++ b/fixtures/generic/mini-beam-280-moving-heads.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Mini Beam 280 Moving Heads",
+  "shortName": "Mini 280W",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["LP"],
+    "createDate": "2025-07-17",
+    "lastModifyDate": "2025-07-17"
+  },
+  "links": {
+    "video": [
+      "https://www.youtube.com/shorts/HM2qfONx6wk"
+    ]
+  },
+  "physical": {
+    "dimensions": [300, 300, 500],
+    "weight": 10,
+    "power": 280,
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "20 Channels",
+      "shortName": "20CH",
+      "channels": [
+        "Dimmer"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `generic/mini-beam-280-moving-heads`

### Fixture warnings / errors

* generic/mini-beam-280-moving-heads
  - ❌ Mode '20 Channels' should have 20 channels according to its name but actually has 1.
  - ❌ Mode '20 Channels' should have 20 channels according to its shortName but actually has 1.
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.
  - ⚠️ Mode '20 Channels' should have shortName '20ch' instead of '20CH'.
  - ⚠️ Mode '20 Channels' should have shortName '20ch' instead of '20CH'.


Thank you **LP**!