### PR TITLE
Add fixture `wisdom/ledspot200w`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -550,5 +550,9 @@
     "name": "Venue",
     "comment": "Venue by Proline",
     "website": "https://venuelightingeffects.com/"
+  },
+  "wisdom": {
+    "name": "Wisdom",
+    "website": "https://www.wisdomb2b.it/stage-lightings-c-31.html?osComm=ms1narhmr3f5lsambshfdhlk01"
   }
 }

--- a/fixtures/wisdom/ledspot200w.json
+++ b/fixtures/wisdom/ledspot200w.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Ledspot200W",
+  "shortName": "ledspot200w",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["anon test"],
+    "createDate": "2025-08-06",
+    "lastModifyDate": "2025-08-06"
+  },
+  "links": {
+    "productPage": [
+      "https://www.ledleditalia.it/p/testa-mobile-motorizzata-spot-beam-led-cob-200w-in-flight-case-baule-da-2-pezzi-wisdom/"
+    ]
+  },
+  "physical": {
+    "dimensions": [48, 36, 38],
+    "weight": 15,
+    "power": 200,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "colorTemperature": 9700,
+      "lumens": 3200
+    },
+    "lens": {
+      "name": "BeamSpot",
+      "degreesMinMax": [7, 25]
+    }
+  },
+  "wheels": {
+    "Ruota Gobo": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        }
+      ]
+    },
+    "Rotazione della ruota Gobo": {
+      "slots": [
+        {
+          "type": "Open"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobo": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "10Hz",
+        "speedEnd": "50Hz"
+      }
+    },
+    "Rosso": {
+      "capability": {
+        "type": "WheelRotation",
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Verde": {
+      "capability": {
+        "type": "WheelRotation",
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Blu": {
+      "capability": {
+        "type": "WheelRotation",
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Bianco freddo": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Messa a fuoco": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Ruota Gobo": {
+      "capability": {
+        "type": "WheelSlot",
+        "slotNumber": 8
+      }
+    },
+    "Rotazione della ruota Gobo": {
+      "capability": {
+        "type": "WheelSlotRotation",
+        "slotNumber": 6,
+        "speedStart": "slow CW",
+        "speedEnd": "fast CW"
+      }
+    },
+    "Zoom": {
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "narrow",
+        "angleEnd": "wide"
+      }
+    },
+    "Prism": {
+      "capability": {
+        "type": "Prism"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "16CH",
+      "shortName": "Ledspot200W",
+      "channels": [
+        "Dimmer",
+        "Strobo",
+        "Rosso",
+        "Verde",
+        "Blu",
+        "Bianco freddo",
+        "Messa a fuoco",
+        "Pan",
+        "Tilt",
+        "Ruota Gobo",
+        "Rotazione della ruota Gobo",
+        "Zoom",
+        "Prism"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `wisdom/ledspot200w`

### Fixture warnings / errors

* wisdom/ledspot200w
  - ❌ Capability 'Wheel rotation CW slow…fast' (0…255) in channel 'Rosso' does not explicitly reference any wheel, but the default wheel 'Rosso' (through the channel name) does not exist.
  - ❌ Capability 'Wheel rotation CW slow…fast' (0…255) in channel 'Verde' does not explicitly reference any wheel, but the default wheel 'Verde' (through the channel name) does not exist.
  - ❌ Capability 'Wheel rotation CW slow…fast' (0…255) in channel 'Blu' does not explicitly reference any wheel, but the default wheel 'Blu' (through the channel name) does not exist.
  - ❌ Mode '16CH' should have 16 channels according to its name but actually has 13.
  - ⚠️ Name of wheel 'Ruota Gobo' does not contain the word 'wheel' or 'disk', which could lead to confusing capability names.
  - ⚠️ Name of wheel 'Rotazione della ruota Gobo' does not contain the word 'wheel' or 'disk', which could lead to confusing capability names.
  - ⚠️ Mode '16CH' should have shortName '16ch' instead of 'Ledspot200W'.
  - ⚠️ Unused wheel slot(s): Ruota Gobo (slot 1), Ruota Gobo (slot 2), Ruota Gobo (slot 3), Ruota Gobo (slot 4), Ruota Gobo (slot 5), Ruota Gobo (slot 6), Ruota Gobo (slot 7), Rotazione della ruota Gobo (slot 1), Rotazione della ruota Gobo (slot 2), Rotazione della ruota Gobo (slot 3), Rotazione della ruota Gobo (slot 4), Rotazione della ruota Gobo (slot 5)


Thank you **anon test**!