### PR TITLE
Add fixture `cameo/flat-pro-spotix-4`

### DIFF
--- a/fixtures/cameo/flat-pro-spotix-4.json
+++ b/fixtures/cameo/flat-pro-spotix-4.json
@@ -1,0 +1,465 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Flat Pro Spotix 4",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Julian Lenzenweger"],
+    "createDate": "2025-08-28",
+    "lastModifyDate": "2025-08-28",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2025-08-28",
+      "comment": "created by Q Light Controller Plus (version 4.13.1)"
+    }
+  },
+  "physical": {
+    "dimensions": [230, 230, 140],
+    "weight": 5.2,
+    "power": 150,
+    "DMXconnector": "3-pin and 5-pin",
+    "bulb": {
+      "type": "LED",
+      "lumens": 3800
+    },
+    "lens": {
+      "degreesMinMax": [30, 30]
+    }
+  },
+  "matrix": {
+    "pixelCount": [
+      null,
+      null,
+      1
+    ]
+  },
+  "availableChannels": {
+    "Master dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [6, 10],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [34, 56],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampUp",
+          "randomTiming": true,
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Ramp up Random"
+        },
+        {
+          "dmxRange": [57, 79],
+          "type": "ShutterStrobe",
+          "shutterEffect": "RampDown",
+          "randomTiming": true,
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Ramp down Random"
+        },
+        {
+          "dmxRange": [80, 102],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "randomTiming": true,
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Random Strobe Effect"
+        },
+        {
+          "dmxRange": [103, 127],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "comment": "Strobe Break Effect.  5s...1s",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "helpWanted": "Are the automatically added speed values correct?"
+        },
+        {
+          "dmxRange": [128, 249],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0Hz",
+          "speedEnd": "20Hz",
+          "comment": "Strobe slow -> fast"
+        },
+        {
+          "dmxRange": [250, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red 1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 1": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red 2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 2": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Red 3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 3": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Colour Macro": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "WheelSlotRotation",
+          "wheel": "",
+          "speedStart": "fast CW",
+          "speedEnd": "slow CW",
+          "comment": "Colour off"
+        },
+        {
+          "dmxRange": [6, 13],
+          "type": "ColorPreset",
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [14, 21],
+          "type": "ColorPreset",
+          "comment": "Amber"
+        },
+        {
+          "dmxRange": [22, 29],
+          "type": "ColorPreset",
+          "comment": "Yellow warm"
+        },
+        {
+          "dmxRange": [30, 37],
+          "type": "ColorPreset",
+          "comment": "Yellow"
+        },
+        {
+          "dmxRange": [38, 45],
+          "type": "ColorPreset",
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [46, 53],
+          "type": "ColorPreset",
+          "comment": "Turquoise"
+        },
+        {
+          "dmxRange": [54, 61],
+          "type": "ColorPreset",
+          "comment": "Cyan"
+        },
+        {
+          "dmxRange": [62, 69],
+          "type": "ColorPreset",
+          "comment": "Blue"
+        },
+        {
+          "dmxRange": [70, 77],
+          "type": "ColorPreset",
+          "comment": "Lavender"
+        },
+        {
+          "dmxRange": [78, 85],
+          "type": "ColorPreset",
+          "comment": "Mauve"
+        },
+        {
+          "dmxRange": [86, 93],
+          "type": "ColorPreset",
+          "comment": "Magenta"
+        },
+        {
+          "dmxRange": [94, 101],
+          "type": "ColorPreset",
+          "comment": "Pink"
+        },
+        {
+          "dmxRange": [102, 109],
+          "type": "ColorPreset",
+          "comment": "Warm White"
+        },
+        {
+          "dmxRange": [110, 117],
+          "type": "ColorPreset",
+          "comment": "White"
+        },
+        {
+          "dmxRange": [118, 125],
+          "type": "ColorPreset",
+          "comment": "Cold White"
+        },
+        {
+          "dmxRange": [126, 128],
+          "type": "ColorPreset",
+          "comment": "Colour Jumping Stop"
+        },
+        {
+          "dmxRange": [129, 192],
+          "type": "ColorPreset",
+          "comment": "Colour Jumping Speed slow -> Fast / Colour 1 -> 12"
+        },
+        {
+          "dmxRange": [193, 255],
+          "type": "ColorPreset",
+          "comment": "Colour Fading Speed slow -> Fast / Colour 1 -> 12"
+        }
+      ]
+    },
+    "Pattern": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "Effect",
+          "effectName": "Pattern off"
+        },
+        {
+          "dmxRange": [6, 31],
+          "type": "Effect",
+          "effectName": "Single spot rotating"
+        },
+        {
+          "dmxRange": [32, 63],
+          "type": "Effect",
+          "effectName": "Dual spot rotating (one Colour)"
+        },
+        {
+          "dmxRange": [64, 95],
+          "type": "Effect",
+          "effectName": "Dual spot rotating (two Colours)"
+        },
+        {
+          "dmxRange": [96, 127],
+          "type": "Effect",
+          "effectName": "Dual spots color change (two Colours)"
+        },
+        {
+          "dmxRange": [128, 159],
+          "type": "Effect",
+          "effectName": "Dual spots color step (two Colours)"
+        },
+        {
+          "dmxRange": [160, 191],
+          "type": "Effect",
+          "effectName": "Meteor effect"
+        },
+        {
+          "dmxRange": [192, 223],
+          "type": "Effect",
+          "effectName": "Rando dot effect"
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "Effect",
+          "effectName": "Colour blot effect"
+        }
+      ]
+    },
+    "Sound": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "Effect",
+          "effectName": "Sound Control OFF (Mic Sensitivity)",
+          "soundControlled": true
+        },
+        {
+          "dmxRange": [6, 255],
+          "type": "Effect",
+          "effectName": "Sound Control ON Low -> High (Mic Sensitivity)",
+          "soundControlled": true
+        }
+      ]
+    },
+    "Red 4": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green 4": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue 4": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Colour Temperature Correction (add to RGB and Colour Macro)": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 5],
+          "type": "ColorPreset",
+          "comment": "off"
+        },
+        {
+          "dmxRange": [6, 255],
+          "type": "ColorPreset",
+          "comment": "Cold to warm"
+        }
+      ]
+    }
+  },
+  "templateChannels": {},
+  "modes": [
+    {
+      "name": "2-channel",
+      "shortName": "2ch",
+      "channels": [
+        "Master dimmer",
+        "Colour Macro"
+      ]
+    },
+    {
+      "name": "3-channel 1",
+      "shortName": "3ch 1",
+      "channels": [
+        "Master dimmer",
+        "Strobe",
+        "Colour Macro"
+      ]
+    },
+    {
+      "name": "3-channel 2",
+      "shortName": "3ch 2",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    },
+    {
+      "name": "9-channel",
+      "shortName": "9ch",
+      "channels": [
+        "Master dimmer",
+        "Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "Colour Macro",
+        "Colour Temperature Correction (add to RGB and Colour Macro)",
+        "Pattern",
+        "Sound"
+      ]
+    },
+    {
+      "name": "18-channel",
+      "shortName": "18ch",
+      "channels": [
+        "Master dimmer",
+        "Strobe",
+        "Red 1",
+        "Green 1",
+        "Blue 1",
+        "Red 2",
+        "Green 2",
+        "Blue 2",
+        "Red 3",
+        "Green 3",
+        "Blue 3",
+        "Red 4",
+        "Green 4",
+        "Blue 4",
+        "Colour Macro",
+        "Colour Temperature Correction (add to RGB and Colour Macro)",
+        "Pattern",
+        "Sound"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `cameo/flat-pro-spotix-4`

### Fixture warnings / errors

* cameo/flat-pro-spotix-4
  - ❌ File does not match schema: fixture/matrix/pixelCount/0 -Infinity must be >= 1
  - ❌ File does not match schema: fixture/matrix/pixelCount/1 -Infinity must be >= 1
  - ❌ File does not match schema: fixture/availableChannels/Colour Macro/capabilities/0/wheel "" must match pattern "^[^\n]+$"
  - ❌ File does not match schema: fixture/availableChannels/Colour Macro/capabilities/0/wheel "" must be array
  - ❌ File does not match schema: fixture/availableChannels/Colour Macro/capabilities/0/wheel "" must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Colour Macro/capabilities/0 (type: WheelSlotRotation) must match "else" schema
  - ❌ File does not match schema: fixture/templateChannels must NOT have fewer than 1 properties
  - ⚠️ Please add 2-channel mode's Head #1 to the fixture's matrix. The included channels were Master dimmer, Colour Macro.
  - ⚠️ Please add 3-channel 1 mode's Head #1 to the fixture's matrix. The included channels were Master dimmer, Strobe, Colour Macro.
  - ⚠️ Please add 3-channel 2 mode's Head #1 to the fixture's matrix. The included channels were Red, Green, Blue.
  - ⚠️ Please add 9-channel mode's Head #1 to the fixture's matrix. The included channels were Master dimmer, Strobe, Red, Green, Blue, Colour Temperature Correction (add to RGB and Colour Macro), Colour Macro, Pattern, Sound.
  - ⚠️ Please add 18-channel mode's Head #1 to the fixture's matrix. The included channels were Master dimmer, Strobe, Red 1, Green 1, Blue 1, Green 2, Red 2, Red 3, Blue 2, Green 3, Blue 3, Green 4, Red 4, Colour Macro, Blue 4, Colour Temperature Correction (add to RGB and Colour Macro), Pattern, Sound.


Thank you @julian-lenz!