### PR TITLE
Add fixture `sheds/led-cob-200-w`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -437,6 +437,9 @@
     "website": "https://sgmlight.com/",
     "rdmId": 21319
   },
+  "sheds": {
+    "name": "Sheds"
+  },
   "shehds": {
     "name": "Shehds",
     "website": "https://shehds.com/"

--- a/fixtures/sheds/led-cob-200-w.json
+++ b/fixtures/sheds/led-cob-200-w.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Led COB 200 W",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["Christophe", "Christophe Mourey"],
+    "createDate": "2025-09-07",
+    "lastModifyDate": "2025-09-07",
+    "importPlugin": {
+      "plugin": "qlcplus_4.12.1",
+      "date": "2025-09-07",
+      "comment": "created by Q Light Controller Plus (version 4.14.3)"
+    }
+  },
+  "physical": {
+    "weight": 6,
+    "power": 200,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "colorTemperature": 5500,
+      "lumens": 5000
+    },
+    "lens": {
+      "name": "PC",
+      "degreesMinMax": [10, 60]
+    }
+  },
+  "availableChannels": {
+    "Cool White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Warm White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Zoom": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "wide",
+        "angleEnd": "narrow"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "3 canaux",
+      "channels": [
+        "Cool White",
+        "Warm White",
+        "Zoom"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `sheds/led-cob-200-w`

### Fixture warnings / errors

* sheds/led-cob-200-w
  - ❌ Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.
  - ⚠️ Please check if manufacturer is correct and add manufacturer URL.


### User comment

Projecteur LED bicolore 200W COB Zoom Éclairage Par Blanc chaud/froid

Thank you **Christophe** and **Christophe Mourey**!