### PR TITLE
Add fixture `flash-professional/led-par-64-18x10w-rgbw-4in1-alu`

### DIFF
--- a/fixtures/flash-professional/led-par-64-18x10w-rgbw-4in1-alu.json
+++ b/fixtures/flash-professional/led-par-64-18x10w-rgbw-4in1-alu.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED PAR 64 18x10W RGBW 4in1 ALU",
+  "categories": ["Pixel Bar"],
+  "meta": {
+    "authors": ["Fanda Marek"],
+    "createDate": "2025-10-11",
+    "lastModifyDate": "2025-10-11"
+  },
+  "links": {
+    "manual": [
+      "https://manuals.plus/flash/f7100332-led-par-64-18x10w-rgbw-manual#voltage_specification"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe Speed": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "1Hz",
+        "speedEnd": "10Hz"
+      }
+    },
+    "Sound Sensitivity": {
+      "capability": {
+        "type": "SoundSensitivity",
+        "soundSensitivityStart": "low",
+        "soundSensitivityEnd": "high"
+      }
+    },
+    "Color Presets": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8ch",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe Speed",
+        "Sound Sensitivity",
+        "Color Presets"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `flash-professional/led-par-64-18x10w-rgbw-4in1-alu`

### Fixture warnings / errors

* flash-professional/led-par-64-18x10w-rgbw-4in1-alu
  - ❌ Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Fanda Marek**!