### PR TITLE
Add fixture `shehds/jms-web-led-beam-wash-big-bees-eyes`

### DIFF
--- a/fixtures/shehds/jms-web-led-beam-wash-big-bees-eyes.json
+++ b/fixtures/shehds/jms-web-led-beam-wash-big-bees-eyes.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "JMS Web LED Beam+Wash Big Bees Eyes",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Carter C"],
+    "createDate": "2025-10-13",
+    "lastModifyDate": "2025-10-13"
+  },
+  "links": {
+    "manual": [
+      "https://drive.google.com/file/d/1bA-eYiSkikBe2W1tbenLx-Q5nNUaBgus/view?usp=drive_link"
+    ],
+    "productPage": [
+      "https://shehds.com/products/new-arrival-wash-big-bee-eye-19x20w-19x40w-rgbw-moving-head-light-for-night-dj-club-performance-stage?variant=42965249032245"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=1ayhlMJRVr8&list=TLGGz3mhvQT8gDMxMzEwMjAyNQ"
+    ]
+  },
+  "physical": {
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "205deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Zoom": {
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "narrow",
+        "angleEnd": "wide"
+      }
+    },
+    "Gobo Wheel Rotation": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 127],
+          "type": "WheelRotation",
+          "speedStart": "0%",
+          "speedEnd": "100%"
+        },
+        {
+          "dmxRange": [128, 191],
+          "type": "WheelRotation",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW"
+        },
+        {
+          "dmxRange": [192, 255],
+          "type": "WheelRotation",
+          "speedStart": "fast CCW",
+          "speedEnd": "slow CCW"
+        }
+      ]
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Shutter / Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 3],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        },
+        {
+          "dmxRange": [4, 200],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [201, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "randomTiming": true
+        }
+      ]
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Color Temperature": {
+      "capability": {
+        "type": "ColorTemperature",
+        "colorTemperatureStart": "warm",
+        "colorTemperatureEnd": "cold"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Static Effect": {
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Dynamic Effect": {
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Dynamic Effect 2": {
+      "name": "Dynamic Effect",
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Background Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Background Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Background Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Background White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Reset": {
+      "capability": {
+        "type": "Maintenance"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "23 Channel",
+      "shortName": "Basic",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Pan/Tilt Speed",
+        "Zoom",
+        "Gobo Wheel Rotation",
+        "Dimmer",
+        "Shutter / Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Color Temperature",
+        "Color Macros",
+        "Static Effect",
+        "Dynamic Effect",
+        "Dynamic Effect 2",
+        "Background Red",
+        "Background Green",
+        "Background Blue",
+        "Background White",
+        "Reset"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `shehds/jms-web-led-beam-wash-big-bees-eyes`

### Fixture warnings / errors

* shehds/jms-web-led-beam-wash-big-bees-eyes
  - ❌ Capability 'Wheel rotation speed 0…100%' (0…127) in channel 'Gobo Wheel Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel Rotation' (through the channel name) does not exist.
  - ❌ Capability 'Wheel rotation CW slow…fast' (128…191) in channel 'Gobo Wheel Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel Rotation' (through the channel name) does not exist.
  - ❌ Capability 'Wheel rotation CCW fast…slow' (192…255) in channel 'Gobo Wheel Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel Rotation' (through the channel name) does not exist.
  - ❌ Capability 'Strobe speed slow…fast' (4…200) in channel 'Shutter / Strobe': StrobeSpeed can't be used in the same channel as ShutterStrobe. Should this rather be a ShutterStrobe capability with shutterEffect "Strobe"?
  - ⚠️ Mode '23 Channel' should have shortName '23ch' instead of 'Basic'.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Carter C**!