### PR TITLE
Add fixture `american-dj/starship`

### DIFF
--- a/fixtures/american-dj/starship.json
+++ b/fixtures/american-dj/starship.json
@@ -1,0 +1,312 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Starship",
+  "categories": ["Effect"],
+  "meta": {
+    "authors": ["aztek musik"],
+    "createDate": "2025-10-24",
+    "lastModifyDate": "2025-10-24"
+  },
+  "comment": "Created by Aztek Musik",
+  "links": {
+    "manual": [
+      "https://www.adj.eu/mwdownloads/download/link/id/1278"
+    ],
+    "productPage": [
+      "https://www.youtube.com/watch?v=oNT35HafT3M"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=oNT35HafT3M"
+    ]
+  },
+  "physical": {
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Tilt 1": {
+      "fineChannelAliases": ["Tilt 1 fine"],
+      "defaultValue": 127,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "90deg"
+      }
+    },
+    "Tilt 2": {
+      "fineChannelAliases": ["Tilt 2 fine"],
+      "defaultValue": 127,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "90deg"
+      }
+    },
+    "Tilt 3": {
+      "fineChannelAliases": ["Tilt 3 fine"],
+      "defaultValue": 127,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "90deg"
+      }
+    },
+    "Tilt 4": {
+      "fineChannelAliases": ["Tilt 4 fine"],
+      "defaultValue": 127,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "90deg"
+      }
+    },
+    "Tilt 5": {
+      "fineChannelAliases": ["Tilt 5 fine"],
+      "defaultValue": 127,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "90deg"
+      }
+    },
+    "Tilt 6": {
+      "fineChannelAliases": ["Tilt 6 fine"],
+      "defaultValue": 127,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "90deg"
+      }
+    },
+    "Tilt 7": {
+      "fineChannelAliases": ["Tilt 7 fine"],
+      "defaultValue": 127,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "90deg"
+      }
+    },
+    "Tilt 8": {
+      "fineChannelAliases": ["Tilt 8 fine"],
+      "defaultValue": 127,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "90deg"
+      }
+    },
+    "RED (ZONE 1)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "GREEN (ZONE 1)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "BLUE (ZONE 1)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "WHITE (ZONE 1)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "RED (ZONE 2)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "GREEN (ZONE 2)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "BLUE (ZONE 2)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "WHITE (ZONE 2)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "RED (ZONE 3)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "GREEN (ZONE 3)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "BLUE (ZONE 3)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "WHITE (ZONE 3)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "RED (ZONE 4)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "GREEN (ZONE 4)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "BLUE (ZONE 4)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "WHITE (ZONE 4)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "RED (ZONE 5)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "GREEN (ZONE 5)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "BLUE (ZONE 5)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "WHITE (ZONE 5)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "RED (ZONE 6)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "GREEN (ZONE 6)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "BLUE (ZONE 6)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "WHITE (ZONE 6)": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "120ch DMX",
+      "channels": [
+        "Tilt 1",
+        "Tilt 1 fine",
+        "Tilt 2",
+        "Tilt 2 fine",
+        "Tilt 3",
+        "Tilt 3 fine",
+        "Tilt 4",
+        "Tilt 4 fine",
+        "Tilt 5",
+        "Tilt 5 fine",
+        "Tilt 6",
+        "Tilt 6 fine",
+        "RED (ZONE 1)",
+        "GREEN (ZONE 1)",
+        "BLUE (ZONE 1)",
+        "WHITE (ZONE 1)",
+        "RED (ZONE 2)",
+        "GREEN (ZONE 2)",
+        "BLUE (ZONE 2)",
+        "WHITE (ZONE 2)",
+        "RED (ZONE 3)",
+        "GREEN (ZONE 3)",
+        "BLUE (ZONE 3)",
+        "WHITE (ZONE 3)",
+        "RED (ZONE 4)",
+        "GREEN (ZONE 4)",
+        "BLUE (ZONE 4)",
+        "WHITE (ZONE 4)",
+        "RED (ZONE 5)",
+        "GREEN (ZONE 5)",
+        "BLUE (ZONE 5)",
+        "WHITE (ZONE 5)",
+        "RED (ZONE 6)",
+        "GREEN (ZONE 6)",
+        "BLUE (ZONE 6)",
+        "WHITE (ZONE 6)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `american-dj/starship`

### Fixture warnings / errors

* american-dj/starship
  - ❌ Mode '120ch DMX' should have 120 channels according to its name but actually has 36.
  - ❌ Mode '120ch DMX' should have 120 channels according to its shortName but actually has 36.
  - ⚠️ Unused channel(s): tilt 7, tilt 7 fine, tilt 8, tilt 8 fine
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **aztek musik**!