### PR TITLE
Add fixture `abstract/mini-beam-holdlamp`

### DIFF
--- a/fixtures/abstract/mini-beam-holdlamp.json
+++ b/fixtures/abstract/mini-beam-holdlamp.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "mini beam holdlamp",
+  "shortName": "mini beam",
+  "categories": ["Moving Head", "Color Changer"],
+  "meta": {
+    "authors": ["anonimo"],
+    "createDate": "2025-10-28",
+    "lastModifyDate": "2025-10-28"
+  },
+  "links": {
+    "productPage": [
+      "https://www.holdlamp.com/"
+    ]
+  },
+  "wheels": {
+    "Ruota dei colori": {
+      "slots": [
+        {
+          "type": "Color",
+          "name": "disk"
+        },
+        {
+          "type": "Color",
+          "name": "disk"
+        }
+      ]
+    },
+    "Ruota Gobo": {
+      "slots": [
+        {
+          "type": "Gobo",
+          "name": "ruota"
+        },
+        {
+          "type": "Gobo",
+          "name": "ruota"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Padella": {
+      "fineChannelAliases": ["Padella fine"],
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "255deg"
+      }
+    },
+    "Inclinare": {
+      "fineChannelAliases": ["Inclinare fine"],
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "180deg"
+      }
+    },
+    "Ruota dei colori": {
+      "capability": {
+        "type": "WheelSlot",
+        "slotNumber": 2
+      }
+    },
+    "Ruota Gobo": {
+      "capability": {
+        "type": "WheelSlot",
+        "slotNumber": 2,
+        "comment": "ruota"
+      }
+    },
+    "Strobo": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "0Hz",
+        "speedEnd": "255Hz"
+      }
+    },
+    "Intensità": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Iris": {
+      "capability": {
+        "type": "Iris",
+        "openPercentStart": "open",
+        "openPercentEnd": "closed"
+      }
+    },
+    "Prenotato": {
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Nessuna funzione": {
+      "capability": {
+        "type": "Maintenance"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "mod. 11ch",
+      "channels": [
+        "Padella",
+        "Padella fine",
+        "Inclinare",
+        "Inclinare fine",
+        "Ruota dei colori",
+        "Ruota Gobo",
+        "Strobo",
+        "Intensità",
+        "Iris",
+        "Prenotato",
+        "Nessuna funzione"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `abstract/mini-beam-holdlamp`

### Fixture warnings / errors

* abstract/mini-beam-holdlamp
  - ⚠️ Name of wheel 'Ruota dei colori' does not contain the word 'wheel' or 'disk', which could lead to confusing capability names.
  - ⚠️ Name of wheel 'Ruota Gobo' does not contain the word 'wheel' or 'disk', which could lead to confusing capability names.
  - ⚠️ Unused wheel slot(s): Ruota dei colori (slot 1), Ruota Gobo (slot 1)


Thank you **anonimo**!