### PR TITLE
Add fixture `flash-butrym/flash-19x15`

### DIFF
--- a/fixtures/flash-butrym/flash-19x15.json
+++ b/fixtures/flash-butrym/flash-19x15.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Flash 19x15",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Anyon"],
+    "createDate": "2025-11-20",
+    "lastModifyDate": "2025-11-20"
+  },
+  "links": {
+    "other": [
+      "https://open-fixture-library.org/fixture-editor"
+    ]
+  },
+  "availableChannels": {
+    "Ch1": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "16ch",
+      "shortName": "16ch",
+      "channels": [
+        "Ch1"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -193,6 +193,9 @@
     "website": "https://fiilex.com/",
     "rdmId": 24868
   },
+  "flash-butrym": {
+    "name": "Flash Butrym"
+  },
   "flash-professional": {
     "name": "Flash Professional",
     "website": "https://flash-butrym.pl/en_US/c/Professional-Series/91"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `flash-butrym/flash-19x15`

### Fixture warnings / errors

* flash-butrym/flash-19x15
  - ❌ Mode '16ch' should have 16 channels according to its name but actually has 1.
  - ❌ Mode '16ch' should have 16 channels according to its shortName but actually has 1.
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.


Thank you **Anyon**!