### PR TITLE
Add fixture `chroma-q/beam`

### DIFF
--- a/fixtures/chroma-q/beam.json
+++ b/fixtures/chroma-q/beam.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "beam",
+  "categories": ["Effect"],
+  "meta": {
+    "authors": ["abdurrahman"],
+    "createDate": "2025-11-23",
+    "lastModifyDate": "2025-11-23"
+  },
+  "links": {
+    "manual": [
+      "https://ultralightsound.co.uk/wp-content/uploads/2019/10/360W-MOVING-HEAD-WASH-MANUAL.pdf"
+    ]
+  },
+  "availableChannels": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "defaultValue": 255,
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "255deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "defaultValue": 255,
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "255deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "defaultValue": 255,
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Dimmer": {
+      "defaultValue": "100%",
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "defaultValue": 9,
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Strobe 2": {
+      "name": "Strobe",
+      "defaultValue": 255,
+      "capabilities": [
+        {
+          "dmxRange": [0, 9],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Closed"
+        },
+        {
+          "dmxRange": [10, 250],
+          "type": "StrobeSpeed",
+          "speedStart": "0Hz",
+          "speedEnd": "250Hz"
+        },
+        {
+          "dmxRange": [251, 254],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [255, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Open"
+        }
+      ]
+    },
+    "Red": {
+      "defaultValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Focus": {
+      "defaultValue": 255,
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "near",
+        "distanceEnd": "far"
+      }
+    },
+    "Color Temperature": {
+      "defaultValue": 255,
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "ColorTemperature",
+          "colorTemperatureStart": "default",
+          "colorTemperatureEnd": "default"
+        },
+        {
+          "dmxRange": [1, 255],
+          "type": "ColorTemperature",
+          "colorTemperatureStart": "1%",
+          "colorTemperatureEnd": "100%"
+        }
+      ]
+    },
+    "Color Macros": {
+      "defaultValue": 255,
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 20],
+          "type": "ColorIntensity",
+          "color": "Red"
+        },
+        {
+          "dmxRange": [21, 30],
+          "type": "ColorIntensity",
+          "color": "Green"
+        },
+        {
+          "dmxRange": [31, 40],
+          "type": "ColorIntensity",
+          "color": "Blue"
+        },
+        {
+          "dmxRange": [41, 50],
+          "type": "ColorIntensity",
+          "color": "White"
+        },
+        {
+          "dmxRange": [51, 60],
+          "type": "ColorIntensity",
+          "color": "Amber"
+        },
+        {
+          "dmxRange": [61, 70],
+          "type": "ColorIntensity",
+          "color": "Cyan"
+        },
+        {
+          "dmxRange": [71, 80],
+          "type": "ColorIntensity",
+          "color": "Magenta"
+        },
+        {
+          "dmxRange": [81, 90],
+          "type": "ColorIntensity",
+          "color": "Yellow"
+        },
+        {
+          "dmxRange": [91, 100],
+          "type": "ColorIntensity",
+          "color": "Warm White"
+        },
+        {
+          "dmxRange": [101, 110],
+          "type": "ColorIntensity",
+          "color": "UV"
+        },
+        {
+          "dmxRange": [111, 120],
+          "type": "ColorIntensity",
+          "color": "Lime"
+        },
+        {
+          "dmxRange": [121, 130],
+          "type": "ColorIntensity",
+          "color": "Indigo"
+        },
+        {
+          "dmxRange": [131, 140],
+          "type": "ColorIntensity",
+          "color": "White"
+        },
+        {
+          "dmxRange": [141, 150],
+          "type": "ColorIntensity",
+          "color": "Red"
+        },
+        {
+          "dmxRange": [151, 255],
+          "type": "EffectSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "beam360",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Pan/Tilt Speed",
+        "Dimmer",
+        "Strobe 2",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Focus",
+        "Color Temperature",
+        "Color Macros"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `chroma-q/beam`

### Fixture warnings / errors

* chroma-q/beam
  - ❌ Capability 'Strobe speed 0…250Hz' (10…250) in channel 'Strobe 2': StrobeSpeed can't be used in the same channel as ShutterStrobe. Should this rather be a ShutterStrobe capability with shutterEffect "Strobe"?
  - ⚠️ Unused channel(s): strobe
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.
  - ⚠️ Category 'Moving Head' suggested since there are pan and tilt channels.
  - ⚠️ Category 'Scanner' suggested since there are pan and tilt channels.
  - ⚠️ Category 'Barrel Scanner' suggested since there are pan and tilt channels.


Thank you **abdurrahman**!