### PR TITLE
Fix Blinder 4 pixel arrangement

### DIFF
--- a/fixtures/lightmaxx/led-blinder-4.json
+++ b/fixtures/lightmaxx/led-blinder-4.json
@@ -25,7 +25,12 @@
     }
   },
   "matrix": {
-    "pixelCount": [2, 2, 1]
+    "pixelKeys": [
+      [
+        ["1", "3"],
+        ["2", "4"]
+      ]
+    ]
   },
   "templateChannels": {
     "Intensity $pixelKey": {
@@ -103,14 +108,10 @@
         "Strobe",
         "Effect",
         "No function",
-        {
-          "insert": "matrixChannels",
-          "repeatFor": "eachPixelXYZ",
-          "channelOrder": "perPixel",
-          "templateChannels": [
-            "Intensity $pixelKey"
-          ]
-        }
+        "Intensity 1",
+        "Intensity 2",
+        "Intensity 3",
+        "Intensity 4"
       ]
     }
   ]


### PR DESCRIPTION
Follow-up to #3658. CC @Doralitze 

The order changed in [`dc0b990` (#3658)](https://github.com/OpenLightingProject/open-fixture-library/pull/3658/commits/dc0b990ee1a56250a30fcd7d5d59d34f495c95ba) and I didn't notice.

See https://open-fixture-library.org/lightmaxx/led-blinder-4:

<table>
<tr>
 <th>Before this PR
 <th>With this PR
<tr>
 <td><img width="357" height="686" alt="image" src="https://github.com/user-attachments/assets/095d7476-dde6-4fb9-afd8-19340981b0ca" />
 <td><img width="308" height="674" alt="image" src="https://github.com/user-attachments/assets/04ea335d-8e9b-4670-9718-a74e07adbfc6" />
</table>


