### PR TITLE
Add fixture `litecraft/washx-432-sw`

### DIFF
--- a/fixtures/litecraft/washx-432-sw.json
+++ b/fixtures/litecraft/washx-432-sw.json
@@ -49,13 +49,13 @@
     "Cold White": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "CoolWhite"
+        "color": "Cold White"
       }
     },
     "Warm White": {
       "capability": {
         "type": "ColorIntensity",
-        "color": "WarmWhite"
+        "color": "Warm White"
       }
     }
   },


### PR DESCRIPTION
* Add fixture `litecraft/washx-432-sw`

### Fixture warnings / errors

* litecraft/washx-432-sw
  - ❌ File does not match schema: fixture/physical/bulb/colorTemperature "invalid" must be number


Thank you @LimoDerEchte!