### PR TITLE
Add fixture `eurolite/led-tmh-b60-moving-head-beam`

### DIFF
--- a/fixtures/eurolite/led-tmh-b60-moving-head-beam.json
+++ b/fixtures/eurolite/led-tmh-b60-moving-head-beam.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED TMH-B60 Moving Head Beam",
+  "shortName": "TMH-B60",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Emmanuel Denoyer"],
+    "createDate": "2026-02-18",
+    "lastModifyDate": "2026-02-18"
+  },
+  "links": {
+    "manual": [
+      "https://www.steinigke.de/download/51786082-Instructions-141993-1.0000-eurolite-led-tmh-b60-moving-head-beam-de_en.pdf"
+    ],
+    "productPage": [
+      "https://www.steinigke.de/fr/mpn51786082-eurolite-led-tmh-b60-moving-head-beam.html"
+    ]
+  },
+  "physical": {
+    "dimensions": [175, 250, 150],
+    "weight": 3.25,
+    "power": 60,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "capability": {
+        "type": "Pan",
+        "angle": "540deg"
+      }
+    },
+    "Tilt": {
+      "capability": {
+        "type": "Tilt",
+        "angle": "180deg"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "fast",
+        "speedEnd": "stop"
+      }
+    },
+    "Dimmer": {
+      "defaultValue": "100%",
+      "highlightValue": "100%",
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 3],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [4, 95],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0Hz",
+          "speedEnd": "10Hz"
+        },
+        {
+          "dmxRange": [96, 176],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "0Hz",
+          "speedEnd": "10Hz",
+          "randomTiming": true,
+          "comment": "Random Strobe"
+        },
+        {
+          "dmxRange": [177, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Pulse",
+          "speedStart": "0Hz",
+          "speedEnd": "10Hz",
+          "comment": "Pulse"
+        }
+      ]
+    },
+    "Red": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "defaultValue": "0%",
+      "highlightValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Internal Programs": {
+      "defaultValue": "0%",
+      "highlightValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [16, 128],
+          "type": "Effect",
+          "effectName": "Automatic"
+        },
+        {
+          "dmxRange": [129, 255],
+          "type": "Effect",
+          "effectName": "Automatic",
+          "soundControlled": true,
+          "comment": "Sound controlled"
+        }
+      ]
+    },
+    "Program Speed": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Motion macros": {
+      "defaultValue": 0,
+      "highlightValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 20],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [21, 100],
+          "type": "PanContinuous"
+        },
+        {
+          "dmxRange": [101, 200],
+          "type": "TiltContinuous"
+        },
+        {
+          "dmxRange": [201, 250],
+          "type": "PanTiltSpeed",
+          "speedStart": "fast",
+          "speedEnd": "slow"
+        },
+        {
+          "dmxRange": [251, 255],
+          "type": "Maintenance"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "12Channels",
+      "shortName": "12CH",
+      "channels": [
+        "Pan",
+        "Tilt",
+        "Pan/Tilt Speed",
+        "Dimmer",
+        "Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Internal Programs",
+        "Program Speed",
+        "Motion macros"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `eurolite/led-tmh-b60-moving-head-beam`

### Fixture warnings / errors

* eurolite/led-tmh-b60-moving-head-beam
  - ❌ File does not match schema: fixture/availableChannels/Motion macros/capabilities/1 (type: PanContinuous) must have required property 'speed'
  - ❌ File does not match schema: fixture/availableChannels/Motion macros/capabilities/1 (type: PanContinuous) must have required property 'speedStart'
  - ❌ File does not match schema: fixture/availableChannels/Motion macros/capabilities/1 (type: PanContinuous) must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Motion macros/capabilities/2 (type: TiltContinuous) must have required property 'speed'
  - ❌ File does not match schema: fixture/availableChannels/Motion macros/capabilities/2 (type: TiltContinuous) must have required property 'speedStart'
  - ❌ File does not match schema: fixture/availableChannels/Motion macros/capabilities/2 (type: TiltContinuous) must match exactly one schema in oneOf


Thank you **Emmanuel Denoyer**!