### PR TITLE
Add fixture `audibax/iowa-70`

### DIFF
--- a/fixtures/audibax/iowa-70.json
+++ b/fixtures/audibax/iowa-70.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Iowa 70",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["a"],
+    "createDate": "2026-02-23",
+    "lastModifyDate": "2026-02-23"
+  },
+  "links": {
+    "productPage": [
+      "https://audibax.com/es/producto/iowa-70-black-2/"
+    ]
+  },
+  "availableChannels": {
+    "Cyan": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "a",
+      "channels": [
+        "Cyan"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `audibax/iowa-70`

### Fixture warnings / errors

* audibax/iowa-70
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **a**!