### PR TITLE
Add fixture `ayra/flash-30-led-stroboscope`

### DIFF
--- a/fixtures/ayra/flash-30-led-stroboscope.json
+++ b/fixtures/ayra/flash-30-led-stroboscope.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Flash 30 LED stroboscope",
+  "shortName": "Flash 30 LED",
+  "categories": ["Other"],
+  "meta": {
+    "authors": ["Sijmen"],
+    "createDate": "2023-04-10",
+    "lastModifyDate": "2023-04-10",
+    "importPlugin": {
+      "plugin": "gdtf",
+      "date": "2026-02-23",
+      "comment": "GDTF v1.2 fixture type ID: 8F4E0E5A-F2CE-400A-AB93-D6AF7BD5244B"
+    }
+  },
+  "comment": "Ayra Flash 30 LED stroboscope",
+  "availableChannels": {
+    "Dim": {
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": 0,
+        "brightnessEnd": 1
+      }
+    },
+    "StrobeM Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "Unknown (StrobeModeStrobe)",
+          "physicalStart": 0,
+          "physicalEnd": 1,
+          "comment": "0%"
+        },
+        {
+          "dmxRange": [1, 63],
+          "type": "Unknown (StrobeModeStrobe)",
+          "physicalStart": 0,
+          "physicalEnd": 1
+        },
+        {
+          "dmxRange": [64, 64],
+          "type": "Unknown (StrobeModeStrobe)",
+          "physicalStart": 0,
+          "physicalEnd": 1,
+          "comment": "25%"
+        },
+        {
+          "dmxRange": [65, 127],
+          "type": "Unknown (StrobeModeStrobe)",
+          "physicalStart": 0,
+          "physicalEnd": 1
+        },
+        {
+          "dmxRange": [128, 128],
+          "type": "Unknown (StrobeModeStrobe)",
+          "physicalStart": 0,
+          "physicalEnd": 1,
+          "comment": "50%"
+        },
+        {
+          "dmxRange": [129, 191],
+          "type": "Unknown (StrobeModeStrobe)",
+          "physicalStart": 0,
+          "physicalEnd": 1
+        },
+        {
+          "dmxRange": [192, 192],
+          "type": "Unknown (StrobeModeStrobe)",
+          "physicalStart": 0,
+          "physicalEnd": 1,
+          "comment": "75%"
+        },
+        {
+          "dmxRange": [193, 254],
+          "type": "Unknown (StrobeModeStrobe)",
+          "physicalStart": 0,
+          "physicalEnd": 1
+        },
+        {
+          "dmxRange": [255, 255],
+          "type": "Unknown (StrobeModeStrobe)",
+          "physicalStart": 0,
+          "physicalEnd": 1,
+          "comment": "100%"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "2 Channel",
+      "channels": [
+        "Dim",
+        "StrobeM Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `ayra/flash-30-led-stroboscope`

### Fixture warnings / errors

* ayra/flash-30-led-stroboscope
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessStart 0 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessStart 0 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessEnd 1 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessEnd 1 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Strobe/capabilities/0 (type: Unknown (StrobeModeStrobe)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Strobe/capabilities/1 (type: Unknown (StrobeModeStrobe)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Strobe/capabilities/2 (type: Unknown (StrobeModeStrobe)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Strobe/capabilities/3 (type: Unknown (StrobeModeStrobe)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Strobe/capabilities/4 (type: Unknown (StrobeModeStrobe)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Strobe/capabilities/5 (type: Unknown (StrobeModeStrobe)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Strobe/capabilities/6 (type: Unknown (StrobeModeStrobe)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Strobe/capabilities/7 (type: Unknown (StrobeModeStrobe)) value of tag "type" must be in oneOf
  - ❌ File does not match schema: fixture/availableChannels/StrobeM Strobe/capabilities/8 (type: Unknown (StrobeModeStrobe)) value of tag "type" must be in oneOf
  - ⚠️ Please add fixture categories.
  - ⚠️ Please add relevant links to the fixture.
  - ⚠️ Please add physical data to the fixture.


Thank you **Sijmen**!