### PR TITLE
Use slim runners for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,7 @@ jobs:
         run: node tests/github/schema-version-reminder.js
   markdown-link-check:
     name: Markdown Links
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - name: Checkout


### PR DESCRIPTION
GitHub Actions offers slim runners which run in containers instead of VM's. It might be worth trying them out on the tests? They are limited to 15 mins so I'm not sure if they are suitable for the external link checker and lighthouse workflows.

https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/