### PR TITLE
Add fixture `big-dipper/lpc010`

### DIFF
--- a/fixtures/big-dipper/lpc010.json
+++ b/fixtures/big-dipper/lpc010.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LPC010",
+  "shortName": "LPC010",
+  "categories": ["Color Changer", "Dimmer", "Effect", "Strobe"],
+  "meta": {
+    "authors": ["ALEJANDRO MOREU"],
+    "createDate": "2026-03-03",
+    "lastModifyDate": "2026-03-03"
+  },
+  "comment": "54X4",
+  "links": {
+    "productPage": [
+      "https://superaudio.com.co/producto/lpc010-big-dipper/?srsltid=AfmBOoqngC6AKMf4iaKhzTDhrXluQRlUmxGBgp3uL7c9yNzB8j8d6s3o"
+    ]
+  },
+  "rdm": {
+    "modelId": 27
+  },
+  "physical": {
+    "lens": {
+      "degreesMinMax": [25, 25]
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Warm White": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Dimmer": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe Speed": {
+      "defaultValue": 0,
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "5Hz",
+        "speedEnd": "20Hz"
+      }
+    },
+    "Effect Duration": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "Intensity"
+        },
+        {
+          "dmxRange": [11, 50],
+          "type": "ColorTemperature",
+          "colorTemperatureStart": "2800K",
+          "colorTemperatureEnd": "8000K"
+        },
+        {
+          "dmxRange": [51, 100],
+          "type": "Effect",
+          "effectName": "COLOR OUTPUT",
+          "soundControlled": true,
+          "comment": "COLOR OUTPUT"
+        },
+        {
+          "dmxRange": [101, 150],
+          "type": "Effect",
+          "effectPreset": "ColorJump"
+        },
+        {
+          "dmxRange": [151, 200],
+          "type": "Effect",
+          "effectPreset": "ColorFade"
+        },
+        {
+          "dmxRange": [201, 250],
+          "type": "Effect",
+          "effectName": "PULSE TRANSFORM"
+        },
+        {
+          "dmxRange": [251, 255],
+          "type": "SoundSensitivity",
+          "soundSensitivityStart": "low",
+          "soundSensitivityEnd": "high"
+        }
+      ]
+    },
+    "CONTROL": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 10],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [11, 20],
+          "type": "Generic",
+          "comment": "LINEAR DIMMER"
+        },
+        {
+          "dmxRange": [21, 30],
+          "type": "Generic",
+          "comment": "SQUARE LAW DIMMER"
+        },
+        {
+          "dmxRange": [31, 40],
+          "type": "Generic",
+          "comment": "INVERSE SQUARE LAW DIMMER"
+        },
+        {
+          "dmxRange": [41, 50],
+          "type": "Generic",
+          "comment": "S-CURVE DIMMER"
+        },
+        {
+          "dmxRange": [51, 60],
+          "type": "Generic",
+          "comment": "FAN MODE1: AUTO"
+        },
+        {
+          "dmxRange": [61, 70],
+          "type": "Generic",
+          "comment": "FAN MODE2: STUDIO"
+        },
+        {
+          "dmxRange": [71, 80],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [81, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "4 CHANNEL A",
+      "shortName": "4CH",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Warm White"
+      ]
+    },
+    {
+      "name": "8 CHANNEL B",
+      "shortName": "8CH",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "Warm White",
+        "Strobe Speed",
+        "Effect Duration",
+        "CONTROL"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `big-dipper/lpc010`

### Fixture warnings / errors

* big-dipper/lpc010
  - ❌ Channel 'Strobe Speed' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.
  - ⚠️ Mode '4 CHANNEL A' should have shortName '4ch' instead of '4CH'.
  - ⚠️ Mode '8 CHANNEL B' should have shortName '8ch' instead of '8CH'.


Thank you **ALEJANDRO MOREU**!