### PR TITLE
Add fixture `beamz/slimpar45`

### DIFF
--- a/fixtures/beamz/slimpar45.json
+++ b/fixtures/beamz/slimpar45.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "SlimPar45",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["D Richards"],
+    "createDate": "2026-03-03",
+    "lastModifyDate": "2026-03-03"
+  },
+  "links": {
+    "manual": [
+      "https://www.beamzlighting.com/wp-content/uploads/2025/11/150.900-Slim-Par-35-manual-V2.0.pdf"
+    ],
+    "productPage": [
+      "https://www.beamzlighting.com/product/slimpar-35/"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=vx4FwcceaNo"
+    ]
+  },
+  "physical": {
+    "dimensions": [90, 180, 185],
+    "weight": 0.8,
+    "power": 3,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [19, 19]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "StrobeSpeed",
+          "speedStart": "stop",
+          "speedEnd": "stop"
+        },
+        {
+          "dmxRange": [1, 255],
+          "type": "StrobeSpeed",
+          "speedStart": "1Hz",
+          "speedEnd": "21Hz"
+        }
+      ]
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    },
+    "Sound Sensitivity": {
+      "capability": {
+        "type": "SoundSensitivity",
+        "soundSensitivityStart": "low",
+        "soundSensitivityEnd": "high"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "7ch",
+      "channels": [
+        "Dimmer",
+        "Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "Color Macros",
+        "Sound Sensitivity"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `beamz/slimpar45`

### Fixture warnings / errors

* beamz/slimpar45
  - ❌ Capability 'Strobe speed stop' (0…0) in channel 'Strobe' uses speedStart and speedEnd with equal values. Use the single property 'speed: "stop"' instead.


Thank you **D Richards**!