### PR TITLE
Add fixture `chauvet-dj/intimidator-375-irz`

### DIFF
--- a/fixtures/chauvet-dj/intimidator-375-irz.json
+++ b/fixtures/chauvet-dj/intimidator-375-irz.json
@@ -1,0 +1,554 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "intimidator 375 irz",
+  "shortName": "375IRZ",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["Joe Cee (AKA STEEEEEVE MAAAAADDON)"],
+    "createDate": "2026-04-07",
+    "lastModifyDate": "2026-04-07"
+  },
+  "links": {
+    "manual": [
+      "https://www.chauvetdj.com/wp-content/uploads/2017/07/Intimidator_Spot_375Z_IRC_UM_Rev7.pdf"
+    ]
+  },
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        {
+          "type": "Color",
+          "name": "White"
+        },
+        {
+          "type": "Color",
+          "name": "Orange"
+        },
+        {
+          "type": "Color",
+          "name": "Lime green"
+        },
+        {
+          "type": "Color",
+          "name": "Cyan"
+        },
+        {
+          "type": "Color",
+          "name": "Red"
+        },
+        {
+          "type": "Color",
+          "name": "Green"
+        },
+        {
+          "type": "Color",
+          "name": "Magenta"
+        },
+        {
+          "type": "Color",
+          "name": "Yellow"
+        },
+        {
+          "type": "Color",
+          "name": "White"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "slots": [
+        {
+          "type": "Gobo",
+          "name": "open"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo"
+        },
+        {
+          "type": "Gobo",
+          "name": "open"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Pan": {
+      "fineChannelAliases": ["Pan fine"],
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "540deg"
+      }
+    },
+    "Tilt": {
+      "fineChannelAliases": ["Tilt fine"],
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "0deg",
+        "angleEnd": "270deg"
+      }
+    },
+    "Color Wheel": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1,
+          "comment": "White"
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2,
+          "comment": "Orange"
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "WheelSlot",
+          "slotNumber": 3,
+          "comment": "Lime green"
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "WheelSlot",
+          "slotNumber": 4,
+          "comment": "Cyan"
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "WheelSlot",
+          "slotNumber": 5,
+          "comment": "Red"
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "WheelSlot",
+          "slotNumber": 6,
+          "comment": "Green"
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "WheelSlot",
+          "slotNumber": 7,
+          "comment": "Magenta"
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 8,
+          "comment": "Yellow"
+        },
+        {
+          "dmxRange": [64, 64],
+          "type": "WheelSlot",
+          "slotNumber": 9,
+          "comment": "White"
+        },
+        {
+          "dmxRange": [65, 189],
+          "type": "Effect",
+          "effectName": "Color indexing",
+          "comment": "Color indexing"
+        },
+        {
+          "dmxRange": [190, 221],
+          "type": "WheelRotation",
+          "speed": "fast CCW"
+        },
+        {
+          "dmxRange": [222, 223],
+          "type": "NoFunction",
+          "comment": "Stop"
+        },
+        {
+          "dmxRange": [224, 255],
+          "type": "WheelRotation",
+          "speed": "slow CCW"
+        }
+      ]
+    },
+    "Gobo Wheel": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 7],
+          "type": "WheelSlot",
+          "slotNumber": 1
+        },
+        {
+          "dmxRange": [8, 15],
+          "type": "WheelSlot",
+          "slotNumber": 2
+        },
+        {
+          "dmxRange": [16, 23],
+          "type": "WheelSlot",
+          "slotNumber": 3
+        },
+        {
+          "dmxRange": [24, 31],
+          "type": "WheelSlot",
+          "slotNumber": 4
+        },
+        {
+          "dmxRange": [32, 39],
+          "type": "WheelSlot",
+          "slotNumber": 5
+        },
+        {
+          "dmxRange": [40, 47],
+          "type": "WheelSlot",
+          "slotNumber": 6
+        },
+        {
+          "dmxRange": [48, 55],
+          "type": "WheelSlot",
+          "slotNumber": 7
+        },
+        {
+          "dmxRange": [56, 63],
+          "type": "WheelSlot",
+          "slotNumber": 8
+        },
+        {
+          "dmxRange": [64, 71],
+          "type": "WheelShake",
+          "slotNumber": 9,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [72, 79],
+          "type": "WheelShake",
+          "slotNumber": 10,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [80, 87],
+          "type": "WheelShake",
+          "slotNumber": 11,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [88, 95],
+          "type": "WheelShake",
+          "slotNumber": 12,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [96, 103],
+          "type": "WheelShake",
+          "slotNumber": 13,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [104, 111],
+          "type": "WheelShake",
+          "slotNumber": 14,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [112, 119],
+          "type": "WheelShake",
+          "slotNumber": 15,
+          "shakeSpeedStart": "slow",
+          "shakeSpeedEnd": "fast"
+        },
+        {
+          "dmxRange": [120, 127],
+          "type": "WheelSlot",
+          "slotNumber": 16
+        },
+        {
+          "dmxRange": [128, 189],
+          "type": "Effect",
+          "effectName": "Cycle effect",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [190, 193],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [194, 255],
+          "type": "Effect",
+          "effectName": "Cycle effect",
+          "speedStart": "slow reverse",
+          "speedEnd": "fast reverse"
+        }
+      ]
+    },
+    "Gobo Wheel Rotation": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [1, 63],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [64, 145],
+          "type": "WheelRotation",
+          "speed": "slow CW"
+        },
+        {
+          "dmxRange": [146, 149],
+          "type": "WheelRotation",
+          "speed": "stop",
+          "comment": "stop"
+        },
+        {
+          "dmxRange": [150, 231],
+          "type": "WheelRotation",
+          "speed": "slow CCW"
+        },
+        {
+          "dmxRange": [232, 255],
+          "type": "Effect",
+          "effectName": "Bounce",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Prism": {
+      "defaultValue": 0,
+      "capabilities": [
+        {
+          "dmxRange": [0, 3],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [4, 6],
+          "type": "Prism",
+          "comment": "6fasat"
+        },
+        {
+          "dmxRange": [7, 65],
+          "type": "Prism",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "6fasat"
+        },
+        {
+          "dmxRange": [66, 123],
+          "type": "Prism",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW",
+          "comment": "6fasat"
+        },
+        {
+          "dmxRange": [124, 127],
+          "type": "Prism",
+          "comment": "6fasat"
+        },
+        {
+          "dmxRange": [128, 131],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [132, 134],
+          "type": "Prism",
+          "comment": "5fasat"
+        },
+        {
+          "dmxRange": [135, 193],
+          "type": "Prism",
+          "speedStart": "slow CW",
+          "speedEnd": "fast CW",
+          "comment": "5fasat"
+        },
+        {
+          "dmxRange": [194, 251],
+          "type": "Prism",
+          "speedStart": "slow CCW",
+          "speedEnd": "fast CCW",
+          "comment": "5fasat"
+        },
+        {
+          "dmxRange": [252, 255],
+          "type": "Prism"
+        }
+      ]
+    },
+    "Focus": {
+      "capability": {
+        "type": "Focus",
+        "distanceStart": "0%",
+        "distanceEnd": "100%"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": "0%",
+        "brightnessEnd": "100%"
+      }
+    },
+    "Pan/Tilt Speed": {
+      "capability": {
+        "type": "PanTiltSpeed",
+        "speedStart": "fast",
+        "speedEnd": "slow"
+      }
+    },
+    "Shutter": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 3],
+          "type": "Intensity",
+          "brightnessStart": "0%",
+          "brightnessEnd": "0%"
+        },
+        {
+          "dmxRange": [4, 7],
+          "type": "Intensity",
+          "brightnessStart": "100%",
+          "brightnessEnd": "100%"
+        },
+        {
+          "dmxRange": [8, 76],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        },
+        {
+          "dmxRange": [77, 145],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Pulse strobe"
+        },
+        {
+          "dmxRange": [146, 215],
+          "type": "StrobeSpeed",
+          "speedStart": "slow",
+          "speedEnd": "fast",
+          "comment": "Random strobe"
+        },
+        {
+          "dmxRange": [216, 255],
+          "type": "Intensity",
+          "brightnessStart": "bright",
+          "brightnessEnd": "bright"
+        }
+      ]
+    },
+    "No function": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "No function 2": {
+      "name": "No function",
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Zoom": {
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "narrow",
+        "angleEnd": "wide"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "375IRZ",
+      "channels": [
+        "Pan",
+        "Pan fine",
+        "Tilt",
+        "Tilt fine",
+        "Pan/Tilt Speed",
+        "Color Wheel",
+        "Gobo Wheel",
+        "Gobo Wheel Rotation",
+        "Prism",
+        "Focus",
+        "Dimmer",
+        "Shutter",
+        "No function",
+        "No function 2",
+        "Zoom"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `chauvet-dj/intimidator-375-irz`

### Fixture warnings / errors

* chauvet-dj/intimidator-375-irz
  - ❌ Capability 'Wheel rotation slow CW' (64…145) in channel 'Gobo Wheel Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel Rotation' (through the channel name) does not exist.
  - ❌ Capability 'Wheel rotation stop (stop)' (146…149) in channel 'Gobo Wheel Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel Rotation' (through the channel name) does not exist.
  - ❌ Capability 'Wheel rotation slow CCW' (150…231) in channel 'Gobo Wheel Rotation' does not explicitly reference any wheel, but the default wheel 'Gobo Wheel Rotation' (through the channel name) does not exist.
  - ❌ Capability 'Intensity 0%' (0…3) in channel 'Shutter' uses brightnessStart and brightnessEnd with equal values. Use the single property 'brightness: "0%"' instead.
  - ❌ Capability 'Intensity 100%' (4…7) in channel 'Shutter' uses brightnessStart and brightnessEnd with equal values. Use the single property 'brightness: "100%"' instead.
  - ❌ Capability 'Intensity bright' (216…255) in channel 'Shutter' uses brightnessStart and brightnessEnd with equal values. Use the single property 'brightness: "bright"' instead.
  - ⚠️ Unused wheel slot(s): Color Wheel (slot 10), Color Wheel (slot 11), Color Wheel (slot 12), Color Wheel (slot 13), Color Wheel (slot 14), Color Wheel (slot 15), Color Wheel (slot 16), Color Wheel (slot 17), Color Wheel (slot 18), Color Wheel (slot 19)
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Joe Cee (AKA STEEEEEVE MAAAAADDON)**!