### PR TITLE
Add fixture `par-36-boaz/par-led-36-boaz`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -394,6 +394,12 @@
     "name": "Panasonic",
     "website": "https://panasonic.net/cns/projector/"
   },
+  "par-36-boaz": {
+    "name": "PAR 36 BOAZ",
+    "comment": "sfdfs",
+    "website": "https://www.instagram.com/gaztoxik/",
+    "rdmId": 2
+  },
   "phocea-light": {
     "name": "Phocea Light",
     "website": "https://www.phocealight.fr/"

--- a/fixtures/par-36-boaz/par-led-36-boaz.json
+++ b/fixtures/par-36-boaz/par-led-36-boaz.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "PAR LED 36 BOAZ",
+  "shortName": "PL36BZ",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["gzatxo"],
+    "createDate": "2026-04-10",
+    "lastModifyDate": "2026-04-10"
+  },
+  "links": {
+    "manual": [
+      "https://www.instagram.com/gaztoxik/"
+    ],
+    "productPage": [
+      "https://www.instagram.com/gaztoxik/"
+    ],
+    "video": [
+      "https://www.instagram.com/gaztoxik/"
+    ]
+  },
+  "rdm": {
+    "modelId": 2
+  },
+  "physical": {
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "colorTemperature": 4000,
+      "lumens": 400
+    }
+  },
+  "availableChannels": {
+    "DIMMER": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "StrobeSpeed",
+        "speedStart": "1Hz",
+        "speedEnd": "499Hz"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "DIM R G B STROBE MACRO",
+      "shortName": "DRGBSM6ch",
+      "rdmPersonalityIndex": 1,
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `par-36-boaz/par-led-36-boaz`

### Fixture warnings / errors

* par-36-boaz/par-led-36-boaz
  - ❌ URL 'https://www.instagram.com/gaztoxik/' is used in multiple link types: manual, productPage, video.
  - ❌ Channel key 'Dimmer' is already defined (maybe in another letter case).
  - ❌ Mode 'DIM R G B STROBE MACRO' should have 6 channels according to its shortName but actually has 5.


Thank you **gzatxo**!