### PR TITLE
Bump embetty-vue from 2.2.1 to 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "color-name-list": "^14.36.0",
         "cookie-universal-nuxt": "^2.2.2",
         "cors": "^2.8.6",
-        "embetty-vue": "^2.2.1",
+        "embetty-vue": "^2.2.2",
         "express": "^5.2.1",
         "jszip": "^3.10.1",
         "node-env-file": "^0.1.8",
@@ -10615,9 +10615,9 @@
       "license": "MIT"
     },
     "node_modules/embetty-vue": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/embetty-vue/-/embetty-vue-2.2.1.tgz",
-      "integrity": "sha512-3rAp1Vkja4RgLMuCmv1G4/p9Bjpayme0HVWRgvDE7LiXr/Lenl8wFZ/Cv4z3VTZQUCTzgxO3c0pVtrYp8RhUSw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/embetty-vue/-/embetty-vue-2.2.2.tgz",
+      "integrity": "sha512-9zX/m8mTFTUDPmdbhRF6lKAKQHo7rshm1GoGMKns8G7o6ereruD3OlZrVRfKZq2ENpiUxLSKg+qljHkzK9QBuA==",
       "license": "MIT",
       "dependencies": {
         "vue-ts-types": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "color-name-list": "^14.36.0",
     "cookie-universal-nuxt": "^2.2.2",
     "cors": "^2.8.6",
-    "embetty-vue": "^2.2.1",
+    "embetty-vue": "^2.2.2",
     "express": "^5.2.1",
     "jszip": "^3.10.1",
     "node-env-file": "^0.1.8",


### PR DESCRIPTION
[v2.2.2](https://github.com/FloEdelmann/embetty-vue/releases/tag/v2.2.2) fixes the `sideEffects: false` field so the package's CSS is no longer tree-shaken out of the production bundle, restoring embetty styles on the live site.