### PR TITLE
Add fixture `generic/amazon-rgbw`

### DIFF
--- a/fixtures/generic/amazon-rgbw.json
+++ b/fixtures/generic/amazon-rgbw.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Amazon RGBW",
+  "shortName": "RGBW",
+  "categories": ["Color Changer", "Dimmer", "Other", "Effect"],
+  "meta": {
+    "authors": ["Appi"],
+    "createDate": "2026-04-26",
+    "lastModifyDate": "2026-04-26"
+  },
+  "links": {
+    "other": [
+      "https://youtube.de"
+    ]
+  },
+  "rdm": {
+    "modelId": 0
+  },
+  "physical": {
+    "dimensions": [150, 150, 50],
+    "weight": 1,
+    "power": 100,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "lumens": 2000
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "highlightValue": "100%",
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Function": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 3],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [4, 127],
+          "type": "ColorPreset"
+        },
+        {
+          "dmxRange": [128, 169],
+          "type": "ColorPreset"
+        },
+        {
+          "dmxRange": [170, 210],
+          "type": "ColorPreset"
+        },
+        {
+          "dmxRange": [211, 229],
+          "type": "ColorPreset"
+        },
+        {
+          "dmxRange": [230, 255],
+          "type": "ColorPreset"
+        }
+      ]
+    },
+    "Function Speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8ch",
+      "shortName": "8ch",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Shutter / Strobe",
+        "Function",
+        "Function Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `generic/amazon-rgbw`

### Fixture warnings / errors

* generic/amazon-rgbw
  - ❌ Channel 'Shutter / Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.


Thank you **Appi**!