### PR TITLE
add: stairville matrix blinder 5 (draft)

### DIFF
--- a/fixtures/stairville/matrix-blinder-5-5.json
+++ b/fixtures/stairville/matrix-blinder-5-5.json
@@ -32,7 +32,7 @@
     ],
     "weight": 10.2,
     "power": 115,
-    "DMXconnector": "3-pin and RJ-45 ArtNet",
+    "DMXconnector": "3-pin",
     "bulb": {
       "type": "LED"
     }

--- a/fixtures/stairville/matrix-blinder-5-5.json
+++ b/fixtures/stairville/matrix-blinder-5-5.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Matrix Blinder 5x5 RGBWW",
+  "shortName": "matrix-blinder-5-5",
+  "categories": [
+    "Matrix",
+    "Color Changer"
+  ],
+  "meta": {
+    "authors": [
+      "Leon Dietrich"
+    ],
+    "createDate": "2026-05-13",
+    "lastModifyDate": "2026-05-13"
+  },
+  "links": {
+    "manual": [
+      "https://fast-images.static-thomann.de/pics/atg/atgdata/document/manual/494410_c_494410_v4_de_online.pdf"
+    ],
+    "productPage": [
+      "https://www.thomann.de/de/stairville_led_matrix_blinder_5x5_rgb_ww.htm"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=9CUvX_CNq_c"
+    ]
+  },
+  "physical": {
+    "dimensions": [
+      450,
+      450,
+      115
+    ],
+    "weight": 10.2,
+    "power": 115,
+    "DMXconnector": "3-pin and RJ-45 ArtNet",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "matrix": {
+    "pixelCount": [
+      5,
+      5,
+      1
+    ]
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [
+            0,
+            10
+          ],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [
+            11,
+            255
+          ],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    }
+  },
+  "templateChannels": {
+    "Red $pixelKey": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green $pixelKey": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue $pixelKey": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White $pixelKey": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "4-channel",
+      "shortName": "4-ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White"
+      ]
+    },
+    {
+      "name": "9-channel",
+      "shortName": "9-ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe"
+      ]
+    },
+    {
+      "name": "100-channel",
+      "shortName": "100-ch",
+      "channels": [
+        {
+          "insert": "matrixChannels",
+          "repeatFor": "eachPixelXYZ",
+          "channelOrder": "perPixel",
+          "templateChannels": [
+            "Red $pixelKey",
+            "Green $pixelKey",
+            "Blue $pixelKey",
+            "White $pixelKey"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the Stairville Matrix Blinder 5x5 RGBWW.

TODOs:
 - [ ] Add automatic channels in 9ch mode
 - [ ] reverse engineer the 102ch mode and include it