### PR TITLE
Add fixture `generic/fader-rgbwauv`

### DIFF
--- a/fixtures/generic/fader-rgbwauv.json
+++ b/fixtures/generic/fader-rgbwauv.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Fader RGBWAUV",
+  "categories": ["Dimmer", "Color Changer"],
+  "meta": {
+    "authors": ["Axkana"],
+    "createDate": "2026-05-13",
+    "lastModifyDate": "2026-05-13"
+  },
+  "links": {
+    "manual": [
+      "https://drive.google.com/drive/folders/1kzc9geYsmZsciOlWd7rOnekrfEprFHSV"
+    ],
+    "productPage": [
+      "https://drive.google.com/drive/folders/1kzc9geYsmZsciOlWd7rOnekrfEprFHSV"
+    ],
+    "video": [
+      "https://drive.google.com/drive/folders/1kzc9geYsmZsciOlWd7rOnekrfEprFHSV"
+    ]
+  },
+  "physical": {
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "UV": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Fader RGBWAUV",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `generic/fader-rgbwauv`

### Fixture warnings / errors

* generic/fader-rgbwauv
  - ❌ URL 'https://drive.google.com/drive/folders/1kzc9geYsmZsciOlWd7rOnekrfEprFHSV' is used in multiple link types: manual, productPage, video.


Thank you **Axkana**!