### PR TITLE
Add fixture `boomtonedj/par-led-rvbwis`

### DIFF
--- a/fixtures/boomtonedj/par-led-rvbwis.json
+++ b/fixtures/boomtonedj/par-led-rvbwis.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Par led RVBWIS",
+  "categories": ["Dimmer"],
+  "meta": {
+    "authors": ["martinm"],
+    "createDate": "2026-05-16",
+    "lastModifyDate": "2026-05-16"
+  },
+  "links": {
+    "productPage": [
+      "https://www.sonovente.com/boomtonedj-ledpar-7x10w-5in1-p61225.html"
+    ]
+  },
+  "rdm": {
+    "modelId": 0
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "1Hz",
+        "speedEnd": "255Hz",
+        "randomTiming": true
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "8 channel",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Intensity",
+        "Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `boomtonedj/par-led-rvbwis`

### Fixture warnings / errors

* boomtonedj/par-led-rvbwis
  - ❌ Channel 'Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.
  - ❌ Mode '8 channel' should have 8 channels according to its name but actually has 6.
  - ❌ Mode '8 channel' should have 8 channels according to its shortName but actually has 6.
  - ⚠️ Mode '8 channel' should have shortName '8ch' instead of '8 channel'.
  - ⚠️ Mode '8 channel' should have shortName '8ch' instead of '8 channel'.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **martinm**!