### PR TITLE
Add fixture `uking/uking-270-led`

### DIFF
--- a/fixtures/uking/uking-270-led.json
+++ b/fixtures/uking/uking-270-led.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Uking 270 LED",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["WH"],
+    "createDate": "2026-05-24",
+    "lastModifyDate": "2026-05-24"
+  },
+  "links": {
+    "productPage": [
+      "https://www.uking-online.com"
+    ]
+  },
+  "rdm": {
+    "modelId": 1
+  },
+  "physical": {
+    "weight": 1,
+    "power": 50,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "colorTemperature": 5000
+    },
+    "lens": {
+      "degreesMinMax": [60, 60]
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    },
+    "Function": {
+      "capability": {
+        "type": "Effect",
+        "effectName": "Funktionen"
+      }
+    },
+    "Function Speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Uking 270 LED",
+      "shortName": "Uking270",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Shutter / Strobe",
+        "Function",
+        "Function Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `uking/uking-270-led`

### Fixture warnings / errors

* uking/uking-270-led
  - ❌ Channel 'Shutter / Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.


Thank you @wh!