### PR TITLE
Add fixture `jb-systems/clubwash-mini`

### DIFF
--- a/fixtures/jb-systems/clubwash-mini.json
+++ b/fixtures/jb-systems/clubwash-mini.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "clubwash mini",
+  "categories": ["Color Changer", "Moving Head"],
+  "meta": {
+    "authors": ["ivhej"],
+    "createDate": "2026-05-25",
+    "lastModifyDate": "2026-05-25"
+  },
+  "links": {
+    "manual": [
+      "https://audioeffetti.com/product/documents/BEG/B05530-05.pdf"
+    ],
+    "productPage": [
+      "https://jb-systems.eu/clubwash-mini"
+    ]
+  },
+  "availableChannels": {
+    "1 pan": {
+      "capability": {
+        "type": "Pan",
+        "angleStart": "0deg",
+        "angleEnd": "180deg"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "9ch",
+      "channels": [
+        "1 pan"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `jb-systems/clubwash-mini`

### Fixture warnings / errors

* jb-systems/clubwash-mini
  - ❌ Mode '9ch' should have 9 channels according to its name but actually has 1.
  - ❌ Mode '9ch' should have 9 channels according to its shortName but actually has 1.
  - ❌ Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.


Thank you @hej!