### PR TITLE
Add fixture `astera/niki`

### DIFF
--- a/fixtures/astera/niki.json
+++ b/fixtures/astera/niki.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "Niki",
+  "shortName": "NiL",
+  "categories": ["Matrix", "Flower", "Hazer", "Laser", "Barrel Scanner", "Blinder", "Pixel Bar", "Moving Head", "Stand", "Smoke"],
+  "meta": {
+    "authors": ["NIki"],
+    "createDate": "2026-05-29",
+    "lastModifyDate": "2026-05-29"
+  },
+  "links": {
+    "manual": [
+      "https://rocketshow.net/designer/app/?id=&token="
+    ],
+    "productPage": [
+      "https://open-fixture-library.org/fixture-editor"
+    ],
+    "video": [
+      "https://www.youtube.com/shorts/r2cM-5-tlXs"
+    ]
+  },
+  "rdm": {
+    "modelId": 41,
+    "softwareVersion": "NnBJG"
+  },
+  "physical": {
+    "bulb": {
+      "colorTemperature": 9,
+      "lumens": 7
+    },
+    "lens": {
+      "name": "IK Lens",
+      "degreesMinMax": [31, 31]
+    }
+  },
+  "availableChannels": {
+    "DBB Chanel": {
+      "defaultValue": 11,
+      "highlightValue": 7,
+      "constant": true,
+      "precedence": "HTP",
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "fast",
+        "speedEnd": "slow",
+        "durationStart": "short",
+        "durationEnd": "short",
+        "randomTiming": true
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "EdeYT",
+      "shortName": "YT",
+      "rdmPersonalityIndex": 24,
+      "physical": {
+        "dimensions": [29, 29, 18]
+      },
+      "channels": [
+        "DBB Chanel"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `astera/niki`

### Fixture warnings / errors

* astera/niki
  - ❌ Channel 'DBB Chanel' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.
  - ❌ Capability 'Random strobe fast…slow short' (0…255) in channel 'DBB Chanel' uses durationStart and durationEnd with equal values. Use the single property 'duration: "short"' instead.
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.
  - ❌ Category 'Barrel Scanner' invalid since there are no pan or tilt channels.
  - ❌ Category 'Smoke' invalid since there are no Fog/FogType capabilities or none has fogType 'Fog'.
  - ❌ Category 'Hazer' invalid since there are no Fog/FogType capabilities or none has fogType 'Haze'.
  - ❌ Category 'Matrix' invalid since fixture does not define a matrix.
  - ❌ Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.


Thank you **nikitavelbyk**!