### PR TITLE
Add fixture `beamz/parled-flat`

### DIFF
--- a/fixtures/beamz/parled-flat.json
+++ b/fixtures/beamz/parled-flat.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "PARLED FLAT",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["valerio maggi"],
+    "createDate": "2026-05-31",
+    "lastModifyDate": "2026-05-31"
+  },
+  "links": {
+    "manual": [
+      "https://www.manualpdf.in/beamz/flatpar-151-287/manual"
+    ],
+    "productPage": [
+      "https://www.beamzlighting.com/product/h2000-faze-machine-with-dmx/"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=Fxl80HCGqjA"
+    ]
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "UV": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Program": {
+      "capability": {
+        "type": "Generic"
+      }
+    },
+    "Program Speed": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "6ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV"
+      ]
+    },
+    {
+      "name": "10ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV",
+        "Dimmer",
+        "Strobe",
+        "Program",
+        "Program Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `beamz/parled-flat`

### Fixture warnings / errors

* beamz/parled-flat
  - ❌ Channel 'Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.


Thank you **valerio maggi**!