### PR TITLE
Add fixture `kino-flo/1`

### DIFF
--- a/fixtures/kino-flo/1.json
+++ b/fixtures/kino-flo/1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "1",
+  "shortName": "1",
+  "categories": ["Barrel Scanner", "Blinder"],
+  "meta": {
+    "authors": ["James"],
+    "createDate": "2026-06-03",
+    "lastModifyDate": "2026-06-03"
+  },
+  "links": {
+    "manual": [
+      "https://www.google.com/"
+    ]
+  },
+  "physical": {
+    "dimensions": [5, 5, 5],
+    "weight": 23,
+    "power": 500,
+    "DMXconnector": "RJ45",
+    "bulb": {
+      "type": "LED",
+      "colorTemperature": 1,
+      "lumens": 5000
+    }
+  },
+  "availableChannels": {
+    "Strobe": {
+      "capability": {
+        "type": "Effect",
+        "effectName": "1",
+        "speed": "fast",
+        "duration": "instant",
+        "parameter": "small"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Extendex",
+      "channels": [
+        "Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `kino-flo/1`

### Fixture warnings / errors

* kino-flo/1
  - ❌ physical.dimensions are too small (5×5×5mm) for a fixture with a RJ45 DMX connector. Did you accidentally enter the dimensions in centimeters instead of millimeters?
  - ❌ Category 'Barrel Scanner' invalid since there are no pan or tilt channels.


Thank you **James**!