### PR TITLE
Add fixture `aputure/test`

### DIFF
--- a/fixtures/aputure/test.json
+++ b/fixtures/aputure/test.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "TEST",
+  "categories": ["Moving Head", "Barrel Scanner", "Blinder", "Color Changer", "Dimmer", "Effect", "Pixel Bar", "Stand", "Smoke"],
+  "meta": {
+    "authors": ["erik"],
+    "createDate": "2026-06-05",
+    "lastModifyDate": "2026-06-05"
+  },
+  "links": {
+    "other": [
+      "https://google.com"
+    ]
+  },
+  "availableChannels": {
+    "Shutter": {
+      "fineChannelAliases": ["Shutter fine"],
+      "capability": {
+        "type": "Tilt",
+        "angleStart": "5deg",
+        "angleEnd": "-22deg"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "zeta",
+      "channels": [
+        "Shutter",
+        "Shutter fine"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `aputure/test`

### Fixture warnings / errors

* aputure/test
  - ❌ Category 'Color Changer' invalid since there are no ColorPreset and less than two ColorIntensity capabilities and no Color wheel slots.
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.
  - ❌ Categories 'Moving Head', 'Barrel Scanner' can't be used together.
  - ❌ Category 'Smoke' invalid since there are no Fog/FogType capabilities or none has fogType 'Fog'.
  - ❌ Category 'Pixel Bar' invalid since no horizontally aligned matrix is defined.


Thank you **erik**!