### PR TITLE
Add fixture `oxo/colorado-2-solo`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -390,6 +390,9 @@
     "name": "Orion Effects Lighting",
     "website": "https://orion-fxlights.com/"
   },
+  "oxo": {
+    "name": "oxo"
+  },
   "panasonic": {
     "name": "Panasonic",
     "website": "https://panasonic.net/cns/projector/"

--- a/fixtures/oxo/colorado-2-solo.json
+++ b/fixtures/oxo/colorado-2-solo.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "colorado 2 solo",
+  "categories": ["Dimmer", "Strobe", "Other"],
+  "meta": {
+    "authors": ["sam"],
+    "createDate": "2026-06-06",
+    "lastModifyDate": "2026-06-06"
+  },
+  "links": {
+    "manual": [
+      "https://www.modesdemploi.fr/chauvet/colorado-2-solo/mode-d-emploi"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "EffectParameter",
+        "parameterStart": "low",
+        "parameterEnd": "high"
+      }
+    },
+    "Strobo": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Open"
+      }
+    },
+    "Programme": {
+      "capability": {
+        "type": "EffectParameter",
+        "parameterStart": "low",
+        "parameterEnd": "high"
+      }
+    },
+    "Auto speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "Zoom": {
+      "capability": {
+        "type": "Zoom",
+        "angleStart": "narrow",
+        "angleEnd": "wide"
+      }
+    },
+    "Zoom control": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Dimmer speed": {
+      "capability": {
+        "type": "Speed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "dimmer",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Color Macros",
+        "Strobo",
+        "Programme",
+        "Auto speed",
+        "Zoom",
+        "Zoom control",
+        "Dimmer speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `oxo/colorado-2-solo`

### Fixture warnings / errors

* oxo/colorado-2-solo
  - ❌ Channel 'Strobo' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **sam**!