### PR TITLE
Add fixture `adb/mh1`

### DIFF
--- a/fixtures/adb/mh1.json
+++ b/fixtures/adb/mh1.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "mh1",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["jessy"],
+    "createDate": "2026-06-06",
+    "lastModifyDate": "2026-06-06"
+  },
+  "links": {
+    "video": [
+      "https://www.youtube.com/watch?v=i7Kv2eFtsEE&list=RDi7Kv2eFtsEE&start_radio=1",
+      "https://www.youtube.com/watch?v=i7Kv2eFtsEE&list=RDi7Kv2eFtsEE&start_radio=1",
+      "https://www.youtube.com/watch?v=i7Kv2eFtsEE&list=RDi7Kv2eFtsEE&start_radio=1"
+    ]
+  },
+  "availableChannels": {
+    "Intensity": {
+      "capability": {
+        "type": "Intensity"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "as",
+      "channels": [
+        "Intensity"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `adb/mh1`

### Fixture warnings / errors

* adb/mh1
  - ❌ File does not match schema: fixture/links/video must NOT have duplicate items (items ## 1 and 2 are identical)


Thank you **jessy**!