### PR TITLE
Add fixture `acoustic-control/sssq`

### DIFF
--- a/fixtures/acoustic-control/sssq.json
+++ b/fixtures/acoustic-control/sssq.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "sssq",
+  "categories": ["Blinder", "Stand", "Scanner", "Effect", "Fan", "Dimmer", "Hazer", "Flower", "Laser", "Moving Head", "Matrix"],
+  "meta": {
+    "authors": ["sasasq"],
+    "createDate": "2026-06-09",
+    "lastModifyDate": "2026-06-09"
+  },
+  "links": {
+    "video": [
+      "https://www.youtube.com/watch?v=biYepYB33uw"
+    ]
+  },
+  "rdm": {
+    "modelId": 8,
+    "softwareVersion": "qsqsax"
+  },
+  "availableChannels": {
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Pulse",
+        "speedStart": "slow",
+        "speedEnd": "slow",
+        "duration": "instant"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "saaecws",
+      "channels": [
+        "Strobe"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `acoustic-control/sssq`

### Fixture warnings / errors

* acoustic-control/sssq
  - ❌ Channel 'Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.
  - ❌ Capability 'Pulse strobe slow instant' (0…255) in channel 'Strobe' uses speedStart and speedEnd with equal values. Use the single property 'speed: "slow"' instead.
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.
  - ❌ Category 'Scanner' invalid since there are no pan or tilt channels.
  - ❌ Category 'Hazer' invalid since there are no Fog/FogType capabilities or none has fogType 'Haze'.
  - ❌ Category 'Matrix' invalid since fixture does not define a matrix.


Thank you **sasasq**!