### PR TITLE
Inline Nuxt 2 ESLint plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,3 @@
-import { fixupPluginRules } from '@eslint/compat';
 import eslintJs from '@eslint/js';
 import eslintMarkdown from '@eslint/markdown';
 import eslintPluginStylistic from '@stylistic/eslint-plugin';
@@ -6,25 +5,14 @@ import eslintPluginVitest from '@vitest/eslint-plugin';
 import eslintPluginImport from 'eslint-plugin-import-x';
 import eslintPluginJsdoc from 'eslint-plugin-jsdoc';
 import { configs as eslintPluginJsoncConfigs } from 'eslint-plugin-jsonc';
-import eslintPluginNuxt from 'eslint-plugin-nuxt';
 import eslintPluginPromise from 'eslint-plugin-promise';
 import eslintPluginSonarjs from 'eslint-plugin-sonarjs';
 import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import eslintPluginVue from 'eslint-plugin-vue';
 import eslintPluginVueA11y from 'eslint-plugin-vuejs-accessibility';
 import globals from 'globals';
+import internalNuxt2EslintPlugin from './lib/internal-eslint-rules/nuxt2/index.js';
 
-const eslintPluginNuxtConfigRecommended = {
-  files: ['**/*.{js,vue}'],
-  plugins: {
-    nuxt: fixupPluginRules(eslintPluginNuxt),
-  },
-  rules: {
-    ...eslintPluginNuxt.configs.base.rules,
-    ...eslintPluginNuxt.configs.recommended.rules,
-    'nuxt/require-func-head': 'error',
-  },
-};
 
 const stylisticEslintConfig = eslintPluginStylistic.configs.customize({
   arrowParens: true,
@@ -392,7 +380,7 @@ export default [
   stylisticEslintConfig,
   eslintPluginImport.flatConfigs.recommended,
   eslintPluginJsdoc.configs['flat/recommended-typescript-flavor'],
-  eslintPluginNuxtConfigRecommended,
+  internalNuxt2EslintPlugin.configs.all,
   eslintPluginPromise.configs['flat/recommended'],
   eslintPluginSonarjs.configs.recommended,
   eslintPluginUnicorn.configs.recommended,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,6 @@ import eslintPluginVueA11y from 'eslint-plugin-vuejs-accessibility';
 import globals from 'globals';
 import internalNuxt2EslintPlugin from './lib/internal-eslint-rules/nuxt2/index.js';
 
-
 const stylisticEslintConfig = eslintPluginStylistic.configs.customize({
   arrowParens: true,
   semi: true,

--- a/lib/internal-eslint-rules/nuxt2/index.js
+++ b/lib/internal-eslint-rules/nuxt2/index.js
@@ -1,0 +1,62 @@
+/**
+ * Internal ESLint plugin providing Nuxt 2 rules.
+ * Ported from eslint-plugin-nuxt (https://github.com/nuxt/eslint-plugin-nuxt).
+ */
+
+import noCjsInConfig from './no-cjs-in-config.js';
+import noEnvInContext from './no-env-in-context.js';
+import noEnvInHooks from './no-env-in-hooks.js';
+import noGlobalsInCreated from './no-globals-in-created.js';
+import noThisInFetchData from './no-this-in-fetch-data.js';
+import noTimingInFetchData from './no-timing-in-fetch-data.js';
+import requireFunctionHead from './require-function-head.js';
+
+const plugin = {
+  rules: {
+    'no-cjs-in-config': noCjsInConfig,
+    'no-env-in-context': noEnvInContext,
+    'no-env-in-hooks': noEnvInHooks,
+    'no-globals-in-created': noGlobalsInCreated,
+    'no-this-in-fetch-data': noThisInFetchData,
+    'no-timing-in-fetch-data': noTimingInFetchData,
+    'require-func-head': requireFunctionHead,
+  },
+  configs: {},
+};
+
+const baseRules = {
+  'nuxt2/no-cjs-in-config': 'error',
+  'nuxt2/no-env-in-context': 'error',
+  'nuxt2/no-env-in-hooks': 'error',
+  'nuxt2/no-globals-in-created': 'error',
+  'nuxt2/no-this-in-fetch-data': 'error',
+};
+
+const files = ['**/*.{js,vue}'];
+
+Object.assign(plugin.configs, {
+  base: {
+    files,
+    plugins: { nuxt2: plugin },
+    rules: baseRules,
+  },
+  recommended: {
+    files,
+    plugins: { nuxt2: plugin },
+    rules: {
+      ...baseRules,
+      'nuxt2/no-timing-in-fetch-data': 'error',
+    },
+  },
+  all: {
+    files,
+    plugins: { nuxt2: plugin },
+    rules: {
+      ...baseRules,
+      'nuxt2/no-timing-in-fetch-data': 'error',
+      'nuxt2/require-func-head': 'error',
+    },
+  },
+});
+
+export default plugin;

--- a/lib/internal-eslint-rules/nuxt2/no-cjs-in-config.js
+++ b/lib/internal-eslint-rules/nuxt2/no-cjs-in-config.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Disallow `require/module.exports/exports` in `nuxt.config.js`
+ * Ported from eslint-plugin-nuxt (https://github.com/nuxt/eslint-plugin-nuxt).
+ */
+
+import path from 'path';
+
+export default {
+  meta: {
+    docs: {
+      description: 'disallow CommonJS module API `require/module.exports/exports` in `nuxt.config.js`',
+    },
+    messages: {
+      noCjs: 'Unexpected {{cjs}}, please use {{esm}} instead.',
+    },
+    type: 'problem',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          file: { type: 'string' },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const options = context.options[0] ?? {};
+    const configFile = options.file ?? 'nuxt.config.js';
+    let isNuxtConfig = false;
+
+    return {
+      Program() {
+        const filename = path.basename(context.filename);
+        if (filename === configFile) {
+          isNuxtConfig = true;
+        }
+      },
+      MemberExpression(node) {
+        if (!isNuxtConfig) {
+          return;
+        }
+
+        if (node.object.name === 'module' && node.property.name === 'exports') {
+          context.report({
+            node,
+            messageId: 'noCjs',
+            data: { cjs: 'module.exports', esm: 'export default' },
+          });
+        }
+
+        if (node.object.name === 'exports') {
+          const isInScope = context.sourceCode.getScope(node).variables
+            .some((variable) => variable.name === 'exports');
+          if (!isInScope) {
+            context.report({
+              node,
+              messageId: 'noCjs',
+              data: { cjs: 'exports', esm: 'export default' },
+            });
+          }
+        }
+      },
+      CallExpression(call) {
+        const module = call.arguments[0];
+
+        if (
+          !isNuxtConfig
+          || context.sourceCode.getScope(call).type !== 'module'
+          || !['ExpressionStatement', 'VariableDeclarator'].includes(call.parent.type)
+          || call.callee.type !== 'Identifier'
+          || call.callee.name !== 'require'
+          || call.arguments.length !== 1
+          || module.type !== 'Literal'
+          || typeof module.value !== 'string'
+        ) {
+          return;
+        }
+
+        context.report({
+          node: call.callee,
+          messageId: 'noCjs',
+          data: { cjs: 'require', esm: 'import' },
+        });
+      },
+    };
+  },
+};

--- a/lib/internal-eslint-rules/nuxt2/no-env-in-context.js
+++ b/lib/internal-eslint-rules/nuxt2/no-env-in-context.js
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview disallow `context.isServer/context.isClient` in `asyncData/fetch/nuxtServerInit`
+ * Ported from eslint-plugin-nuxt (https://github.com/nuxt/eslint-plugin-nuxt).
+ */
+
+import { executeOnVue, getFunctionWithName, isInFunction } from './utilities.js';
+
+const ENV = new Set(['isServer', 'isClient']);
+const DEFAULT_HOOKS = new Set(['asyncData', 'fetch']);
+
+export default {
+  meta: {
+    docs: {
+      description: 'disallow `context.isServer/context.isClient` in `asyncData/fetch/nuxtServerInit`',
+    },
+    messages: {
+      noEnv: 'Unexpected {{env}} in {{funcName}}.',
+    },
+    type: 'problem',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          methods: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const forbiddenNodes = [];
+    const options = context.options[0] ?? {};
+    const HOOKS = new Set([...DEFAULT_HOOKS, ...(options.methods ?? [])]);
+
+    return {
+      MemberExpression(node) {
+        const propertyName = node.computed ? node.property.value : node.property.name;
+        if (propertyName && ENV.has(propertyName)) {
+          forbiddenNodes.push({ name: propertyName, node });
+        }
+      },
+      ...executeOnVue(context, (object) => {
+        for (const functionName of HOOKS) {
+          const function_ = getFunctionWithName(object, functionName);
+          const parameter = function_?.value ? function_.value.params?.[0] : false;
+          if (parameter) {
+            if (parameter.type === 'ObjectPattern') {
+              for (const property of parameter.properties) {
+                if (property.key?.name && ENV.has(property.key.name)) {
+                  context.report({
+                    node: property,
+                    messageId: 'noEnv',
+                    data: { env: property.key.name, funcName: functionName },
+                  });
+                }
+              }
+            }
+            else {
+              for (const { name, node: child } of forbiddenNodes) {
+                if (isInFunction(function_, child) && parameter.name === child.object.name) {
+                  context.report({
+                    node: child,
+                    messageId: 'noEnv',
+                    data: { env: name, funcName: functionName },
+                  });
+                }
+              }
+            }
+          }
+        }
+      }),
+    };
+  },
+};

--- a/lib/internal-eslint-rules/nuxt2/no-env-in-hooks.js
+++ b/lib/internal-eslint-rules/nuxt2/no-env-in-hooks.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview disallow process.server/process.client/process.browser in lifecycle hooks
+ * Ported from eslint-plugin-nuxt (https://github.com/nuxt/eslint-plugin-nuxt).
+ */
+
+import { executeOnVue, getFunctionWithName, isInFunction } from './utilities.js';
+
+const ENV = new Set(['server', 'client', 'browser']);
+const DEFAULT_HOOKS = new Set([
+  'beforeMount', 'mounted', 'beforeUpdate', 'updated',
+  'activated', 'deactivated', 'beforeDestroy', 'destroyed',
+]);
+
+export default {
+  meta: {
+    docs: {
+      description: 'disallow process.server and process.client in lifecycle hooks: beforeMount, mounted, beforeUpdate, updated, activated, deactivated, beforeDestroy and destroyed',
+    },
+    messages: {
+      noEnv: 'Unexpected {{name}} in {{funcName}}.',
+    },
+    type: 'problem',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          methods: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const forbiddenNodes = [];
+    const options = context.options[0] ?? {};
+    const HOOKS = new Set([...DEFAULT_HOOKS, ...(options.methods ?? [])]);
+
+    return {
+      MemberExpression(node) {
+        if (node.object.name === 'process') {
+          const propertyName = node.computed ? node.property.value : node.property.name;
+          if (propertyName && ENV.has(propertyName)) {
+            forbiddenNodes.push({ name: `process.${propertyName}`, node });
+          }
+        }
+      },
+      ...executeOnVue(context, (object) => {
+        for (const functionName of HOOKS) {
+          const function_ = getFunctionWithName(object, functionName);
+          if (function_) {
+            for (const { name, node: child } of forbiddenNodes) {
+              if (isInFunction(function_, child)) {
+                context.report({
+                  node: child,
+                  messageId: 'noEnv',
+                  data: { name, funcName: functionName },
+                });
+              }
+            }
+          }
+        }
+      }),
+    };
+  },
+};

--- a/lib/internal-eslint-rules/nuxt2/no-globals-in-created.js
+++ b/lib/internal-eslint-rules/nuxt2/no-globals-in-created.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview disallow `window/document` in `created/beforeCreate`
+ * Ported from eslint-plugin-nuxt (https://github.com/nuxt/eslint-plugin-nuxt).
+ */
+
+import { executeOnVue, getFunctionWithChild } from './utilities.js';
+
+const DEFAULT_HOOKS = new Set(['created', 'beforeCreate']);
+const GLOBALS = new Set(['window', 'document']);
+
+export default {
+  meta: {
+    docs: {
+      description: 'disallow `window/document` in `created/beforeCreate`',
+    },
+    messages: {
+      noGlobals: 'Unexpected {{name}} in {{funcName}}.',
+    },
+    type: 'problem',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          methods: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const forbiddenNodes = [];
+    const options = context.options[0] ?? {};
+    const HOOKS = new Set([...DEFAULT_HOOKS, ...(options.methods ?? [])]);
+
+    return {
+      MemberExpression(node) {
+        if (node.object && GLOBALS.has(node.object.name)) {
+          forbiddenNodes.push({ name: node.object.name, node });
+        }
+      },
+      VariableDeclarator(node) {
+        if (node.init && GLOBALS.has(node.init.name)) {
+          forbiddenNodes.push({ name: node.init.name, node });
+        }
+      },
+      ...executeOnVue(context, (object) => {
+        for (const { funcName, name, node } of getFunctionWithChild(object, HOOKS, forbiddenNodes)) {
+          context.report({
+            node,
+            messageId: 'noGlobals',
+            data: { name, funcName },
+          });
+        }
+      }),
+    };
+  },
+};

--- a/lib/internal-eslint-rules/nuxt2/no-this-in-fetch-data.js
+++ b/lib/internal-eslint-rules/nuxt2/no-this-in-fetch-data.js
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview disallow `this` in `asyncData`
+ * Ported from eslint-plugin-nuxt (https://github.com/nuxt/eslint-plugin-nuxt).
+ * Note: The `fetch` hook allows `this` since Nuxt 2.12.0, so only `asyncData` is checked.
+ */
+
+import { executeOnVue, getFunctionWithName } from './utilities.js';
+
+const DEFAULT_HOOKS = new Set(['asyncData']);
+
+export default {
+  meta: {
+    docs: {
+      description: 'disallow `this` in `asyncData`',
+    },
+    messages: {
+      noThis: 'Unexpected this in {{funcName}}.',
+    },
+    type: 'problem',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          methods: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const forbiddenNodes = new Map();
+    const options = context.options[0] ?? {};
+    const HOOKS = new Set([...DEFAULT_HOOKS, ...(options.methods ?? [])]);
+
+    let nodeUsingThis = [];
+
+    /** @returns {void} */
+    function enterFunction() {
+      nodeUsingThis = [];
+    }
+
+    /**
+     * @param {object} node The function node being exited.
+     * @returns {void}
+     */
+    function exitFunction(node) {
+      if (nodeUsingThis.length > 0) {
+        forbiddenNodes.set(node, nodeUsingThis);
+      }
+    }
+
+    /**
+     * @param {object} node The this/super expression node.
+     * @returns {void}
+     */
+    function markThisUsed(node) {
+      nodeUsingThis.push(node);
+    }
+
+    return {
+      'FunctionExpression': enterFunction,
+      'FunctionExpression:exit': exitFunction,
+      'ArrowFunctionExpression': enterFunction,
+      'ArrowFunctionExpression:exit': exitFunction,
+      'ThisExpression': markThisUsed,
+      'Super': markThisUsed,
+      ...executeOnVue(context, (object) => {
+        for (const functionName of HOOKS) {
+          const property = getFunctionWithName(object, functionName);
+          if (property && forbiddenNodes.has(property.value)) {
+            for (const node of forbiddenNodes.get(property.value)) {
+              context.report({
+                node,
+                messageId: 'noThis',
+                data: { funcName: functionName },
+              });
+            }
+          }
+        }
+      }),
+    };
+  },
+};

--- a/lib/internal-eslint-rules/nuxt2/no-timing-in-fetch-data.js
+++ b/lib/internal-eslint-rules/nuxt2/no-timing-in-fetch-data.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview disallow `setTimeout/setInterval` in `asyncData/fetch`
+ * Ported from eslint-plugin-nuxt (https://github.com/nuxt/eslint-plugin-nuxt).
+ */
+
+import { executeOnVue, getFunctionWithChild } from './utilities.js';
+
+const DEFAULT_HOOKS = new Set(['fetch', 'asyncData']);
+const TIMING = new Set(['setTimeout', 'setInterval']);
+
+export default {
+  meta: {
+    docs: {
+      description: 'disallow `setTimeout/setInterval` in `asyncData/fetch`',
+    },
+    messages: {
+      noTiming: 'Unexpected {{name}} in {{funcName}}.',
+    },
+    type: 'problem',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          methods: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const forbiddenNodes = [];
+    const options = context.options[0] ?? {};
+    const HOOKS = new Set([...DEFAULT_HOOKS, ...(options.methods ?? [])]);
+
+    return {
+      CallExpression(node) {
+        if (node.callee && TIMING.has(node.callee.name)) {
+          forbiddenNodes.push({ name: node.callee.name, node });
+        }
+      },
+      VariableDeclarator(node) {
+        if (node.init && TIMING.has(node.init.name)) {
+          forbiddenNodes.push({ name: node.init.name, node });
+        }
+      },
+      ...executeOnVue(context, (object) => {
+        for (const { funcName, name, node } of getFunctionWithChild(object, HOOKS, forbiddenNodes)) {
+          context.report({
+            node,
+            messageId: 'noTiming',
+            data: { name, funcName },
+          });
+        }
+      }),
+    };
+  },
+};

--- a/lib/internal-eslint-rules/nuxt2/require-function-head.js
+++ b/lib/internal-eslint-rules/nuxt2/require-function-head.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview enforce component's head property to be a function
+ * Ported from eslint-plugin-nuxt (https://github.com/nuxt/eslint-plugin-nuxt).
+ */
+
+import { executeOnVueComponent, getFirstAndLastTokens } from './utilities.js';
+
+export default {
+  meta: {
+    docs: {
+      description: 'enforce component\'s head property to be a function',
+    },
+    fixable: 'code',
+    messages: {
+      head: '`head` property in component must be a function.',
+    },
+    type: 'suggestion',
+    schema: [],
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    return executeOnVueComponent(context, (object) => {
+      for (const p of object.properties) {
+        if (
+          p.type === 'Property'
+          && p.key.type === 'Identifier'
+          && p.key.name === 'head'
+          && p.value.type !== 'FunctionExpression'
+          && p.value.type !== 'ArrowFunctionExpression'
+          && p.value.type !== 'Identifier'
+          && p.value.type !== 'CallExpression'
+        ) {
+          context.report({
+            node: p,
+            messageId: 'head',
+            fix(fixer) {
+              const tokens = getFirstAndLastTokens(sourceCode, p.value);
+
+              return [
+                fixer.insertTextBefore(tokens.first, 'function() {\nreturn '),
+                fixer.insertTextAfter(tokens.last, ';\n}'),
+              ];
+            },
+          });
+        }
+      }
+    });
+  },
+};

--- a/lib/internal-eslint-rules/nuxt2/utilities.js
+++ b/lib/internal-eslint-rules/nuxt2/utilities.js
@@ -1,0 +1,105 @@
+/**
+ * Shared utilities for internal Nuxt ESLint rules.
+ * Ported from eslint-plugin-nuxt (https://github.com/nuxt/eslint-plugin-nuxt).
+ */
+
+import { createRequire } from 'module';
+
+// createRequire is needed here to load the CJS internal utils from eslint-plugin-vue.
+
+const vueUtilities = createRequire(import.meta.url)('eslint-plugin-vue/dist/utils/index.js').default;
+const { getStaticPropertyName } = vueUtilities;
+
+export const executeOnVue = vueUtilities.executeOnVue.bind(vueUtilities);
+export const executeOnVueComponent = vueUtilities.executeOnVueComponent.bind(vueUtilities);
+
+/**
+ * Finds the first property with the given name on the object expression node that matches the condition.
+ * @param {object} node The object expression node.
+ * @param {string} name The property name to find.
+ * @param {(p: object) => boolean} condition Predicate the property must satisfy.
+ * @returns {object | undefined} The matching property node, if any.
+ */
+export function getProperty(node, name, condition) {
+  return node.properties.find(
+    (p) => p.type === 'Property' && name === getStaticPropertyName(p) && condition(p),
+  );
+}
+
+/**
+ * Finds the property with the given name whose value is a function expression.
+ * @param {object} rootNode The object expression node.
+ * @param {string} name The property name to find.
+ * @returns {object | undefined} The matching property node, if any.
+ */
+export function getFunctionWithName(rootNode, name) {
+  return getProperty(
+    rootNode,
+    name,
+    (item) => item.value.type === 'ArrowFunctionExpression' || item.value.type === 'FunctionExpression',
+  );
+}
+
+/**
+ * Returns true if the child node is located inside the function node.
+ * @param {object} function_ The function property node.
+ * @param {object} child The node to check.
+ * @returns {boolean} Whether the child is inside the function.
+ */
+export function isInFunction(function_, child) {
+  return (
+    function_.value.type === 'FunctionExpression'
+    && child != null
+    && child.loc.start.line >= function_.value.loc.start.line
+    && child.loc.end.line <= function_.value.loc.end.line
+  );
+}
+
+/**
+ * Yields all child nodes that appear inside any of the named functions on the object expression.
+ * @param {object} rootNode The object expression node.
+ * @param {Set<string>} functionNames The set of function names to search within.
+ * @param {{name: string, node: object}[]} childNodes The child nodes to look for.
+ * @yields {{name: string, node: object, func: object, funcName: string}} Each matching child.
+ */
+export function* getFunctionWithChild(rootNode, functionNames, childNodes) {
+  const functionNodes = rootNode.properties.filter(
+    (p) => p.type === 'Property' && (functionNames.size === 0 || functionNames.has(getStaticPropertyName(p))),
+  );
+
+  for (const function_ of functionNodes) {
+    for (const { name, node: child } of childNodes) {
+      const functionName = getStaticPropertyName(function_);
+      if (!functionName) {
+        continue;
+      }
+
+      if (isInFunction(function_, child)) {
+        yield { name, node: child, func: function_, funcName: functionName };
+      }
+    }
+  }
+}
+
+/**
+ * Gets the first and last tokens of a node, expanding outward through any wrapping parentheses.
+ * @param {object} sourceCode The ESLint source code object.
+ * @param {object} node The node whose tokens to retrieve.
+ * @returns {{first: object, last: object}} The outermost first and last tokens.
+ */
+export function getFirstAndLastTokens(sourceCode, node) {
+  let first = sourceCode.getFirstToken(node);
+  let last = sourceCode.getLastToken(node);
+
+  while (true) {
+    const previous = sourceCode.getTokenBefore(first);
+    const next = sourceCode.getTokenAfter(last);
+    if (previous?.type === 'Punctuator' && previous.value === '(' && next?.type === 'Punctuator' && next.value === ')') {
+      first = previous;
+      last = next;
+    }
+    else {
+      return { first, last };
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "xmlbuilder": "^15.1.1"
       },
       "devDependencies": {
-        "@eslint/compat": "^2.1.0",
         "@eslint/js": "~9.39.3",
         "@eslint/markdown": "~8.0.2",
         "@stylistic/eslint-plugin": "~5.10.0",
@@ -54,7 +53,6 @@
         "eslint-plugin-import-x": "~4.16.2",
         "eslint-plugin-jsdoc": "~63.0.0",
         "eslint-plugin-jsonc": "~3.2.0",
-        "eslint-plugin-nuxt": "~4.0.0",
         "eslint-plugin-promise": "~7.3.0",
         "eslint-plugin-sonarjs": "~4.0.3",
         "eslint-plugin-unicorn": "~65.0.1",
@@ -3054,40 +3052,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/compat": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
-      "integrity": "sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^1.2.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "peerDependencies": {
-        "eslint": "^8.40 || 9 || 10"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@eslint/compat/node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-array": {
@@ -11052,129 +11016,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/eslint-plugin-nuxt": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-nuxt/-/eslint-plugin-nuxt-4.0.0.tgz",
-      "integrity": "sha512-v3Vwdk8YKe52bAz8eSIDqQuTtfL/T1r9dSl1uhC5SyR5pgLxgKkQdxXVf/Bf6Ax7uyd9rHqiAuYVdqqDb7ILdA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-plugin-vue": "^9.4.0",
-        "semver": "^7.3.7",
-        "vue-eslint-parser": "^9.0.3"
-      }
-    },
-    "node_modules/eslint-plugin-nuxt/node_modules/eslint-plugin-vue": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.33.0.tgz",
-      "integrity": "sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "globals": "^13.24.0",
-        "natural-compare": "^1.4.0",
-        "nth-check": "^2.1.1",
-        "postcss-selector-parser": "^6.0.15",
-        "semver": "^7.6.3",
-        "vue-eslint-parser": "^9.4.3",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-nuxt/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-nuxt/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-nuxt/node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-plugin-nuxt/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-nuxt/node_modules/vue-eslint-parser": {
-      "version": "9.4.3",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
-      "integrity": "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "eslint-scope": "^7.1.1",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
-        "esquery": "^1.4.0",
-        "lodash": "^4.17.21",
-        "semver": "^7.3.6"
-      },
-      "engines": {
-        "node": "^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=6.0.0"
       }
     },
     "node_modules/eslint-plugin-promise": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "xmlbuilder": "^15.1.1"
   },
   "devDependencies": {
-    "@eslint/compat": "^2.1.0",
     "@eslint/js": "~9.39.3",
     "@eslint/markdown": "~8.0.2",
     "@stylistic/eslint-plugin": "~5.10.0",
@@ -84,7 +83,6 @@
     "eslint-plugin-import-x": "~4.16.2",
     "eslint-plugin-jsdoc": "~63.0.0",
     "eslint-plugin-jsonc": "~3.2.0",
-    "eslint-plugin-nuxt": "~4.0.0",
     "eslint-plugin-promise": "~7.3.0",
     "eslint-plugin-sonarjs": "~4.0.3",
     "eslint-plugin-unicorn": "~65.0.1",


### PR DESCRIPTION
[eslint-plugin-nuxt](https://github.com/nuxt/eslint-plugin-nuxt) is no longer maintained, and [@nuxt/eslint-plugin](https://github.com/nuxt/eslint/tree/main/packages/eslint-plugin) is only intended for Nuxt v3+, which we can't yet use.

Since `eslint-plugin-nuxt` is blocking the ESLint v10 update, let's inline those rules to the repo while we're still on Nuxt v2.