### PR TITLE
Add `fixture-json-array-format` internal ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ import eslintPluginUnicorn from 'eslint-plugin-unicorn';
 import eslintPluginVue from 'eslint-plugin-vue';
 import eslintPluginVueA11y from 'eslint-plugin-vuejs-accessibility';
 import globals from 'globals';
+import fixtureJsonArrayFormatRule from './lib/internal-eslint-rules/fixture-json-array-format.js';
 
 const eslintPluginNuxtConfigRecommended = {
   files: ['**/*.{js,vue}'],
@@ -473,6 +474,13 @@ export default [
   },
   {
     files: ['fixtures/**/*.json'],
+    plugins: {
+      ofl: {
+        rules: {
+          'fixture-json-array-format': fixtureJsonArrayFormatRule,
+        },
+      },
+    },
     rules: {
       // allow alignment of pixel keys in matrix
       '@stylistic/no-multi-spaces': ['error', {
@@ -482,6 +490,7 @@ export default [
       }],
       'jsonc/array-bracket-spacing': 'off',
 
+      'ofl/fixture-json-array-format': 'error',
       'unicorn/prevent-abbreviations': 'off',
     },
   },

--- a/fixtures/ayrton/magicblade-fx.json
+++ b/fixtures/ayrton/magicblade-fx.json
@@ -197,78 +197,50 @@
           "dmxRange": [8, 39],
           "type": "ColorPreset",
           "comment": "Red -> Yellow",
-          "colorsStart": [
-            "#ff0000"
-          ],
-          "colorsEnd": [
-            "#ffff00"
-          ]
+          "colorsStart": ["#ff0000"],
+          "colorsEnd": ["#ffff00"]
         },
         {
           "dmxRange": [40, 71],
           "type": "ColorPreset",
           "comment": "Yellow -> Green",
-          "colorsStart": [
-            "#ffff00"
-          ],
-          "colorsEnd": [
-            "#00ff00"
-          ]
+          "colorsStart": ["#ffff00"],
+          "colorsEnd": ["#00ff00"]
         },
         {
           "dmxRange": [72, 103],
           "type": "ColorPreset",
           "comment": "Green -> Cyan",
-          "colorsStart": [
-            "#00ff00"
-          ],
-          "colorsEnd": [
-            "#00ffff"
-          ]
+          "colorsStart": ["#00ff00"],
+          "colorsEnd": ["#00ffff"]
         },
         {
           "dmxRange": [104, 135],
           "type": "ColorPreset",
           "comment": "Cyan -> Blue",
-          "colorsStart": [
-            "#00ffff"
-          ],
-          "colorsEnd": [
-            "#0000ff"
-          ]
+          "colorsStart": ["#00ffff"],
+          "colorsEnd": ["#0000ff"]
         },
         {
           "dmxRange": [136, 167],
           "type": "ColorPreset",
           "comment": "Blue -> Magenta",
-          "colorsStart": [
-            "#0000ff"
-          ],
-          "colorsEnd": [
-            "#ff00ff"
-          ]
+          "colorsStart": ["#0000ff"],
+          "colorsEnd": ["#ff00ff"]
         },
         {
           "dmxRange": [168, 199],
           "type": "ColorPreset",
           "comment": "Magenta -> Red",
-          "colorsStart": [
-            "#ff00ff"
-          ],
-          "colorsEnd": [
-            "#ff0000"
-          ]
+          "colorsStart": ["#ff00ff"],
+          "colorsEnd": ["#ff0000"]
         },
         {
           "dmxRange": [200, 231],
           "type": "ColorPreset",
           "comment": "Red -> White",
-          "colorsStart": [
-            "#ff0000"
-          ],
-          "colorsEnd": [
-            "#ffffff"
-          ]
+          "colorsStart": ["#ff0000"],
+          "colorsEnd": ["#ffffff"]
         },
         {
           "dmxRange": [232, 255],

--- a/lib/internal-eslint-rules/fixture-json-array-format.js
+++ b/lib/internal-eslint-rules/fixture-json-array-format.js
@@ -20,29 +20,23 @@ export default {
 
     return {
       JSONProperty(node) {
-        const keyName = node.key.type === 'JSONLiteral' ? node.key.value : node.key.name;
-
-        if (!allKeys.has(keyName)) {
-          return;
-        }
-
+        const keyName = node.key.value;
         const { value } = node;
-        if (value.type !== 'JSONArrayExpression') {
+
+        if (
+          !allKeys.has(keyName)
+          || value.type !== 'JSONArrayExpression'
+          || value.loc.start.line === value.loc.end.line
+        ) {
           return;
         }
-
-        if (value.loc.start.line === value.loc.end.line) {
-          return;
-        }
-
-        const { sourceCode } = context;
 
         context.report({
           node: value,
           messageId: 'shouldBeSingleLine',
           data: { key: keyName },
           fix(fixer) {
-            const elementTexts = value.elements.map((element) => sourceCode.getText(element));
+            const elementTexts = value.elements.map((element) => context.sourceCode.getText(element));
             return fixer.replaceText(value, `[${elementTexts.join(', ')}]`);
           },
         });

--- a/lib/internal-eslint-rules/fixture-json-array-format.js
+++ b/lib/internal-eslint-rules/fixture-json-array-format.js
@@ -1,0 +1,52 @@
+/** @import * as eslint from 'eslint'; */
+
+/** @type {eslint.Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'layout',
+    fixable: 'whitespace',
+    docs: {
+      description: 'Require specific array properties in fixture JSON files to be on a single line.',
+    },
+    schema: [],
+    messages: {
+      shouldBeSingleLine: 'Array "{{key}}" should be on a single line.',
+    },
+  },
+  create(context) {
+    const numberArrayKeys = new Set(['dmxRange', 'range', 'dimensions', 'spacing', 'degreesMinMax']);
+    const stringArrayKeys = new Set(['categories', 'authors', 'fineChannelAliases', 'colorsStart', 'colorsEnd', 'colors']);
+    const allKeys = new Set([...numberArrayKeys, ...stringArrayKeys]);
+
+    return {
+      JSONProperty(node) {
+        const keyName = node.key.type === 'JSONLiteral' ? node.key.value : node.key.name;
+
+        if (!allKeys.has(keyName)) {
+          return;
+        }
+
+        const { value } = node;
+        if (value.type !== 'JSONArrayExpression') {
+          return;
+        }
+
+        if (value.loc.start.line === value.loc.end.line) {
+          return;
+        }
+
+        const { sourceCode } = context;
+
+        context.report({
+          node: value,
+          messageId: 'shouldBeSingleLine',
+          data: { key: keyName },
+          fix(fixer) {
+            const elementTexts = value.elements.map((element) => sourceCode.getText(element));
+            return fixer.replaceText(value, `[${elementTexts.join(', ')}]`);
+          },
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
Since more and more fixtures are likely written by LLMs (e.g. #5831), we need stronger guardrails for consistent fixture file formatting.