### PR TITLE
Add fixture `kadence/350mm-strobe`

### DIFF
--- a/fixtures/kadence/350mm-strobe.json
+++ b/fixtures/kadence/350mm-strobe.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "350MM-STROBE",
+  "shortName": "350MM-STROBE",
+  "categories": ["Strobe"],
+  "meta": {
+    "authors": ["Kadence"],
+    "createDate": "2026-06-13",
+    "lastModifyDate": "2026-06-13"
+  },
+  "links": {
+    "manual": [
+      "https://kadence.in/wp-content/uploads/2024/05/350MM-STROBE.pdf?srsltid=AfmBOooitOKipEzscZB5phOtSIvLBvA9duKIX0r3T2NAcwYqpSskvsRD"
+    ],
+    "productPage": [
+      "https://kadence.in/wp-content/uploads/2024/05/350MM-STROBE.pdf?srsltid=AfmBOooitOKipEzscZB5phOtSIvLBvA9duKIX0r3T2NAcwYqpSskvsRD"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Shutter / Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "ColorPreset"
+      }
+    },
+    "Color Macros 2": {
+      "name": "Color Macros",
+      "capability": {
+        "type": "ColorPreset"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Standard",
+      "channels": [
+        "Dimmer",
+        "Shutter / Strobe",
+        "Color Macros",
+        "Color Macros 2"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -288,6 +288,10 @@
     "name": "JB Systems",
     "website": "https://jb-systems.eu/"
   },
+  "kadence": {
+    "name": "Kadence",
+    "website": "https://kadence.in/wp-content/uploads/2024/05/350MM-STROBE.pdf?srsltid=AfmBOooitOKipEzscZB5phOtSIvLBvA9duKIX0r3T2NAcwYqpSskvsRD"
+  },
   "kam": {
     "name": "KAM",
     "comment": "No website - no longer trading"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `kadence/350mm-strobe`

### Fixture warnings / errors

* kadence/350mm-strobe
  - ❌ URL 'https://kadence.in/wp-content/uploads/2024/05/350MM-STROBE.pdf?srsltid=AfmBOooitOKipEzscZB5phOtSIvLBvA9duKIX0r3T2NAcwYqpSskvsRD' is used in multiple link types: manual, productPage.
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **Kadence**!