### PR TITLE
Update ADJ product links to use correct redirect URLs

### DIFF
--- a/fixtures/american-dj/12p-hex-ip.json
+++ b/fixtures/american-dj/12p-hex-ip.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/11451/ADJ%2012P%20Hex%20IP%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/12p-hex-ip"
+      "https://www.adj.com/products/12p-hex-ip"
     ],
     "video": [
       "https://www.youtube.com/watch?v=NOuPRgtXDfg",

--- a/fixtures/american-dj/18p-hex-ip.json
+++ b/fixtures/american-dj/18p-hex-ip.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/11452/ADJ%2018P%20Hex%20IP%20-%20User%20Manual%20.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/18p-hex-ip"
+      "https://www.adj.com/products/18p-hex-ip"
     ],
     "video": [
       "https://www.youtube.com/watch?v=NOuPRgtXDfg",

--- a/fixtures/american-dj/7p-hex-ip.json
+++ b/fixtures/american-dj/7p-hex-ip.json
@@ -13,7 +13,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/11448/ADJ%207P%20Hex%20IP%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/7p-hex-ip"
+      "https://www.adj.com/products/7p-hex-ip"
     ],
     "video": [
       "https://www.youtube.com/watch?v=NOuPRgtXDfg",

--- a/fixtures/american-dj/cob-cannon-wash.json
+++ b/fixtures/american-dj/cob-cannon-wash.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/8775/COB%20CANNON%20WASH%20-%20USER%20MANUAL.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/cob-cannon-wash"
+      "https://www.adj.com/products/cob-cannon-wash"
     ]
   },
   "physical": {

--- a/fixtures/american-dj/crazy-pocket-8.json
+++ b/fixtures/american-dj/crazy-pocket-8.json
@@ -13,7 +13,7 @@
       "https://cdb.s3-us-west-1.amazonaws.com/ItemRelatedFiles/8887/crazy_pocket_8.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/crazy-pocket-8"
+      "https://www.adj.com/products/crazy-pocket-8"
     ],
     "video": [
       "https://www.youtube.com/watch?v=6P0B1ANc_I4",

--- a/fixtures/american-dj/dekker-led.json
+++ b/fixtures/american-dj/dekker-led.json
@@ -13,7 +13,7 @@
       "https://cdb.s3-us-west-1.amazonaws.com/ItemRelatedFiles/7156/dekker_led.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/dekker-led"
+      "https://www.adj.com/products/dekker-led"
     ],
     "video": [
       "https://www.youtube.com/watch?v=vq36Zvue0dU"

--- a/fixtures/american-dj/dotz-par.json
+++ b/fixtures/american-dj/dotz-par.json
@@ -13,7 +13,7 @@
       "https://cdb.s3.amazonaws.com/ItemRelatedFiles/8795/ADJ%20Dotz%20Par%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/dotz-par"
+      "https://www.adj.com/products/dotz-par"
     ],
     "video": [
       "https://www.youtube.com/watch?v=0KXL39CwBp8"

--- a/fixtures/american-dj/encore-lp12z-ip.json
+++ b/fixtures/american-dj/encore-lp12z-ip.json
@@ -14,7 +14,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/13583/ADJ%20Encore%20LP12Z%20IP%20-%20DMX%20Traits.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/encore-lp12z-ip"
+      "https://www.adj.com/products/encore-lp12z-ip"
     ],
     "video": [
       "https://www.youtube.com/watch?v=f_LbX1cYPYw",

--- a/fixtures/american-dj/encore-profile-1000-ww.json
+++ b/fixtures/american-dj/encore-profile-1000-ww.json
@@ -13,7 +13,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/8872/ADJ%20Encore%20Profile%201000%20WW%20-%20User%20Manual%2006-06-2023.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/encore-profile-1000-ww"
+      "https://www.adj.com/products/encore-profile-1000-ww"
     ],
     "video": [
       "https://www.youtube.com/watch?v=zz6L0bJZoF8",

--- a/fixtures/american-dj/flat-par-qa12.json
+++ b/fixtures/american-dj/flat-par-qa12.json
@@ -13,7 +13,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/7028/flat_par_qa12.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/flat-par-qa12"
+      "https://www.adj.com/products/flat-par-qa12"
     ]
   },
   "physical": {

--- a/fixtures/american-dj/flat-par-qa12xs.json
+++ b/fixtures/american-dj/flat-par-qa12xs.json
@@ -16,7 +16,7 @@
       "https://www.youtube.com/watch?v=JklRIKHLV3Y"
     ],
     "productPage": [
-      "https://www.adj.com/flat-par-qa12xs"
+      "https://www.adj.com/products/flat-par-qa12xs"
     ]
   },
   "physical": {

--- a/fixtures/american-dj/fog-fury-jett-pro.json
+++ b/fixtures/american-dj/fog-fury-jett-pro.json
@@ -13,7 +13,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/10687/Fog%20Fury%20Jett%20Pro%20-%20User%20Manual%20(08-10-2022).pdf"
     ],
     "productPage": [
-      "https://www.adj.com/fog-fury-jett-pro"
+      "https://www.adj.com/products/fog-fury-jett-pro"
     ],
     "video": [
       "https://www.youtube.com/watch?v=dN6IbP1x5Fo",

--- a/fixtures/american-dj/illusion-dotz-4-4.json
+++ b/fixtures/american-dj/illusion-dotz-4-4.json
@@ -17,7 +17,7 @@
       "https://cdb.s3.amazonaws.com/ItemRelatedFiles/8697/Illusion%20Dotz%204.4%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/illusion-dotz-4-4"
+      "https://www.adj.com/products/illusion-dotz-4-4"
     ],
     "video": [
       "https://www.youtube.com/watch?v=NbQMI2cSr00",

--- a/fixtures/american-dj/inno-pocket-fusion.json
+++ b/fixtures/american-dj/inno-pocket-fusion.json
@@ -13,7 +13,7 @@
       "https://cdb.s3-us-west-1.amazonaws.com/ItemRelatedFiles/8780/inno_pocket_fusion.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/inno-pocket-fusion"
+      "https://www.adj.com/products/inno-pocket-fusion"
     ],
     "video": [
       "https://www.youtube.com/watch?v=hLYHfn-D5aY",

--- a/fixtures/american-dj/inno-pocket-spot.json
+++ b/fixtures/american-dj/inno-pocket-spot.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/6902/inno_pocket_spot.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/inno-pocket-spot"
+      "https://www.adj.com/products/inno-pocket-spot"
     ],
     "video": [
       "https://www.youtube.com/watch?v=eLkPO3C_jVQ"

--- a/fixtures/american-dj/inno-spot-pro.json
+++ b/fixtures/american-dj/inno-spot-pro.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/6922/inno_spot_pro.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/inno-spot-pro"
+      "https://www.adj.com/products/inno-spot-pro"
     ],
     "video": [
       "https://www.youtube.com/watch?v=qZIVSOfQyBE"

--- a/fixtures/american-dj/mega-bar-50rgb-rc.json
+++ b/fixtures/american-dj/mega-bar-50rgb-rc.json
@@ -12,7 +12,7 @@
       "https://cdb.s3.amazonaws.com/ItemRelatedFiles/7103/mega_bar_50rgb_rc.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/mega-bar-50rgb-rc"
+      "https://www.adj.com/products/mega-bar-50rgb-rc"
     ],
     "video": [
       "https://www.youtube.com/watch?v=8Px1FM_7BU8"

--- a/fixtures/american-dj/mega-bar-50rgb.json
+++ b/fixtures/american-dj/mega-bar-50rgb.json
@@ -12,7 +12,7 @@
       "https://cdb.s3-us-west-1.amazonaws.com/ItemRelatedFiles/7191/mega_bar_50rgb.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/mega-bar-50-rgb"
+      "https://www.adj.com/products/mega-bar-50-rgb"
     ],
     "video": [
       "https://www.youtube.com/watch?v=F4gV5-FdGl0"

--- a/fixtures/american-dj/mega-bar-rgba.json
+++ b/fixtures/american-dj/mega-bar-rgba.json
@@ -13,7 +13,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/6989/ADJ%20Mega%20Bar%20RGBA%20-%20User%20Manual%202023-04-11.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/mega-bar-rgba"
+      "https://www.adj.com/products/mega-bar-rgba"
     ],
     "video": [
       "https://www.youtube.com/watch?v=WXp4BXd6yC8"

--- a/fixtures/american-dj/mega-hex-par.json
+++ b/fixtures/american-dj/mega-hex-par.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/11285/ADJ%20Mega%20Hex%20Par%20-%20USER%20MANUAL%2006-19-2023.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/mega-hex-par"
+      "https://www.adj.com/products/mega-hex-par"
     ],
     "video": [
       "https://www.youtube.com/watch?v=VOx_gAC7YgA",

--- a/fixtures/american-dj/mega-par-profile-plus.json
+++ b/fixtures/american-dj/mega-par-profile-plus.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/8761/ADJ%20Mega%20Par%20Profile%20Plus%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/mega-par-profile-plus"
+      "https://www.adj.com/products/mega-par-profile-plus"
     ],
     "video": [
       "https://www.youtube.com/watch?v=g0ON1EzrZzQ"

--- a/fixtures/american-dj/mega-tripar-profile-plus.json
+++ b/fixtures/american-dj/mega-tripar-profile-plus.json
@@ -12,7 +12,7 @@
       "https://cdb.s3-us-west-1.amazonaws.com/ItemRelatedFiles/8800/Mega%20TRIPAR%20Profile%20Plus.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/mega-tripar-profile-plus"
+      "https://www.adj.com/products/mega-tripar-profile-plus"
     ],
     "video": [
       "https://www.youtube.com/watch?v=9z1gcBc233Q"

--- a/fixtures/american-dj/mega-tripar-profile.json
+++ b/fixtures/american-dj/mega-tripar-profile.json
@@ -12,7 +12,7 @@
       "https://cdb.s3-us-west-1.amazonaws.com/ItemRelatedFiles/7049/mega_tripar_profile.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/mega-tripar-profile"
+      "https://www.adj.com/products/mega-tripar-profile"
     ],
     "video": [
       "https://www.youtube.com/watch?v=NFXLK0EjYCQ"

--- a/fixtures/american-dj/mod-hex100.json
+++ b/fixtures/american-dj/mod-hex100.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/11302/ADJ%20MOD%20HEX100%20User%20Manual%20.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/mod-hex100"
+      "https://www.adj.com/products/mod-hex100"
     ],
     "video": [
       "https://www.youtube.com/watch?v=-X430bUWt50"

--- a/fixtures/american-dj/pocket-pro.json
+++ b/fixtures/american-dj/pocket-pro.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/11246/ADJ%20Pocket%20Pro%20%20Pocket%20Pro%20Pearl%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/pocket-pro"
+      "https://www.adj.com/products/pocket-pro"
     ],
     "video": [
       "https://www.youtube.com/watch?v=KOGvGZemSUA"

--- a/fixtures/american-dj/quad-phase-hp.json
+++ b/fixtures/american-dj/quad-phase-hp.json
@@ -13,7 +13,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/6976/ADJ%20Quad%20Phase%20HP%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/quad-phase-hp"
+      "https://www.adj.com/products/quad-phase-hp"
     ],
     "video": [
       "https://www.youtube.com/watch?v=g3qTCXyDvK8",

--- a/fixtures/american-dj/saber-spot-rgbw.json
+++ b/fixtures/american-dj/saber-spot-rgbw.json
@@ -14,7 +14,7 @@
       "https://cdb.s3.amazonaws.com/ItemRelatedFiles/10530/Saber%20Spot%20RGBW%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/saber-spot-rgbw"
+      "https://www.adj.com/products/saber-spot-rgbw"
     ],
     "video": [
       "https://www.youtube.com/watch?v=lkNhECfzFqo",

--- a/fixtures/american-dj/starburst.json
+++ b/fixtures/american-dj/starburst.json
@@ -13,7 +13,7 @@
       "https://cdb.s3.amazonaws.com/ItemRelatedFiles/8787/ADJ%20Starburst%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/starburst"
+      "https://www.adj.com/products/starburst"
     ],
     "video": [
       "https://www.youtube.com/watch?v=SetHSmR7J6c",

--- a/fixtures/american-dj/stinger-ii.json
+++ b/fixtures/american-dj/stinger-ii.json
@@ -13,7 +13,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/8885/ADJ%20Stinger%20II%20-%20User%20Manual%202023-08-11.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/stinger-ii"
+      "https://www.adj.com/products/stinger-ii"
     ],
     "video": [
       "https://www.youtube.com/watch?v=XCDmUI576hg",

--- a/fixtures/american-dj/stinger-spot.json
+++ b/fixtures/american-dj/stinger-spot.json
@@ -13,7 +13,7 @@
       "https://cdb.s3.amazonaws.com/ItemRelatedFiles/11167/ADJ%20Stinger%20Spot%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/stinger-spot"
+      "https://www.adj.com/products/stinger-spot"
     ],
     "video": [
       "https://www.youtube.com/watch?v=nOYqH2oVWZg"

--- a/fixtures/american-dj/uv-eco-bar.json
+++ b/fixtures/american-dj/uv-eco-bar.json
@@ -14,7 +14,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/6914/ADJ%20Eco%20UV%20Bar%20DMX%20-%20User%20Manual.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/eco-uv-bar-dmx"
+      "https://www.adj.com/products/eco-uv-bar-dmx"
     ],
     "video": [
       "https://www.youtube.com/watch?v=mEH-cVF_iB4"

--- a/fixtures/american-dj/vbar-pak.json
+++ b/fixtures/american-dj/vbar-pak.json
@@ -12,7 +12,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/8659/vbar_pak.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/vbar-pak"
+      "https://www.adj.com/products/vbar-pak"
     ],
     "video": [
       "https://www.youtube.com/watch?v=bah_MlTImIg"

--- a/fixtures/american-dj/vizi-q-wash7.json
+++ b/fixtures/american-dj/vizi-q-wash7.json
@@ -14,7 +14,7 @@
       "https://d295jznhem2tn9.cloudfront.net/ItemRelatedFiles/10532/ADJ%20VIZI%20Q%20WASH7%20-%20USER%20MANUAL%20.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/vizi-q-wash7"
+      "https://www.adj.com/products/vizi-q-wash7"
     ],
     "video": [
       "https://www.youtube.com/watch?v=EHeTZ_G_8zM"

--- a/fixtures/eliminator/stealth-beam.json
+++ b/fixtures/eliminator/stealth-beam.json
@@ -17,7 +17,7 @@
       "https://cdb.s3.amazonaws.com/ItemRelatedFiles/13271/Stealth%20Beam%20(1st%20Ed.).pdf"
     ],
     "productPage": [
-      "https://www.adj.com/stealth-beam"
+      "https://www.adj.com/products/stealth-beam"
     ],
     "video": [
       "https://www.youtube.com/watch?v=A2l0YIFRARA",

--- a/fixtures/eliminator/stealth-wash-zoom.json
+++ b/fixtures/eliminator/stealth-wash-zoom.json
@@ -12,7 +12,7 @@
       "https://cdb.s3.amazonaws.com/ItemRelatedFiles/13274/Stealth%20Wash%20Zoom%20User%20Manual%20Revised%20092018.pdf"
     ],
     "productPage": [
-      "https://www.adj.com/stealth-wash-zoom"
+      "https://www.adj.com/products/stealth-wash-zoom"
     ],
     "video": [
       "https://www.youtube.com/watch?v=M7ALeJ3_jGc",

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -149,7 +149,7 @@
   },
   "eliminator": {
     "name": "Eliminator Lighting",
-    "website": "https://www.adj.com/eliminator-lighting"
+    "website": "https://www.adj.com/collections/eliminator-lighting"
   },
   "empire-lighting": {
     "name": "EMPiRE Lighting",


### PR DESCRIPTION
- 34 fixture files: productPage URLs updated from adj.com/... to www.adj.com/products/...
- manufacturers.json: eliminator lighting URL updated to /collections/eliminator-lighting

Found via #999