### PR TITLE
Run independent CI steps in parallel

### DIFF
--- a/.github/workflows/external-links-checker.yaml
+++ b/.github/workflows/external-links-checker.yaml
@@ -20,13 +20,14 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
-      - name: Check external links
-        run: node --tls-min-v1.0 tests/external-links.js
-        env:
-          GITHUB_USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_BROKEN_LINKS_ISSUE_NUMBER: 999
-          NODE_ENV: production
-      - name: Check Markdown Links in all files
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-verbose-mode: 'yes'
+      - parallel:
+          - name: Check external links
+            run: node --tls-min-v1.0 tests/external-links.js
+            env:
+              GITHUB_USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              GITHUB_BROKEN_LINKS_ISSUE_NUMBER: 999
+              NODE_ENV: production
+          - name: Check Markdown Links in all files
+            uses: gaurav-nelson/github-action-markdown-link-check@v1
+            with:
+              use-verbose-mode: 'yes'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,18 +19,19 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
-      - name: Run ESLint
-        run: npm run lint:eslint
-      - name: Run Stylelint
-        run: npm run lint:stylelint -- --formatter compact
-      - name: Run dmx-value-scaling test
-        run: npm run test:dmx-value-scaling
-      - name: Run fixtures-valid test
-        run: npm run test:fixtures-valid
-      - name: Run http-status test
-        run: npm run test:http-status
-      - name: Run built-files-committed test
-        run: npm run test:built-files-committed
+      - parallel:
+          - name: Run ESLint
+            run: npm run lint:eslint
+          - name: Run Stylelint
+            run: npm run lint:stylelint -- --formatter compact
+          - name: Run dmx-value-scaling test
+            run: npm run test:dmx-value-scaling
+          - name: Run fixtures-valid test
+            run: npm run test:fixtures-valid
+          - name: Run http-status test
+            run: npm run test:http-status
+          - name: Run built-files-committed test
+            run: npm run test:built-files-committed
   status:
     name: Status
     runs-on: ubuntu-latest
@@ -56,12 +57,13 @@ jobs:
           npm ci
       - name: Build
         run: npm run build
-      - name: Run export-diff test
-        run: node tests/github/export-diff.js
-      - name: Run exports-valid test
-        run: node tests/github/exports-valid.js
-      - name: Run schema-version-reminder
-        run: node tests/github/schema-version-reminder.js
+      - parallel:
+          - name: Run export-diff test
+            run: node tests/github/export-diff.js
+          - name: Run exports-valid test
+            run: node tests/github/exports-valid.js
+          - name: Run schema-version-reminder
+            run: node tests/github/schema-version-reminder.js
   markdown-link-check:
     name: Markdown Links
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use GitHub Actions' new step-level [`parallel:` keyword](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/) to run independent lint/test steps concurrently instead of sequentially. `parallel:` is shorthand for marking each grouped step `background: true` with an implicit `wait` afterwards.

## Changes

**`.github/workflows/test.yaml`**
- `required` job: the 6 lint/test steps (ESLint, Stylelint, dmx-value-scaling, fixtures-valid, http-status, built-files-committed) now run in parallel after `Build`.
- `status` job: the 3 checks (export-diff, exports-valid, schema-version-reminder) now run in parallel after `Build`.

**`.github/workflows/external-links-checker.yaml`**
- The external-link check and the Markdown-link check now run in parallel after `Build`.

The `Checkout` → `Setup Node` → `Install` → `Build` prefix stays sequential since the parallel steps depend on the build output.

## Notes
- The grouped steps are independent: `eslint --cache` only touches its own cache file, the rest are read-only validations.
- GitHub caps concurrent background steps at 10 per job; the largest group here is 6.
- Trade-off: on failure the job still fails (at the implicit wait), but the whole group runs to completion rather than fail-fast, so all failures surface at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)