### PR TITLE
Add fixture meta update reminder 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,8 @@ jobs:
         run: node tests/github/exports-valid.js
       - name: Run schema-version-reminder
         run: node tests/github/schema-version-reminder.js
+      - name: Run metadata-update-reminder
+        run: node tests/github/metadata-update-reminder.js
   markdown-link-check:
     name: Markdown Links
     runs-on: ubuntu-latest

--- a/fixtures/abstract/twister-4.json
+++ b/fixtures/abstract/twister-4.json
@@ -4,7 +4,7 @@
   "shortName": "Twister4",
   "categories": ["Flower", "Color Changer"],
   "meta": {
-    "authors": ["Flo Edelmann", "Felix Edelmann"],
+    "authors": ["Flo Edelmann", "Felix Edelmann", "Luke Nelson"],
     "createDate": "2017-01-24",
     "lastModifyDate": "2022-05-03",
     "importPlugin": {

--- a/fixtures/glp/knv-arc.json
+++ b/fixtures/glp/knv-arc.json
@@ -3,7 +3,7 @@
   "name": "KNV Arc",
   "categories": ["Effect", "Color Changer", "Strobe"],
   "meta": {
-    "authors": ["Flo Edelmann", "Ryan Goodwin"],
+    "authors": ["Flo Edelmann", "Ryan Goodwin", "Luke Nelson"],
     "createDate": "2019-04-07",
     "lastModifyDate": "2023-07-12"
   },

--- a/tests/github/metadata-update-reminder.js
+++ b/tests/github/metadata-update-reminder.js
@@ -58,6 +58,16 @@ try {
 
     const lineNumber = lineIndex + 1; // 1-indexed for the GitHub API
     const oldLine = fileLines[lineIndex];
+
+    // Check that the line is in a diff hunk (otherwise GitHub will reject the comment)
+    const patch = await pullRequest.getFilePatch(filePath);
+    if (patch !== null) {
+      const inHunk = isLineInDiffHunk(patch, lineNumber);
+      if (!inHunk) {
+        console.warn(styleText('yellow', 'Warning:'), `lastModifyDate line ${lineNumber} is not in a diff hunk in ${filePath}; skipping.`);
+        continue;
+      }
+    }
     const updatedLine = oldLine.replace(/"lastModifyDate"\s*:\s*"[^"]*"/, `"lastModifyDate": "${today}"`);
 
     const commentBody = [
@@ -103,4 +113,25 @@ try {
 catch (error) {
   console.error(error);
   process.exit(1);
+}
+
+/**
+ * Check if a line number in the new file is within any diff hunk.
+ * @param {string} patch - The unified diff patch.
+ * @param {number} lineNumber - The 1-indexed line number in the new file.
+ * @returns {boolean} True if the line is within a hunk.
+ */
+function isLineInDiffHunk(patch, lineNumber) {
+  const hunkHeaderRegex = /^@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,(\d+))?\s+@@/gm;
+  let match = hunkHeaderRegex.exec(patch);
+  while (match !== null) {
+    const start = Number.parseInt(match[1], 10);
+    const count = match[2] ? Number.parseInt(match[2], 10) : 1;
+    const end = start + count - 1;
+    if (lineNumber >= start && lineNumber <= end) {
+      return true;
+    }
+    match = hunkHeaderRegex.exec(patch);
+  }
+  return false;
 }

--- a/tests/github/metadata-update-reminder.js
+++ b/tests/github/metadata-update-reminder.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import '../../lib/load-env-file.js';
+
+import { styleText } from 'util';
+import * as pullRequest from './pull-request.js';
+
+try {
+  await pullRequest.checkEnv();
+  await pullRequest.init();
+  const changedComponents = await pullRequest.fetchChangedComponents();
+  const headSha = pullRequest.getHeadSha();
+
+  const addedFixtures = changedComponents.added.fixtures;
+  const modifiedFixtures = changedComponents.modified.fixtures;
+
+  if (addedFixtures.length === 0 && modifiedFixtures.length === 0) {
+    // Nothing to remind about; clear any prior review and exit.
+    await pullRequest.updateReview({
+      fileUrl: new URL(import.meta.url),
+      body: '',
+      comments: [],
+    });
+    process.exit(0);
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  // Build the inline review comments (one per modified fixture).
+  const reviewComments = [];
+
+  const sortedModified = modifiedFixtures.toSorted(([manufacturerA, fixtureA], [manufacturerB, fixtureB]) => {
+    const manufacturerCompare = manufacturerA.localeCompare(manufacturerB);
+    if (manufacturerCompare !== 0) {
+      return manufacturerCompare;
+    }
+    return fixtureA.localeCompare(fixtureB);
+  });
+
+  for (const [manufacturerKey, fixtureKey] of sortedModified) {
+    const filePath = `fixtures/${manufacturerKey}/${fixtureKey}.json`;
+
+    let fileContent;
+    try {
+      fileContent = await pullRequest.getFileContent(filePath, headSha);
+    }
+    catch (error) {
+      console.warn(styleText('yellow', 'Warning:'), `Could not fetch ${filePath} at ${headSha}:`, error.message);
+      continue;
+    }
+
+    const fileLines = fileContent.split('\n');
+    const lineIndex = fileLines.findIndex((line) => line.includes('"lastModifyDate"'));
+    if (lineIndex === -1) {
+      console.warn(styleText('yellow', 'Warning:'), `No "lastModifyDate" line found in ${filePath}; skipping review comment.`);
+      continue;
+    }
+
+    const lineNumber = lineIndex + 1; // 1-indexed for the GitHub API
+    const oldLine = fileLines[lineIndex];
+    const updatedLine = oldLine.replace(/"lastModifyDate"\s*:\s*"[^"]*"/, `"lastModifyDate": "${today}"`);
+
+    const commentBody = [
+      'Update `meta.lastModifyDate` to today.',
+      '',
+      '```suggestion',
+      updatedLine,
+      '```',
+    ].join('\n');
+
+    reviewComments.push({
+      path: filePath,
+      line: lineNumber,
+      side: 'RIGHT',
+      body: commentBody,
+    });
+  }
+
+  // Build the brief review summary body.
+  let summaryBody = 'Some fixture metadata needs updating — see the review comments below for one-click suggestions.';
+
+  if (addedFixtures.length > 0) {
+    const sortedAdded = addedFixtures.toSorted(([manufacturerA, fixtureA], [manufacturerB, fixtureB]) => {
+      const manufacturerCompare = manufacturerA.localeCompare(manufacturerB);
+      if (manufacturerCompare !== 0) {
+        return manufacturerCompare;
+      }
+      return fixtureA.localeCompare(fixtureB);
+    });
+
+    summaryBody += '\n\n**Added fixtures** (no suggestion possible — set `createDate`, `lastModifyDate`, and `authors` manually):\n';
+    for (const [manufacturerKey, fixtureKey] of sortedAdded) {
+      summaryBody += `- \`${manufacturerKey}/${fixtureKey}\`\n`;
+    }
+  }
+
+  await pullRequest.updateReview({
+    fileUrl: new URL(import.meta.url),
+    body: summaryBody,
+    comments: reviewComments,
+  });
+}
+catch (error) {
+  console.error(error);
+  process.exit(1);
+}

--- a/tests/github/pull-request.js
+++ b/tests/github/pull-request.js
@@ -308,6 +308,11 @@ export function getHeadSha() {
  * `test.fileUrl`) is dismissed, and its individual review comments are deleted.
  * This keeps the PR clean across re-runs.
  *
+ * If both `test.body` and `test.comments` are empty, the function only performs cleanup
+ * (dismiss prior reviews, delete orphan comments) and skips creating a new review. This
+ * is useful for "nothing to remind about" cases where a prior review should be cleared
+ * without leaving a stub.
+ *
  * @param {object} test - Information about the test script that wants to update the review.
  * @param {URL} test.fileUrl - URL of the test file. Used to derive the marker.
  * @param {string} test.body - The review summary body (shown once, above the inline comments).
@@ -394,7 +399,12 @@ export async function updateReview(test) {
 
   await Promise.all([...dismissPromises, ...deletePromises]);
 
-  // 3) Post the new review.
+  // 3) Post the new review, unless the caller only wanted cleanup.
+  if (test.body === '' && test.comments.length === 0) {
+    console.log(`Skipping review creation at ${process.env.GITHUB_REPOSITORY}#${process.env.GITHUB_PR_NUMBER} (no body, no comments — cleanup-only mode).`);
+    return undefined;
+  }
+
   console.log(`Creating review at ${process.env.GITHUB_REPOSITORY}#${process.env.GITHUB_PR_NUMBER} with ${test.comments.length} inline comment(s).`);
   return githubClient.rest.pulls.createReview({
     owner: repoOwner,
@@ -431,4 +441,33 @@ export async function getFileContent(filePath, ref) {
   }
 
   return Buffer.from(data.content, 'base64').toString('utf-8');
+}
+
+/**
+ * Fetch the unified diff patch for a file in the PR. Returns null if the patch is not
+ * available (e.g., file too large, binary file, or no diff).
+ * @param {string} filePath - Path of the file relative to the repo root.
+ * @returns {Promise<string|null>} The unified diff patch, or null if not available.
+ */
+export async function getFilePatch(filePath) {
+  // Paginate listFiles to find the file (up to 10 pages × 100 = 1000 files)
+  const filePromises = [];
+  for (let index = 0; index < 10; index++) {
+    filePromises.push(
+      githubClient.rest.pulls.listFiles({
+        owner: repoOwner,
+        repo: repoName,
+        // eslint-disable-next-line camelcase -- required by GitHub API
+        pull_number: process.env.GITHUB_PR_NUMBER,
+        // eslint-disable-next-line camelcase -- required by GitHub API
+        per_page: 100,
+        page: index + 1,
+      }),
+    );
+  }
+
+  const blocks = await Promise.all(filePromises);
+  const files = blocks.flatMap((block) => block.data);
+  const file = files.find((f) => f.filename === filePath);
+  return file ? file.patch : null;
 }

--- a/tests/github/pull-request.js
+++ b/tests/github/pull-request.js
@@ -411,3 +411,24 @@ export async function updateReview(test) {
     })),
   });
 }
+
+/**
+ * Fetch the UTF-8 text content of a file at a specific ref.
+ * @param {string} filePath - Path of the file relative to the repo root.
+ * @param {string} ref - The git ref (branch name, tag, or commit SHA) to fetch from.
+ * @returns {Promise<string>} The file content as a UTF-8 string.
+ */
+export async function getFileContent(filePath, ref) {
+  const { data } = await githubClient.rest.repos.getContent({
+    owner: repoOwner,
+    repo: repoName,
+    path: filePath,
+    ref,
+  });
+
+  if (Array.isArray(data) || data.type !== 'file') {
+    throw new Error(`${filePath} at ${ref} is not a regular file.`);
+  }
+
+  return Buffer.from(data.content, 'base64').toString('utf-8');
+}

--- a/tests/github/pull-request.js
+++ b/tests/github/pull-request.js
@@ -286,3 +286,128 @@ export function appendOrTruncate(lines, newLines, tooLongMessage, trailingLines 
   lines.push(...newLines);
   return false;
 }
+
+/**
+ * @returns {string} The SHA of the head commit of the current pull request.
+ * @throws {Error} If `init()` has not been called.
+ */
+export function getHeadSha() {
+  if (!prData) {
+    throw new Error('init() must be called before getHeadSha().');
+  }
+  return prData.head.sha;
+}
+
+/**
+ * Posts (or updates) a pull request review with a summary body and an array of inline
+ * review comments. Each inline comment may contain a `suggestion` code block, which
+ * only renders GitHub's "Apply suggestion" button when posted via the review API
+ * (not via `updateComment` / `issues.createComment`).
+ *
+ * Cleanup: any prior review whose body starts with the marker (derived from
+ * `test.fileUrl`) is dismissed, and its individual review comments are deleted.
+ * This keeps the PR clean across re-runs.
+ *
+ * @param {object} test - Information about the test script that wants to update the review.
+ * @param {URL} test.fileUrl - URL of the test file. Used to derive the marker.
+ * @param {string} test.body - The review summary body (shown once, above the inline comments).
+ * @param {{path: string, line: number, side?: 'LEFT'|'RIGHT', body: string}[]} test.comments - The inline review comments to attach. Each is anchored to a specific line in a file.
+ * @returns {Promise} A promise that is fulfilled once all GitHub operations have completed.
+ */
+export async function updateReview(test) {
+  if (prData.head.repo.full_name !== prData.base.repo.full_name) {
+    console.warn(styleText('yellow', 'Warning:'), 'This PR is created from a forked repository, so there is no write permission for the repo.');
+    return undefined;
+  }
+
+  const oflRootPath = fileURLToPath(new URL('../../', import.meta.url));
+  const relativeFilePath = path.relative(oflRootPath, fileURLToPath(test.fileUrl));
+  const marker = `<!-- GITHUB-TEST-REVIEW: ${relativeFilePath} -->`;
+
+  // 1) Dismiss any prior reviews from this test.
+  // Paginate up to 5 pages of 100 (500 reviews) — more than enough for typical re-runs,
+  // and prevents silently missing old reviews on long-lived PRs.
+  const reviewPromises = [];
+  for (let index = 0; index < 5; index++) {
+    reviewPromises.push(
+      githubClient.rest.pulls.listReviews({
+        owner: repoOwner,
+        repo: repoName,
+        // eslint-disable-next-line camelcase -- required by GitHub API
+        pull_number: process.env.GITHUB_PR_NUMBER,
+        // eslint-disable-next-line camelcase -- required by GitHub API
+        per_page: 100,
+        page: index + 1,
+      }),
+    );
+  }
+
+  const reviewBlocks = await Promise.all(reviewPromises);
+  const existingReviews = reviewBlocks.flatMap((block) => block.data);
+
+  const dismissPromises = existingReviews
+    .filter((review) => review.body && review.body.startsWith(marker))
+    .map((review) => {
+      console.log(`Dismissing old review ${review.id} at ${process.env.GITHUB_REPOSITORY}#${process.env.GITHUB_PR_NUMBER}.`);
+      return githubClient.rest.pulls.updateReview({
+        owner: repoOwner,
+        repo: repoName,
+        // eslint-disable-next-line camelcase -- required by GitHub API
+        pull_number: process.env.GITHUB_PR_NUMBER,
+        // eslint-disable-next-line camelcase -- required by GitHub API
+        review_id: review.id,
+        state: 'DISMISSED',
+      });
+    });
+
+  // 2) Delete any prior review comments from this test (orphan cleanup).
+  // Paginate using prData.review_comments count, mirroring the updateComment pattern.
+  const commentPromises = [];
+  for (let index = 0; index < prData.review_comments / 100; index++) {
+    commentPromises.push(
+      githubClient.rest.pulls.listReviewComments({
+        owner: repoOwner,
+        repo: repoName,
+        // eslint-disable-next-line camelcase -- required by GitHub API
+        pull_number: process.env.GITHUB_PR_NUMBER,
+        // eslint-disable-next-line camelcase -- required by GitHub API
+        per_page: 100,
+        page: index + 1,
+      }),
+    );
+  }
+
+  const commentBlocks = await Promise.all(commentPromises);
+  const existingComments = commentBlocks.flatMap((block) => block.data);
+
+  const deletePromises = existingComments
+    .filter((comment) => comment.body && comment.body.startsWith(marker))
+    .map((comment) => {
+      console.log(`Deleting old review comment ${comment.id} at ${process.env.GITHUB_REPOSITORY}#${process.env.GITHUB_PR_NUMBER}.`);
+      return githubClient.rest.pulls.deleteReviewComment({
+        owner: repoOwner,
+        repo: repoName,
+        // eslint-disable-next-line camelcase -- required by GitHub API
+        comment_id: comment.id,
+      });
+    });
+
+  await Promise.all([...dismissPromises, ...deletePromises]);
+
+  // 3) Post the new review.
+  console.log(`Creating review at ${process.env.GITHUB_REPOSITORY}#${process.env.GITHUB_PR_NUMBER} with ${test.comments.length} inline comment(s).`);
+  return githubClient.rest.pulls.createReview({
+    owner: repoOwner,
+    repo: repoName,
+    // eslint-disable-next-line camelcase -- required by GitHub API
+    pull_number: process.env.GITHUB_PR_NUMBER,
+    // eslint-disable-next-line camelcase -- required by GitHub API
+    commit_id: getHeadSha(),
+    body: `${marker}\n${test.body}`,
+    event: 'COMMENT',
+    comments: test.comments.map((comment) => ({
+      ...comment,
+      side: comment.side || 'RIGHT',
+    })),
+  });
+}


### PR DESCRIPTION
Similar to the existing [schema-version-reminder](https://github.com/OpenLightingProject/open-fixture-library/blob/master/tests/github/schema-version-reminder.js), this adds a GitHub test that posts a PR reminder to update a fixture's `meta.lastModifyDate` (and `meta.authors` if needed) whenever fixture files are added or modified in the PR.

The reminder is delivered as a single **pull request review** (not a conversation comment), with:

- A brief **summary body** that points to the inline review comments.
- One **inline review comment per modified fixture**, anchored to the `lastModifyDate` line. The body contains a `suggestion` code block with the replacement line, so maintainers can click "Apply suggestion" to commit the change with one click.
- **Added** fixtures are listed in the review summary with a note to set `createDate`, `lastModifyDate`, and `authors` manually (no inline comment — there's no existing line to replace in a new file).
- Removed fixtures are excluded (nothing to update).

This should prevent PRs like #372, where `lastModifyDate` had to be retroactively added to many fixtures.

### Files

- `tests/github/pull-request.js` (adds `getHeadSha`, `updateReview`, `getFileContent`, and `getFilePatch` helpers)
- `tests/github/metadata-update-reminder.js` (new)
- `.github/workflows/test.yaml` (adds one step in the `Status` job)