### PR TITLE
Add fixture `betopper/lpc1818-cri-lime`

### DIFF
--- a/fixtures/betopper/lpc1818-cri-lime.json
+++ b/fixtures/betopper/lpc1818-cri-lime.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LPC1818 CRI/LIME",
+  "shortName": "LPC1818",
+  "categories": ["Color Changer"],
+  "meta": {
+    "authors": ["neuil"],
+    "createDate": "2026-07-01",
+    "lastModifyDate": "2026-07-01"
+  },
+  "links": {
+    "manual": [
+      "https://cdn.shopify.com/s/files/1/0084/5230/9047/files/18x18W_RGBWA_UV_Par_Light_User_Manual_5f020ddd-a8b6-4622-8c62-d83ebe5617d2.pdf?v=1753086383"
+    ],
+    "productPage": [
+      "https://betopperdj.com/fr/products/betopper-lpc1818-upgraded-18x18w-lime-amber-uv-rgb-led-par-light-8pcs?utm_source=google&utm_medium=cpc&utm_campaign=Search-Brand-EU&utm_content=Brand%20product&gad_source=1&gad_campaignid=22502257810&gbraid=0AAAAA_fDo50dbTDsQCGT9ad1-rgYJlviF&gclid=Cj0KCQjw9ZLSBhCcARIsAEhGKgM8fN33LK_f33ylgsl-2mXsyJXtpIas1mPFQ8TIGtl_kgnArW5Kt1saAplxEALw_wcB"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=K6Uy4YdwD98"
+    ]
+  },
+  "physical": {
+    "dimensions": [400, 400, 20],
+    "weight": 2.6,
+    "power": 200,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED",
+      "lumens": 3600
+    }
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "defaultValue": "0%",
+      "highlightValue": "100%",
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "defaultValue": "0%",
+      "highlightValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "defaultValue": "0%",
+      "highlightValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "defaultValue": "0%",
+      "highlightValue": "100%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Lime": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Lime"
+      }
+    },
+    "Amber": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "UV": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    },
+    "Strobe": {
+      "defaultValue": "0%",
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    },
+    "No function": {
+      "defaultValue": "0%",
+      "highlightValue": "0%",
+      "capability": {
+        "type": "NoFunction"
+      }
+    },
+    "Program Speed": {
+      "defaultValue": "0%",
+      "highlightValue": "0%",
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    },
+    "CTO": {
+      "defaultValue": "0%",
+      "capabilities": [
+        {
+          "dmxRange": [0, 15],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [16, 255],
+          "type": "ColorTemperature",
+          "colorTemperatureStart": "cold",
+          "colorTemperatureEnd": "warm"
+        }
+      ]
+    }
+  },
+  "modes": [
+    {
+      "name": "11CH",
+      "shortName": "11CH",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "Lime",
+        "Amber",
+        "UV",
+        "Strobe",
+        "No function",
+        "Program Speed",
+        "CTO"
+      ]
+    }
+  ]
+}

--- a/fixtures/betopper/lpc1818-cri-lime.json
+++ b/fixtures/betopper/lpc1818-cri-lime.json
@@ -10,12 +10,13 @@
   },
   "links": {
     "manual": [
-      "https://cdn.shopify.com/s/files/1/0084/5230/9047/files/18x18W_RGBWA_UV_Par_Light_User_Manual_5f020ddd-a8b6-4622-8c62-d83ebe5617d2.pdf?v=1753086383"
+      "https://cdn.shopify.com/s/files/1/0084/5230/9047/files/Betopper_LPC1818_User_Manual.pdf?v=1780977377"
     ],
     "productPage": [
-      "https://betopperdj.com/fr/products/betopper-lpc1818-upgraded-18x18w-lime-amber-uv-rgb-led-par-light-8pcs?utm_source=google&utm_medium=cpc&utm_campaign=Search-Brand-EU&utm_content=Brand%20product&gad_source=1&gad_campaignid=22502257810&gbraid=0AAAAA_fDo50dbTDsQCGT9ad1-rgYJlviF&gclid=Cj0KCQjw9ZLSBhCcARIsAEhGKgM8fN33LK_f33ylgsl-2mXsyJXtpIas1mPFQ8TIGtl_kgnArW5Kt1saAplxEALw_wcB"
+      "https://betopperdj.com/products/betopper-18x18w-rgbw-amber-uv-6-in-1-led-par-light"
     ],
     "video": [
+      "https://www.youtube.com/watch?v=WYNiD_hgQTg",
       "https://www.youtube.com/watch?v=K6Uy4YdwD98"
     ]
   },

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -62,6 +62,9 @@
     "comment": "Brand of the Tronios Group.",
     "website": "https://www.tronios.com/lighting/filter/brand_beamz/"
   },
+  "betopper": {
+    "name": "Betopper"
+  },
   "big-dipper": {
     "name": "Big Dipper",
     "website": "https://bigdipper-laser.com/"


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `betopper/lpc1818-cri-lime`

### Fixture warnings / errors

* betopper/lpc1818-cri-lime
  - ❌ physical.dimensions are too small (400×400×20mm) for a fixture with a 3-pin DMX connector. Did you accidentally enter the dimensions in centimeters instead of millimeters?
  - ❌ Channel 'Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.
  - ⚠️ Mode '11CH' should have shortName '11ch' instead of '11CH'.
  - ⚠️ Mode '11CH' should have shortName '11ch' instead of '11CH'.


Thank you **neuil**!