### PR TITLE
Add fixture `generic/16bit-dim-strobe-rgbwa-uv-macro`

### DIFF
--- a/fixtures/generic/16bit-dim-strobe-rgbwa-uv-macro.json
+++ b/fixtures/generic/16bit-dim-strobe-rgbwa-uv-macro.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "16bit dim, strobe, RGBWA-UV, macro",
+  "categories": ["Color Changer", "Dimmer"],
+  "meta": {
+    "authors": ["An Millot"],
+    "createDate": "2026-07-04",
+    "lastModifyDate": "2026-07-04"
+  },
+  "links": {
+    "other": [
+      "https://generic.com"
+    ]
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "fineChannelAliases": ["Dimmer fine"],
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Amber": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Amber"
+      }
+    },
+    "UV": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "UV"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "NoFunction"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Generic",
+      "channels": [
+        "Dimmer",
+        "Dimmer fine",
+        "Strobe",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Amber",
+        "UV",
+        "Color Macros"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `generic/16bit-dim-strobe-rgbwa-uv-macro`

### Fixture warnings / errors

* generic/16bit-dim-strobe-rgbwa-uv-macro
  - ❌ Channel 'Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.


Thank you **An Millot**!