### PR TITLE
Add fixture `riukoe/12x8w-rgbw-4in1-indoor-led-par`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -419,6 +419,9 @@
     "comment": "Store brand of German electronics retailer Conrad.",
     "website": "https://www.conrad.at/de/marken/renkforce.html"
   },
+  "riukoe": {
+    "name": "RIUKOE"
+  },
   "robe": {
     "name": "Robe",
     "website": "https://www.robe.cz/",

--- a/fixtures/riukoe/12x8w-rgbw-4in1-indoor-led-par.json
+++ b/fixtures/riukoe/12x8w-rgbw-4in1-indoor-led-par.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "12X8W RGBW 4IN1 INDOOR LED PAR",
+  "shortName": "12X8W",
+  "categories": ["Color Changer", "Effect"],
+  "meta": {
+    "authors": ["MANKI AUDIO"],
+    "createDate": "2026-07-08",
+    "lastModifyDate": "2026-07-08"
+  },
+  "links": {
+    "other": [
+      "https://secure.chamsys.co.uk/fixturefinder/"
+    ]
+  },
+  "rdm": {
+    "modelId": 0
+  },
+  "physical": {
+    "dimensions": [212, 175, 62],
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "defaultValue": 8,
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    },
+    "Effect Speed": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 50],
+          "type": "Generic"
+        },
+        {
+          "dmxRange": [51, 100],
+          "type": "Generic"
+        },
+        {
+          "dmxRange": [101, 150],
+          "type": "Generic"
+        },
+        {
+          "dmxRange": [151, 200],
+          "type": "Generic"
+        },
+        {
+          "dmxRange": [201, 255],
+          "type": "Generic"
+        }
+      ]
+    },
+    "Program Speed": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "LED PAR 4IN1",
+      "shortName": "LED PAR",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Dimmer",
+        "Strobe",
+        "Effect Speed",
+        "Program Speed"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `riukoe/12x8w-rgbw-4in1-indoor-led-par`

### Fixture warnings / errors

* riukoe/12x8w-rgbw-4in1-indoor-led-par
  - ❌ Channel 'Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.


Thank you **MANKI AUDIO**!