### PR TITLE
Add fixture `eurolite/led-ip-pix-strobe-rgb-cw-ww`

### DIFF
--- a/fixtures/eurolite/led-ip-pix-strobe-rgb-cw-ww.json
+++ b/fixtures/eurolite/led-ip-pix-strobe-rgb-cw-ww.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "LED IP PIX Strobe RGB CW WW",
+  "shortName": "LED IP PIX Strobe",
+  "categories": ["Other"],
+  "meta": {
+    "authors": ["G"],
+    "createDate": "2021-07-05",
+    "lastModifyDate": "2025-03-31",
+    "importPlugin": {
+      "plugin": "gdtf",
+      "date": "2026-07-08",
+      "comment": "GDTF v1.2 fixture type ID: 5B17B112-12D0-4331-9280-04956FC78AAF"
+    }
+  },
+  "comment": "LED IP PIX Strobe RGB CW/WW",
+  "availableChannels": {
+    "Dim": {
+      "dmxValueResolution": "32bit",
+      "highlightValue": 4294967295,
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": 0,
+        "brightnessEnd": 1
+      }
+    },
+    "Dim 2": {
+      "name": "Dim",
+      "highlightValue": 255,
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": 0,
+        "brightnessEnd": 1
+      }
+    },
+    "Dim 3": {
+      "name": "Dim",
+      "highlightValue": 255,
+      "capability": {
+        "type": "Intensity",
+        "brightnessStart": 0,
+        "brightnessEnd": 1
+      }
+    },
+    "R": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "G": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "B": {
+      "highlightValue": 255,
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "32ch",
+      "channels": [
+        "R",
+        "G",
+        "B"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `eurolite/led-ip-pix-strobe-rgb-cw-ww`

### Fixture warnings / errors

* eurolite/led-ip-pix-strobe-rgb-cw-ww
  - ❌ File does not match schema: fixture/availableChannels/Dim/dmxValueResolution "32bit" must be equal to one of [8bit, 16bit, 24bit]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessStart 0 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessStart 0 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessEnd 1 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim/capability/brightnessEnd 1 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim must have property fineChannelAliases when property dmxValueResolution is present
  - ❌ File does not match schema: fixture/availableChannels/Dim 2/capability/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim 2/capability/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim 2/capability/brightnessStart 0 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim 2/capability/brightnessStart 0 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim 2/capability/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim 2/capability/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim 2/capability/brightnessEnd 1 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim 2/capability/brightnessEnd 1 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim 3/capability/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim 3/capability/brightnessStart 0 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim 3/capability/brightnessStart 0 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim 3/capability/brightnessStart 0 must match exactly one schema in oneOf
  - ❌ File does not match schema: fixture/availableChannels/Dim 3/capability/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim 3/capability/brightnessEnd 1 must be string
  - ❌ File does not match schema: fixture/availableChannels/Dim 3/capability/brightnessEnd 1 must be equal to one of [off, dark, bright]
  - ❌ File does not match schema: fixture/availableChannels/Dim 3/capability/brightnessEnd 1 must match exactly one schema in oneOf
  - ⚠️ Please add fixture categories.
  - ⚠️ Please add relevant links to the fixture.
  - ⚠️ Please add physical data to the fixture.


Thank you **G**!