### PR TITLE
Add fixture `fun-generation/partypar-12-dmx`

### DIFF
--- a/fixtures/fun-generation/partypar-12-dmx.json
+++ b/fixtures/fun-generation/partypar-12-dmx.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "PartyPar 12 DMX",
+  "categories": ["Color Changer", "Strobe", "Dimmer"],
+  "meta": {
+    "authors": ["Anonymous"],
+    "createDate": "2026-07-09",
+    "lastModifyDate": "2026-07-09"
+  },
+  "links": {
+    "manual": [
+      "https://fast-images.static-thomann.de/pics/atg/atgdata/document/manual/591166_v3_en_online.pdf"
+    ],
+    "productPage": [
+      "https://www.thomannmusic.com/fun_generation_partypar_12_dmx.htm"
+    ]
+  },
+  "physical": {
+    "dimensions": [155, 190, 90],
+    "weight": 0.5,
+    "power": 11,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "type": "LED"
+    },
+    "lens": {
+      "degreesMinMax": [7, 7]
+    }
+  },
+  "availableChannels": {
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Color Macros": {
+      "capability": {
+        "type": "Generic",
+        "comment": "Color macros, refer to manual"
+      }
+    },
+    "Macro Speed": {
+      "capability": {
+        "type": "EffectSpeed",
+        "speedStart": "slow",
+        "speedEnd": "fast",
+        "comment": "Speed of color macro"
+      }
+    },
+    "Sound Control / Strobe": {
+      "capabilities": [
+        {
+          "dmxRange": [0, 0],
+          "type": "NoFunction"
+        },
+        {
+          "dmxRange": [1, 10],
+          "type": "Generic",
+          "comment": "Sound Control"
+        },
+        {
+          "dmxRange": [11, 255],
+          "type": "ShutterStrobe",
+          "shutterEffect": "Strobe",
+          "speedStart": "slow",
+          "speedEnd": "fast"
+        }
+      ]
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe",
+        "speedStart": "stop",
+        "speedEnd": "fast"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "6-channel",
+      "shortName": "6ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Dimmer",
+        "Color Macros",
+        "Macro Speed"
+      ]
+    },
+    {
+      "name": "5-channel",
+      "shortName": "5ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Dimmer",
+        "Sound Control / Strobe"
+      ]
+    },
+    {
+      "name": "4-channel",
+      "shortName": "4ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue",
+        "Strobe"
+      ]
+    },
+    {
+      "name": "3-channel",
+      "shortName": "3ch",
+      "channels": [
+        "Red",
+        "Green",
+        "Blue"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `fun-generation/partypar-12-dmx`

### Fixture warnings / errors

* fun-generation/partypar-12-dmx
  - ❌ Channel 'Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.


Thank you **Anonymous**!