### PR TITLE
Add fixture `abstract/nyr`

### DIFF
--- a/fixtures/abstract/nyr.json
+++ b/fixtures/abstract/nyr.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "nyr",
+  "shortName": "nt",
+  "categories": ["Smoke", "Blinder", "Laser"],
+  "meta": {
+    "authors": ["35"],
+    "createDate": "2026-07-12",
+    "lastModifyDate": "2026-07-12"
+  },
+  "links": {
+    "video": [
+      "https://www.youtube.com/watch?v=KNbW4XEwuH4&list=RDKNbW4XEwuH4&start_radio=1"
+    ]
+  },
+  "rdm": {
+    "modelId": 53,
+    "softwareVersion": "453"
+  },
+  "physical": {
+    "dimensions": [28, 10, 12],
+    "weight": 18,
+    "power": 11,
+    "DMXconnector": "3-pin",
+    "bulb": {
+      "colorTemperature": 5,
+      "lumens": 4
+    }
+  },
+  "availableChannels": {
+    "Strobe Speed": {
+      "fineChannelAliases": ["Strobe Speed fine", "Strobe Speed fine^2"],
+      "highlightValue": "233%",
+      "precedence": "LTP",
+      "capability": {
+        "type": "WheelRotation",
+        "speedStart": "fast CW",
+        "speedEnd": "fast CW"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "fede",
+      "channels": [
+        "Strobe Speed",
+        "Strobe Speed fine",
+        "Strobe Speed fine^2"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Add fixture `abstract/nyr`

### Fixture warnings / errors

* abstract/nyr
  - ❌ File does not match schema: fixture/availableChannels/Strobe Speed/highlightValue "233%" must be integer
  - ❌ File does not match schema: fixture/availableChannels/Strobe Speed/highlightValue "233%" must match pattern "^(([1-9][0-9]?|0)(\.[0-9]+)?|100)%$"
  - ❌ File does not match schema: fixture/availableChannels/Strobe Speed/highlightValue "233%" must match exactly one schema in oneOf


Thank you @53!