### PR TITLE
Search fixtures by attributes (channel count, channel types, colors)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ docker-compose.yml
 # Generated files
 .nuxt/
 fixtures/register.json
+fixtures/search-attributes.json
 
 # Temporary files
 tmp/

--- a/cli/build-search-attributes.js
+++ b/cli/build-search-attributes.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { styleText } from 'util';
+import importJson from '../lib/import-json.js';
+import Fixture from '../lib/model/Fixture.js';
+import Manufacturer from '../lib/model/Manufacturer.js';
+
+const fixturesPath = fileURLToPath(new URL('../fixtures/', import.meta.url));
+
+try {
+  const register = await importJson('../fixtures/register.json', import.meta.url);
+  const manufacturersData = await importJson('../fixtures/manufacturers.json', import.meta.url);
+
+  const searchAttributes = await getSearchAttributes(register, manufacturersData);
+
+  const filename = path.join(fixturesPath, 'search-attributes.json');
+  const fileContents = `${JSON.stringify(getObjectSortedByKeys(searchAttributes), null, 2)}\n`;
+
+  await writeFile(filename, fileContents, 'utf-8');
+  console.log(styleText('green', '[Success]'), 'Updated search attributes file', filename);
+  process.exit(0);
+}
+catch (error) {
+  console.error(styleText('red', '[Fail]'), 'Could not build search attributes file.', error);
+  process.exit(1);
+}
+
+/**
+ * Compute the searchable attributes of every fixture (and fixture redirect) in the register.
+ * Fixture redirects use the attributes of the fixture they point to, so that e.g. rebadged fixtures
+ * (see docs/fixture-format.md#fixture-redirects) can be found by attribute search as well.
+ * @param {Readonly<object>} register - The fixture register, as built by `cli/build-register.js`.
+ * @param {Readonly<object>} manufacturersData - All known manufacturers, like specified by the manufacturer schema.
+ * @returns {Promise<Record<string, object>>} A Promise that resolves to an object mapping each fixture key to its search attributes.
+ */
+async function getSearchAttributes(register, manufacturersData) {
+  const searchAttributes = {};
+
+  // fixture data (and computed attributes) of already-visited fixtures, keyed by fixture key,
+  // so that a fixture that is pointed to by multiple redirects is only read and computed once
+  const attributesByTargetKey = new Map();
+
+  for (const [fixtureKey, registerEntry] of Object.entries(register.filesystem)) {
+    const targetKey = registerEntry.redirectTo || fixtureKey;
+
+    if (!attributesByTargetKey.has(targetKey)) {
+      const [manufacturerKey, key] = targetKey.split('/', 2);
+      const fixtureJson = await importJson(`${targetKey}.json`, fixturesPath);
+      const manufacturer = new Manufacturer(manufacturerKey, manufacturersData[manufacturerKey]);
+      const fixture = new Fixture(manufacturer, key, fixtureJson);
+
+      attributesByTargetKey.set(targetKey, computeFixtureSearchAttributes(fixture));
+    }
+
+    searchAttributes[fixtureKey] = attributesByTargetKey.get(targetKey);
+  }
+
+  return searchAttributes;
+}
+
+/**
+ * @param {Readonly<Fixture>} fixture - The fixture to compute search attributes for.
+ * @returns {object} The fixture's searchable attributes: DMX channel counts (one per mode), used channel types and used single colors.
+ */
+function computeFixtureSearchAttributes(fixture) {
+  const channelCounts = [...new Set(
+    fixture.modes.map((mode) => mode.channels.length),
+  )].toSorted((a, b) => a - b);
+
+  const channelTypes = new Set();
+  const colors = new Set();
+
+  for (const channel of fixture.coarseChannels) {
+    if (channel.type !== 'NoFunction' && channel.type !== 'Unknown') {
+      channelTypes.add(channel.type);
+    }
+
+    if (channel.color !== null) {
+      colors.add(channel.color);
+    }
+  }
+
+  return {
+    channelCounts,
+    channelTypes: [...channelTypes].toSorted((a, b) => a.localeCompare(b, 'en')),
+    colors: [...colors].toSorted((a, b) => a.localeCompare(b, 'en')),
+  };
+}
+
+/**
+ * @param {Readonly<object>} object - The object to sort.
+ * @returns {object} A new object with the same entries, sorted by keys.
+ */
+function getObjectSortedByKeys(object) {
+  const sortedObject = {};
+  const sortedKeys = Object.keys(object).toSorted((a, b) => a.localeCompare(b, 'en', { numeric: true }));
+
+  for (const key of sortedKeys) {
+    sortedObject[key] = object[key];
+  }
+
+  return sortedObject;
+}

--- a/docs/model-api.md
+++ b/docs/model-api.md
@@ -61,6 +61,15 @@ Currently used to create matrix channels.</p>
 </dd>
 </dl>
 
+## Constants
+
+<dl>
+<dt><a href="#CHANNEL_TYPES">CHANNEL_TYPES</a> : <code>Array.&lt;string&gt;</code></dt>
+<dd><p>All possible values of <a href="#CoarseChannel+type">type</a>, except <code>Unknown</code> (which is only returned as a
+fallback and can&#39;t be searched for) and <code>NoFunction</code> (which is not a meaningful search criterion).</p>
+</dd>
+</dl>
+
 ## Typedefs
 
 <dl>
@@ -2680,6 +2689,13 @@ Creates a new WheelSlot instance.
 ### wheelSlot.ceilSlot ⇒ [<code>WheelSlot</code>](#WheelSlot) \| <code>null</code>
 **Kind**: instance property of [<code>WheelSlot</code>](#WheelSlot)  
 **Returns**: [<code>WheelSlot</code>](#WheelSlot) \| <code>null</code> - For split slots, the ceil (end) slot. Null for non-split slots.  
+<a name="CHANNEL_TYPES"></a>
+
+## CHANNEL\_TYPES : <code>Array.&lt;string&gt;</code>
+All possible values of [type](#CoarseChannel+type), except `Unknown` (which is only returned as a
+fallback and can't be searched for) and `NoFunction` (which is not a meaningful search criterion).
+
+**Kind**: global constant  
 <a name="Resolution"></a>
 
 ## Resolution : <code>number</code>

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -30,6 +30,14 @@ Return search results for given parameters.
   ],
   "categoriesQuery": [
     "string"
+  ],
+  "channelsMinQuery": 0,
+  "channelsMaxQuery": 0,
+  "channelTypesQuery": [
+    "string"
+  ],
+  "colorsQuery": [
+    "string"
   ]
 }
 ```
@@ -41,6 +49,10 @@ Return search results for given parameters.
 |searchQuery|body|string|true|none|
 |manufacturersQuery|body|[string]|true|none|
 |categoriesQuery|body|[string]|true|none|
+|channelsMinQuery|body|integer¦null|true|none|
+|channelsMaxQuery|body|integer¦null|true|none|
+|channelTypesQuery|body|[string]|true|none|
+|colorsQuery|body|[string]|true|none|
 
 > Example responses
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -31,8 +31,8 @@ Return search results for given parameters.
   "categoriesQuery": [
     "string"
   ],
-  "channelsMinQuery": 0,
-  "channelsMaxQuery": 0,
+  "channelsMinQuery": 1,
+  "channelsMaxQuery": 1,
   "channelTypesQuery": [
     "string"
   ],
@@ -49,8 +49,8 @@ Return search results for given parameters.
 |searchQuery|body|string|true|none|
 |manufacturersQuery|body|[string]|true|none|
 |categoriesQuery|body|[string]|true|none|
-|channelsMinQuery|body|integer¦null|true|none|
-|channelsMaxQuery|body|integer¦null|true|none|
+|channelsMinQuery|body|integer,null|true|none|
+|channelsMaxQuery|body|integer,null|true|none|
 |channelTypesQuery|body|[string]|true|none|
 |colorsQuery|body|[string]|true|none|
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -363,6 +363,7 @@ export default defineConfig([
     ignores: [
       'package-lock.json',
       'fixtures/register.json',
+      'fixtures/search-attributes.json',
       'server/ofl-secrets.json',
       '.vscode/',
       '.nuxt/',

--- a/lib/model/CoarseChannel.js
+++ b/lib/model/CoarseChannel.js
@@ -46,6 +46,13 @@ const channelTypeConstraints = {
 };
 
 /**
+ * All possible values of {@link CoarseChannel#type}, except `Unknown` (which is only returned as a
+ * fallback and can't be searched for) and `NoFunction` (which is not a meaningful search criterion).
+ * @type {string[]}
+ */
+export const CHANNEL_TYPES = Object.keys(channelTypeConstraints).filter((type) => type !== 'NoFunction');
+
+/**
  * A single DMX channel, either created as availableChannel or resolved templateChannel.
  * Only the MSB (most significant byte) channel if it's a multi-byte channel.
  * @extends AbstractChannel

--- a/lib/single-colors.js
+++ b/lib/single-colors.js
@@ -1,0 +1,21 @@
+/**
+ * The predefined single colors that a `ColorIntensity` capability's `color` property can have,
+ * see the capability schema (`schemas/capability.json`) and `docs/capability-types.md`.
+ * Used to offer a fixed list of colors to filter fixtures by on the search page.
+ * @type {string[]}
+ */
+export const SINGLE_COLORS = [
+  'Red',
+  'Green',
+  'Blue',
+  'Cyan',
+  'Magenta',
+  'Yellow',
+  'Amber',
+  'White',
+  'Warm White',
+  'Cold White',
+  'UV',
+  'Lime',
+  'Indigo',
+];

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "start": "nuxt start",
 
     "build": "npm run build-without-nuxt && npm run build:nuxt",
-    "build-without-nuxt": "npm run build:register && npm run build:plugin-data && npm run build:test-fixtures && npm run build:model-docs && npm run build:api-docs",
+    "build-without-nuxt": "npm run build:register && npm run build:search-attributes && npm run build:plugin-data && npm run build:test-fixtures && npm run build:model-docs && npm run build:api-docs",
     "build:nuxt": "nuxt build",
     "build:register": "node cli/build-register.js",
+    "build:search-attributes": "node cli/build-search-attributes.js",
     "build:plugin-data": "node cli/build-plugin-data.js",
     "build:test-fixtures": "node cli/build-test-fixtures.js",
     "build:model-docs": "jsdoc2md --private --files lib/model/*.js > docs/model-api.md",

--- a/ui/api/routes/get-search-results.js
+++ b/ui/api/routes/get-search-results.js
@@ -2,6 +2,7 @@ import importJson from '../../../lib/import-json.js';
 
 let register;
 let manufacturers;
+let searchAttributes;
 
 /** @import { Context as OpenApiBackendContext } from 'openapi-backend' */
 /** @import { ApiResponse } from '../index.js' */
@@ -12,13 +13,22 @@ let manufacturers;
  * @returns {Promise<ApiResponse>} The handled response.
  */
 export async function getSearchResults({ request }) {
-  const { searchQuery, manufacturersQuery, categoriesQuery } = request.requestBody;
+  const {
+    searchQuery, manufacturersQuery, categoriesQuery,
+    channelsMinQuery, channelsMaxQuery, channelTypesQuery, colorsQuery,
+  } = request.requestBody;
 
   register = await importJson('../../../fixtures/register.json', import.meta.url);
   manufacturers = await importJson('../../../fixtures/manufacturers.json', import.meta.url);
+  searchAttributes = await importJson('../../../fixtures/search-attributes.json', import.meta.url);
 
   const results = Object.keys(register.filesystem).filter(
-    (key) => queryMatch(searchQuery, key) && manufacturerMatch(manufacturersQuery, key) && categoryMatch(categoriesQuery, key),
+    (key) => queryMatch(searchQuery, key)
+      && manufacturerMatch(manufacturersQuery, key)
+      && categoryMatch(categoriesQuery, key)
+      && channelCountMatch(channelsMinQuery, channelsMaxQuery, key)
+      && channelTypesMatch(channelTypesQuery, key)
+      && colorsMatch(colorsQuery, key),
   );
   return {
     body: results,
@@ -67,5 +77,58 @@ function categoryMatch(categoriesQuery, fixtureKey) {
     || categoriesQuery.some(
       (category) => register.categories[category]?.includes(fixtureKey),
     )
+  );
+}
+
+/**
+ * Test if a fixture has a mode whose DMX channel count is within the given range. Fixture redirects
+ * use the channel counts of the fixture they point to (see `cli/build-search-attributes.js`).
+ * @param {number | null} channelsMinQuery - Minimum number of channels a matching mode must have, if given.
+ * @param {number | null} channelsMaxQuery - Maximum number of channels a matching mode must have, if given.
+ * @param {string} fixtureKey - Key of the fixture to test.
+ * @returns {boolean} True if the fixture matches the channel count query, false otherwise.
+ */
+function channelCountMatch(channelsMinQuery, channelsMaxQuery, fixtureKey) {
+  if (channelsMinQuery === null && channelsMaxQuery === null) {
+    return true;
+  }
+
+  const min = channelsMinQuery ?? -Infinity;
+  const max = channelsMaxQuery ?? Infinity;
+
+  return searchAttributes[fixtureKey].channelCounts.some(
+    (channelCount) => channelCount >= min && channelCount <= max,
+  );
+}
+
+/**
+ * Test if a fixture matches the channel types query. A fixture matches if it has a channel of at
+ * least one of the selected types (e.g. selecting "Gobo" and "Prism" finds fixtures that have either).
+ * @param {string[]} channelTypesQuery - Selected channel types, see `CHANNEL_TYPES` in `lib/model/CoarseChannel.js`.
+ * @param {string} fixtureKey - Key of the fixture to test.
+ * @returns {boolean} True if the fixture matches the channel types query, false otherwise.
+ */
+function channelTypesMatch(channelTypesQuery, fixtureKey) {
+  return (
+    channelTypesQuery.length === 0
+    || channelTypesQuery.some(
+      (channelType) => searchAttributes[fixtureKey].channelTypes.includes(channelType),
+    )
+  );
+}
+
+/**
+ * Test if a fixture matches the colors query.
+ *
+ * Design decision: unlike `channelTypesMatch()`, this uses AND semantics instead of OR – selecting
+ * "Red" and "Green" should only return fixtures that have *both* a Red and a Green channel (e.g. to
+ * find RGB(W) fixtures or rebadges of a known fixture), not fixtures that have either one.
+ * @param {string[]} colorsQuery - Selected single colors, see `SINGLE_COLORS` in `lib/single-colors.js`.
+ * @param {string} fixtureKey - Key of the fixture to test.
+ * @returns {boolean} True if the fixture matches the colors query, false otherwise.
+ */
+function colorsMatch(colorsQuery, fixtureKey) {
+  return colorsQuery.every(
+    (color) => searchAttributes[fixtureKey].colors.includes(color),
   );
 }

--- a/ui/api/routes/get-search-results.json
+++ b/ui/api/routes/get-search-results.json
@@ -24,19 +24,47 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "channelsMinQuery": {
+                "type": ["integer", "null"],
+                "minimum": 1
+              },
+              "channelsMaxQuery": {
+                "type": ["integer", "null"],
+                "minimum": 1
+              },
+              "channelTypesQuery": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "colorsQuery": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             },
             "required": [
               "searchQuery",
               "manufacturersQuery",
-              "categoriesQuery"
+              "categoriesQuery",
+              "channelsMinQuery",
+              "channelsMaxQuery",
+              "channelTypesQuery",
+              "colorsQuery"
             ],
             "additionalProperties": false
           },
           "example": {
             "searchQuery": "showtec phantom",
             "manufacturersQuery": [],
-            "categoriesQuery": []
+            "categoriesQuery": [],
+            "channelsMinQuery": null,
+            "channelsMaxQuery": null,
+            "channelTypesQuery": [],
+            "colorsQuery": []
           }
         }
       }

--- a/ui/pages/search.vue
+++ b/ui/pages/search.vue
@@ -34,6 +34,47 @@
             :selected="categoriesQuery.includes(cat)"
             :value="cat">{{ cat }}</option>
         </select>
+
+        <select v-model="channelTypesQuery" name="channelTypes" multiple>
+          <option
+            :selected="channelTypesQuery.length === 0"
+            value="">Filter by channel type</option>
+
+          <option
+            v-for="channelType of channelTypes"
+            :key="channelType"
+            :selected="channelTypesQuery.includes(channelType)"
+            :value="channelType">{{ channelType }}</option>
+        </select>
+
+        <select v-model="colorsQuery" name="colors" multiple>
+          <option
+            :selected="colorsQuery.length === 0"
+            value="">Filter by color</option>
+
+          <option
+            v-for="color of colors"
+            :key="color"
+            :selected="colorsQuery.includes(color)"
+            :value="color">{{ color }}</option>
+        </select>
+
+        <label class="channel-count-range">
+          Number of channels:
+          <input
+            v-model.number="channelsMinQuery"
+            type="number"
+            min="1"
+            name="channelsMin"
+            placeholder="min">
+          <span aria-hidden="true">–</span>
+          <input
+            v-model.number="channelsMaxQuery"
+            type="number"
+            min="1"
+            name="channelsMax"
+            placeholder="max">
+        </label>
       </ConditionalDetails>
 
       <button :disabled="searchQuery === `` && isBrowser" type="submit" class="primary">Search</button>
@@ -82,10 +123,23 @@
 .search ::v-deep details {
   margin: 1rem 0;
 }
+
+.search ::v-deep .channel-count-range {
+  display: inline-flex;
+  gap: 0.5ex;
+  align-items: center;
+  margin-right: 1ex;
+
+  input[type="number"] {
+    width: 5em;
+  }
+}
 </style>
 
 <script>
 import register from '../../fixtures/register.json';
+import { CHANNEL_TYPES } from '../../lib/model/CoarseChannel.js';
+import { SINGLE_COLORS } from '../../lib/single-colors.js';
 import ConditionalDetails from '../components/ConditionalDetails.vue';
 import LabeledInput from '../components/LabeledInput.vue';
 
@@ -110,9 +164,15 @@ export default {
       searchQuery: '',
       manufacturersQuery: [],
       categoriesQuery: [],
+      channelsMinQuery: null,
+      channelsMaxQuery: null,
+      channelTypesQuery: [],
+      colorsQuery: [],
       detailsInitiallyOpen: null,
       results: [],
       categories: Object.keys(register.categories).toSorted((a, b) => a.localeCompare(b, 'en')),
+      channelTypes: CHANNEL_TYPES.toSorted((a, b) => a.localeCompare(b, 'en')),
+      colors: SINGLE_COLORS.toSorted((a, b) => a.localeCompare(b, 'en')),
       loading: false,
       isBrowser: false,
     };
@@ -124,10 +184,19 @@ export default {
     this.searchQuery = sanitizedQuery.search;
     this.manufacturersQuery = sanitizedQuery.manufacturers;
     this.categoriesQuery = sanitizedQuery.categories;
+    this.channelsMinQuery = sanitizedQuery.channelsMin;
+    this.channelsMaxQuery = sanitizedQuery.channelsMax;
+    this.channelTypesQuery = sanitizedQuery.channelTypes;
+    this.colorsQuery = sanitizedQuery.colors;
     this.searchFor = sanitizedQuery.search;
 
     if (this.detailsInitiallyOpen === null) {
-      this.detailsInitiallyOpen = this.manufacturersQuery.length > 0 || this.categoriesQuery.length > 0;
+      this.detailsInitiallyOpen = this.manufacturersQuery.length > 0
+        || this.categoriesQuery.length > 0
+        || this.channelsMinQuery !== null
+        || this.channelsMaxQuery !== null
+        || this.channelTypesQuery.length > 0
+        || this.colorsQuery.length > 0;
     }
 
     try {
@@ -135,6 +204,10 @@ export default {
         searchQuery: sanitizedQuery.search,
         manufacturersQuery: sanitizedQuery.manufacturers,
         categoriesQuery: sanitizedQuery.categories,
+        channelsMinQuery: sanitizedQuery.channelsMin,
+        channelsMaxQuery: sanitizedQuery.channelsMax,
+        channelTypesQuery: sanitizedQuery.channelTypes,
+        colorsQuery: sanitizedQuery.colors,
       });
     }
     catch {
@@ -188,6 +261,10 @@ export default {
           q: this.searchQuery,
           manufacturers: this.manufacturersQuery,
           categories: this.categoriesQuery,
+          channelsMin: toPositiveIntegerOrNull(this.channelsMinQuery),
+          channelsMax: toPositiveIntegerOrNull(this.channelsMaxQuery),
+          channelTypes: this.channelTypesQuery,
+          colors: this.colorsQuery,
         },
       });
     },
@@ -196,25 +273,43 @@ export default {
 
 /**
  * @param {object} query - The raw query returned by Vue Router
- * @returns {object} Object with properties "search" (string), "manufacturers" and "categories" (arrays of strings).
+ * @returns {object} Object with properties "search" (string), "manufacturers", "categories", "channelTypes"
+ * and "colors" (arrays of strings), and "channelsMin" / "channelsMax" (positive integers or null).
  */
 function getSanitizedQuery(query) {
   const searchQuery = (query.q || '').trim();
 
-  let manufacturersQuery = query.manufacturers || [];
-  if (typeof manufacturersQuery === 'string') {
-    manufacturersQuery = [manufacturersQuery];
-  }
-
-  let categoriesQuery = query.categories || [];
-  if (typeof categoriesQuery === 'string') {
-    categoriesQuery = [categoriesQuery];
-  }
-
   return {
     search: searchQuery,
-    manufacturers: manufacturersQuery,
-    categories: categoriesQuery,
+    manufacturers: toArray(query.manufacturers),
+    categories: toArray(query.categories),
+    channelsMin: toPositiveIntegerOrNull(query.channelsMin),
+    channelsMax: toPositiveIntegerOrNull(query.channelsMax),
+    channelTypes: toArray(query.channelTypes),
+    colors: toArray(query.colors),
   };
+}
+
+/**
+ * Vue Router returns a single string if a query parameter is only given once, and an array of
+ * strings if it's given multiple times (or omits the property completely if it's not given at all).
+ * @param {string | string[] | undefined} queryValue - The raw value of a multi-value query parameter.
+ * @returns {string[]} The query parameter's value, always as an array.
+ */
+function toArray(queryValue) {
+  if (queryValue === undefined) {
+    return [];
+  }
+
+  return typeof queryValue === 'string' ? [queryValue] : queryValue;
+}
+
+/**
+ * @param {string | number | undefined} queryValue - The raw value of a query parameter.
+ * @returns {number | null} The query parameter's value as a positive integer, or null if it isn't one.
+ */
+function toPositiveIntegerOrNull(queryValue) {
+  const number = Number.parseInt(queryValue, 10);
+  return Number.isSafeInteger(number) && number > 0 ? number : null;
 }
 </script>


### PR DESCRIPTION
## Summary

Closes #2796. Adds attribute filters to the search page:

- **Number of channels** — filter to fixtures that have a mode with a DMX channel count in the given min/max range.
- **Channel type** — filter to fixtures that have a channel of at least one of the selected types (Pan, Tilt, Gobo, Zoom, Prism, ...).
- **Color** — filter to fixtures whose `Single Color` channels cover *all* of the selected colors (e.g. selecting Red + Green + Blue finds RGB fixtures). This is useful for finding rebadged/noname fixtures that share the same channel layout but are sold under different names, as discussed in the issue.

### How it works

- `cli/build-search-attributes.js` is a new build step (wired into `build-without-nuxt`, right after `build:register`) that precomputes each fixture's searchable attributes (channel counts per mode, channel types used, single colors used) using the existing `Fixture` model, and writes them to a new gitignored `fixtures/search-attributes.json` — mirroring how `fixtures/register.json` is already built.
  - I intentionally kept this out of `register.json` itself, since `register.json` is imported directly into the search page's Vue component (so its full contents ship to the client); a separate, server-only file avoids growing that client bundle.
  - Fixture redirects (rebadges) reuse the attributes of the fixture they point to, so a rebadge is matched the same way as the fixture it redirects to.
- `ui/api/routes/get-search-results.js` gained three new filter predicates (`channelCountMatch`, `channelTypesMatch`, `colorsMatch`) alongside the existing manufacturer/category matchers, plus the corresponding OpenAPI request schema in `get-search-results.json`.
- `ui/pages/search.vue` gained the three new filter controls, reusing the existing "Filter results" `<details>` panel and multi-select pattern.
- `lib/model/CoarseChannel.js` now exports `CHANNEL_TYPES` (the existing internal list of channel type names) so the search page and the build script share one source of truth instead of duplicating the list.
- Added `lib/single-colors.js` exporting the predefined `SINGLE_COLORS` list from the capability schema, for the same reason.

I chose **OR** semantics for channel types (matches if any selected type is present) but **AND** semantics for colors (matches only if all selected colors are present) — documented in `colorsMatch()`'s JSDoc. Happy to adjust if maintainers prefer different semantics here.

## Test plan

- [x] `npm run lint` passes on all changed files
- [x] Ran the dev server locally and verified:
  - the three new filter controls render correctly
  - filtering by color (e.g. `UV`) narrows results to fixtures that actually have a UV channel
  - combining manufacturer + channel type (`Gobo`) + channel count range narrows to the expected moving-head/scanner fixtures
  - filter state round-trips correctly through the URL query string
- [x] Regenerated `docs/model-api.md` via `npm run build:model-docs`
- [x] Manually synced `docs/rest-api.md` to match the new OpenAPI request schema (the `build:api-docs` widdershins tool has a pre-existing bug with paths containing spaces on Windows, unrelated to this change, that prevented me from running it directly in my environment — I verified the manual edit matches the existing formatting conventions used elsewhere in the file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)