### PR TITLE
Add missing manual/productPage links to 3 fixtures

### DIFF
--- a/fixtures/ghost/ip-spot-bat.json
+++ b/fixtures/ghost/ip-spot-bat.json
@@ -10,6 +10,9 @@
   },
   "comment": "Mode 2",
   "links": {
+    "productPage": [
+      "https://www.sonorythme.fr/product-page/ghost-ipspot-bat"
+    ],
     "video": [
       "https://www.youtube.com/watch?v=_nbH55XYGYU"
     ]

--- a/fixtures/ghost/ip-spot-pro.json
+++ b/fixtures/ghost/ip-spot-pro.json
@@ -8,6 +8,11 @@
     "createDate": "2019-08-08",
     "lastModifyDate": "2019-08-08"
   },
+  "links": {
+    "manual": [
+      "https://www.manualslib.fr/manual/111371/Ghost-Ip-Spot-Pro.html"
+    ]
+  },
   "physical": {
     "dimensions": [340, 240, 240],
     "weight": 4.5,

--- a/fixtures/ibiza-light/ls-005led.json
+++ b/fixtures/ibiza-light/ls-005led.json
@@ -8,11 +8,13 @@
     "lastModifyDate": "2019-07-29"
   },
   "links": {
+    "productPage": [
+      "https://www.bsacoustic.com/stroboscope/ls-005led/"
+    ],
     "video": [
       "https://www.youtube.com/watch?v=Ojwpf-J7rvQ"
     ]
   },
-  "helpWanted": "Can you provide a link to a manual, product page, or similar?",
   "physical": {
     "dimensions": [460, 160, 140],
     "power": 30,


### PR DESCRIPTION
## Summary

Part of #578. This issue is intentionally open-ended ("no need to do everything in one PR... small pull requests to only add a single link are appreciated as well" per @FloEdelmann's comment), so this covers a small, verified batch rather than all fixtures missing links.

- `ghost/ip-spot-bat.json` — had only a video link, added `productPage`
- `ghost/ip-spot-pro.json` — had no links at all, added `manual`
- `ibiza-light/ls-005led.json` — had only a video link, added `productPage`. This also resolves the fixture's own `helpWanted` note, which literally asked: *"Can you provide a link to a manual, product page, or similar?"*

For each, I confirmed the replacement page/PDF actually loads and (where I could check content) that it describes the right brand + model, not just a similarly-named page.

### What I looked at but didn't add

I also researched `cinetec/par-18x15w-rgbwa.json`, `kam/gobotracer.json`, `lep-laser/diamond-pro-2-8.json`, `skypix/ribalta-beam.json`, `solaris/smart-36.json`, `studio-due/light-deflector.json`, and `uking/mini-led-spot-25w.json` (all also missing manual/productPage), but didn't find anything I was confident enough to add:
- No findable source at all for most of them (very niche/OEM-rebrand brands with little web presence)
- For `skypix/ribalta-beam.json` specifically, I found a manual on the manufacturer's own site, but its spec (10 LEDs, 40W, 14/54 DMX channels) doesn't match this fixture's definition (8x10W LEDs, single 10-channel mode) closely enough to trust it's the same product revision — didn't want to attach a manual that might actually describe a different version of the fixture.

## Test plan

- [x] `node tests/fixtures-valid.js <the 3 files>` — all pass schema validation
- [x] Verified each new URL with `curl -I -L` (200 OK) and, where reachable, fetched the page content to confirm it's actually about the named product

🤖 Generated with [Claude Code](https://claude.com/claude-code)