### PR TITLE
Fix broken U'King manual links

### DIFF
--- a/fixtures/uking/b117-par-can-4in1-rgbw-18-leds.json
+++ b/fixtures/uking/b117-par-can-4in1-rgbw-18-leds.json
@@ -11,7 +11,7 @@
   "comment": "This is an unbranded fixture bought online, but the appearance and user manual match the UKing B117 closely.\n\nThe B117 webpage isn't even internally consistent, so I've done the best I could here.",
   "links": {
     "manual": [
-      "https://www.uking-online.com/wp-content/uploads/2020/10/ZQ-B117.pdf"
+      "https://web.archive.org/web/20240413151514id_/https://www.uking-online.com/wp-content/uploads/2020/10/ZQ-B117.pdf"
     ],
     "productPage": [
       "https://www.uking-online.com/product/b117-par-can-4in1-rgbw-18-leds/"

--- a/fixtures/uking/par-light-b262.json
+++ b/fixtures/uking/par-light-b262.json
@@ -10,7 +10,7 @@
   "comment": "This light appears to be identical to the \"LUNSY DJ Par Lights.\"\n\nSee \"other\" links for the LUNSY products and reviews.\n\nI was unable to find an online copy of the manual -- the manual link is someone's photo of a U'King manual, different model, which appears to have the same information as the one which came with the lights.",
   "links": {
     "manual": [
-      "https://www.uking-online.com/wp-content/uploads/2020/10/ZQ-B262.pdf"
+      "https://web.archive.org/web/20240517212018id_/https://www.uking-online.com/wp-content/uploads/2020/10/ZQ-B262.pdf"
     ],
     "productPage": [
       "https://www.uking-online.com/product/par-can-b262-36w-36led-rgb-par-light-uking/"

--- a/fixtures/uking/zq-b20-mini-spider-light.json
+++ b/fixtures/uking/zq-b20-mini-spider-light.json
@@ -16,7 +16,7 @@
       "https://www.youtube.com/watch?v=4KL1MdtnQ34"
     ],
     "manual": [
-      "https://www.uking-online.com/wp-content/uploads/2020/10/ZQ-B20.pdf"
+      "https://community.etcconnect.com/cfs-file/__key/communityserver-discussions-components-files/191/ZQ_2D00_B20.pdf"
     ]
   },
   "physical": {


### PR DESCRIPTION
Part of #999.

## Summary

- replace the dead B117 and B262 manual URLs with archived snapshots of the original U'King PDFs
- replace the dead ZQ-B20 manual URL with a working ETC Community copy of the same manual
- leave `lastModifyDate` unchanged, as required for link-only fixture updates

## Verification

- all three previous URLs return HTTP 404
- both Wayback replacements return HTTP 200 with `application/pdf`
- the ETC replacement returns HTTP 200 with `application/pdf`
- `npm run build:register` using Node 24.11.1
- targeted fixture validation: 3/3 valid
- full fixture validation: 635/635 valid (32 existing warnings)
