### PR TITLE
Add fixture `ledfull/parled`

### DIFF
--- a/fixtures/ledfull/parled.json
+++ b/fixtures/ledfull/parled.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "ParLed",
+  "shortName": "SVT",
+  "categories": ["Dimmer", "Color Changer", "Strobe"],
+  "meta": {
+    "authors": ["Parled SVT"],
+    "createDate": "2026-08-27",
+    "lastModifyDate": "2026-08-27"
+  },
+  "links": {
+    "manual": [
+      "https://svt.com.vn/san-pham/den-led-20x15w-svt/"
+    ]
+  },
+  "physical": {
+    "dimensions": [250, 250, 350],
+    "weight": 5,
+    "power": 300,
+    "DMXconnector": "3-pin"
+  },
+  "availableChannels": {
+    "Dimmer": {
+      "capability": {
+        "type": "Intensity"
+      }
+    },
+    "Red": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Red"
+      }
+    },
+    "Green": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Green"
+      }
+    },
+    "Blue": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "Blue"
+      }
+    },
+    "White": {
+      "capability": {
+        "type": "ColorIntensity",
+        "color": "White"
+      }
+    },
+    "Strobe": {
+      "capability": {
+        "type": "ShutterStrobe",
+        "shutterEffect": "Strobe"
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "Parled",
+      "shortName": "SVT",
+      "channels": [
+        "Dimmer",
+        "Red",
+        "Green",
+        "Blue",
+        "White",
+        "Strobe"
+      ]
+    }
+  ]
+}

--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -304,6 +304,10 @@
     "name": "Laserworld",
     "website": "https://www.laserworld.com/en/"
   },
+  "ledfull": {
+    "name": "LedFull",
+    "website": "https://svt.com.vn/san-pham/den-led-20x15w-svt/"
+  },
   "ledj": {
     "name": "LEDJ",
     "comment": "Brand of the Prolight Concepts Group.",


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `ledfull/parled`

### Fixture warnings / errors

* ledfull/parled
  - ❌ Channel 'Strobe' only has a single ShutterStrobe capability and the fixture is not a Strobe, so it is not clear when strobe is disabled.


Thank you **Parled**!