### PR TITLE
Fix SHEHDS 18x12W RGBW fixture metadata

### DIFF
--- a/fixtures/shehds/18x12w-rgbw-par.json
+++ b/fixtures/shehds/18x12w-rgbw-par.json
@@ -5,16 +5,27 @@
   "meta": {
     "authors": ["Gemini", "Mamoz"],
     "createDate": "2026-08-28",
-    "lastModifyDate": "2026-08-28",
+    "lastModifyDate": "2026-09-06",
     "importPlugin": {
       "plugin": "qlcplus_4.12.1",
       "date": "2026-08-28",
       "comment": "created by Q Light Controller Plus (version 4.13.0)"
     }
   },
+  "links": {
+    "manual": [
+      "https://drive.google.com/file/d/1uMpShfMAUMFvymKPGpqtAn3REG90t5Ad/view"
+    ],
+    "productPage": [
+      "https://shehds.com/products/2pcs-lot-led-par-can-18x12w-rgbw-4in1-led-flat-par-dmx512-for-discos-music-stage-effect-disco-lamp-stage-light"
+    ],
+    "video": [
+      "https://www.youtube.com/watch?v=S4MggzefVw8"
+    ]
+  },
   "physical": {
-    "dimensions": [200, 200, 100],
-    "weight": 1.5,
+    "dimensions": [200, 265, 115],
+    "weight": 3.15,
     "power": 216,
     "DMXconnector": "3-pin",
     "bulb": {


### PR DESCRIPTION
AI-generated contribution. I am the human operator responsible for follow-up with maintainers. Please feel free to close this PR or request any changes.

Updates `shehds/18x12w-rgbw-par` based on the maintainer-requested review findings:

- corrects the physical dimensions to OFL's width / height / depth order (`200 × 265 × 115 mm`)
- corrects the fixture weight to `3.15 kg`
- adds the official SHEHDS product page
- adds the official SHEHDS manual file
- adds the product video embedded on the official SHEHDS product page
- updates `lastModifyDate`

I also re-checked the current official product data against the fixture definition. The documented 216 W power, 4/8-channel modes, and 0–10 Hz strobe specification remain consistent with the existing definition.

Validation performed locally:
- JSON parses successfully
- targeted fixture invariants pass
- `git diff --check` passes

I intentionally left the existing DMX capability ranges unchanged where the manual does not provide enough detail to improve them confidently.