### PR TITLE
Fix RockPAR50 fixture links

### DIFF
--- a/fixtures/rockville/rockpar50.json
+++ b/fixtures/rockville/rockpar50.json
@@ -6,11 +6,14 @@
   "meta": {
     "authors": ["Jeff Kowalik"],
     "createDate": "2019-05-03",
-    "lastModifyDate": "2019-05-03"
+    "lastModifyDate": "2026-09-08"
   },
   "links": {
+    "manual": [
+      "https://rockvilleaudio.com/cdn/shop/files/RockPAR50_Manual_OLR.pdf?v=17546616375341130832"
+    ],
     "productPage": [
-      "https://www.rockvilleaudio.com/rockpar50/"
+      "https://rockvilleaudio.com/products/rockpar50-black"
     ],
     "video": [
       "https://www.youtube.com/watch?v=E4kI6QuNiMg"

--- a/fixtures/rockville/rockpar50.json
+++ b/fixtures/rockville/rockpar50.json
@@ -6,7 +6,7 @@
   "meta": {
     "authors": ["Jeff Kowalik"],
     "createDate": "2019-05-03",
-    "lastModifyDate": "2026-09-08"
+    "lastModifyDate": "2019-05-03"
   },
   "links": {
     "manual": [


### PR DESCRIPTION
**AI-generated PR; managed by a human.**

### AI proof review

| Check | Evidence | Result |
|---|---|---|
| Fixture identity | OFL, Rockville product page, and Rockville manual all identify `RockPAR50` | **PASS** |
| Manual link | First-party Rockville PDF returns 200 and its cover says `RockPAR50` | **PASS** |
| Product link | Old `/rockpar50/` URL resolves to the current `/products/rockpar50-black` page, which identifies `RockPAR50` | **PASS** |
| Diff scope | One fixture JSON; link changes only | **PASS** |

This adds Rockville's current first-party RockPAR50 owner's manual and replaces the old product URL with its current canonical first-party page. No fixture, DMX, physical, UI, or `lastModifyDate` data changes.

### Quick review

Only three correspondence checks are needed:
1. Does the OFL fixture name match the current Rockville product page?
2. Does the actual Rockville manual identify the same fixture?
3. Does the diff only add/replace those links?

The screenshots below are direct captures/renders of the first-party sources and are hosted from the contributor fork so the upstream diff stays fixture-only.

| Current Rockville product page | Current Rockville owner's manual |
|---|---|
| <img src="https://raw.githubusercontent.com/keeltrace/open-fixture-library/220529a87eabd7dd40e7edb46fa75f937a884079/.keeltrace-evidence/rockpar50/product-page-identity.png" width="380"> | <img src="https://raw.githubusercontent.com/keeltrace/open-fixture-library/220529a87eabd7dd40e7edb46fa75f937a884079/.keeltrace-evidence/rockpar50/manual-identity.png" width="300"> |

First-party sources:
- Product: https://rockvilleaudio.com/products/rockpar50-black
- Manual: https://rockvilleaudio.com/cdn/shop/files/RockPAR50_Manual_OLR.pdf?v=17546616375341130832

```diff
+    "manual": [
+      "https://rockvilleaudio.com/cdn/shop/files/RockPAR50_Manual_OLR.pdf?v=17546616375341130832"
+    ],
     "productPage": [
-      "https://www.rockvilleaudio.com/rockpar50/"
+      "https://rockvilleaudio.com/products/rockpar50-black"
     ],
```

**OFL `RockPAR50` = product page `RockPAR50` = manual `RockPAR50` — PASS**

### Why include the proof?

The goal is to make AI-assisted janitorial work cheaper to review: **comparison rather than investigation**. The relevant first-party evidence is carried with the change instead of asking maintainers to repeat the research.

Please feel free to close or request changes. If this proof-carrying format creates more overhead than it saves, I won't keep using it.

Related maintenance work: #578 and #999.

— Keeltrace handler