### PR TITLE
Fix stale Steinigke fixture links

### DIFF
--- a/fixtures/eurolite/led-par-56-tcl.json
+++ b/fixtures/eurolite/led-par-56-tcl.json
@@ -10,7 +10,7 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/documents_t/51913611-MANUAL-1.00-de-en_00066247.pdf"
+      "https://www.steinigke.de/download/51913610-Manual-66247-1.00-eurolite-led-par-56-tcl-9x3w-short-sil-de_en.pdf"
     ],
     "productPage": [
       "https://www.steinigke.de/en/mpn51913611-eurolite-led-par-56-tcl-9x3w-short-black.html"

--- a/fixtures/eurolite/led-ps-4-hcl.json
+++ b/fixtures/eurolite/led-ps-4-hcl.json
@@ -10,7 +10,7 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/download_t/51913503-MANUAL-1.10-de-en_00096357.pdf"
+      "https://www.steinigke.de/download/51913503-Manual-96357-1.100-eurolite-led-ps-4-hcl-spot-en_de.pdf"
     ],
     "productPage": [
       "https://www.steinigke.de/en/mpn51913503-eurolite-led-ps-4-hcl-spot.html"

--- a/fixtures/eurolite/led-svf-1.json
+++ b/fixtures/eurolite/led-svf-1.json
@@ -10,10 +10,10 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/documents_t/51918662-MANUAL-1.10-de-en_00073902.pdf"
+      "https://www.steinigke.de/download/51918662-Manual-73902-1.100-eurolite-led-svf-1-flower-effect-de_en.pdf"
     ],
     "productPage": [
-      "https://www.steinigke.de/download/51918662-Manual-73902-1.100-eurolite-led-svf-1-flower-effect-de_en.pdf"
+      "https://www.steinigke.com/mpn51918662-eurolite-led-svf-1-flower-effect.html"
     ],
     "video": [
       "https://www.youtube.com/watch?v=fg8kl3vCfD4",

--- a/fixtures/eurolite/led-tmh-18.json
+++ b/fixtures/eurolite/led-tmh-18.json
@@ -10,7 +10,7 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/documents_t/51786060-MANUAL-1.00-de-en_00095278.pdf"
+      "https://www.steinigke.de/download/51786060-Manual-95278-1.000-eurolite-led-tmh-18-moving-head-beam-de_en.pdf"
     ],
     "productPage": [
       "https://www.steinigke.de/en/mpn51786060-eurolite-led-tmh-18-moving-head-beam.html"

--- a/fixtures/eurolite/led-tmh-7.json
+++ b/fixtures/eurolite/led-tmh-7.json
@@ -9,7 +9,7 @@
   },
   "links": {
     "manual": [
-      "https://www.steinigke.de/download/51785973-Anleitung-93407-2.100-eurolite-led-tmh-7-moving-head-wash-de_en.pdf"
+      "https://www.steinigke.de/download/51785973-Anleitung-93407-2.1000-eurolite-led-tmh-7-moving-head-wash-de_en.pdf"
     ],
     "productPage": [
       "https://www.steinigke.de/en/mpn51785973-eurolite-led-tmh-7-moving-head-wash.html"

--- a/fixtures/eurolite/led-tmh-7.json
+++ b/fixtures/eurolite/led-tmh-7.json
@@ -9,7 +9,7 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/documents_t/51785973-MANUAL-2.10-en-de_00093407.pdf"
+      "https://www.steinigke.de/download/51785973-Anleitung-93407-2.100-eurolite-led-tmh-7-moving-head-wash-de_en.pdf"
     ],
     "productPage": [
       "https://www.steinigke.de/en/mpn51785973-eurolite-led-tmh-7-moving-head-wash.html"

--- a/fixtures/eurolite/led-tmh-9.json
+++ b/fixtures/eurolite/led-tmh-9.json
@@ -10,7 +10,7 @@
   },
   "links": {
     "manual": [
-      "https://www.steinigke.de/download/51785964-Anleitung-96748-1.10-eurolite-led-tmh-9-moving-head-wash-de_en.pdf"
+      "https://www.steinigke.de/download/51785964-Anleitung-96748-1.1000-eurolite-led-tmh-9-moving-head-wash-de_en.pdf"
     ],
     "productPage": [
       "https://www.steinigke.de/en/mpn51785964-eurolite-led-tmh-9-moving-head-wash.html"

--- a/fixtures/eurolite/led-tmh-9.json
+++ b/fixtures/eurolite/led-tmh-9.json
@@ -10,7 +10,7 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/documents_t/51785964-MANUAL-1.10-de-en_00096748.pdf"
+      "https://www.steinigke.de/download/51785964-Anleitung-96748-1.10-eurolite-led-tmh-9-moving-head-wash-de_en.pdf"
     ],
     "productPage": [
       "https://www.steinigke.de/en/mpn51785964-eurolite-led-tmh-9-moving-head-wash.html"

--- a/fixtures/eurolite/led-tmh-x25.json
+++ b/fixtures/eurolite/led-tmh-x25.json
@@ -10,7 +10,7 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/documents_t/51785991-MANUAL-1.10-de-en_00094116.pdf"
+      "https://www.steinigke.de/download/51785991-Anleitung-94116-1.1000-eurolite-led-tmh-x25-moving-head-de_en.pdf"
     ],
     "productPage": [
       "https://www.steinigke.de/en/mpn51785991-eurolite-led-tmh-x25-moving-head.html"

--- a/fixtures/futurelight/dmh-75-i-led-moving-head.json
+++ b/fixtures/futurelight/dmh-75-i-led-moving-head.json
@@ -10,7 +10,7 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/documents_t/51841840-MANUAL-1.10-de-en_00087817.pdf"
+      "https://www.steinigke.de/download/51841840-Manual-87817-1.100-futurelight-dmh-75i-led-spot-de_en.pdf"
     ],
     "video": [
       "https://www.youtube.com/watch?v=oMMej19YziM"

--- a/fixtures/futurelight/pro-slim-par-7-hcl.json
+++ b/fixtures/futurelight/pro-slim-par-7-hcl.json
@@ -10,7 +10,7 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/documents_t/51842547-MANUAL-1.10-de-en_00094623.pdf"
+      "https://www.steinigke.de/download/51842547-Manual-94623-1.10-futurelight-pro-slim-par-7-hcl-de_en.pdf"
     ],
     "video": [
       "https://www.youtube.com/watch?v=Aql4Q-Rqs_g",

--- a/fixtures/futurelight/stb-648-led-strobe-smd-5050.json
+++ b/fixtures/futurelight/stb-648-led-strobe-smd-5050.json
@@ -9,7 +9,7 @@
   },
   "links": {
     "manual": [
-      "https://media.steinigke.de/documents_t/51841370-MANUAL-1.00-de-en_00068855.pdf"
+      "https://www.steinigke.de/download/51841370-Manual-68855-1.00-futurelight-stb-648-led-strobe-smd-5050-de_en.pdf"
     ],
     "video": [
       "https://www.youtube.com/watch?v=M_syNbUd4iY"


### PR DESCRIPTION
**AI-generated PR; managed by a human.**

### AI proof review

| Fixture | First-party source | Result |
|---|---|---|
| LED TMH-18 | [manual](https://www.steinigke.de/download/51786060-Manual-95278-1.000-eurolite-led-tmh-18-moving-head-beam-de_en.pdf) | model + article match |
| LED TMH-7 | [manual](https://www.steinigke.de/download/51785973-Anleitung-93407-2.1000-eurolite-led-tmh-7-moving-head-wash-de_en.pdf) | model + article match |
| LED PS-4 HCL | [manual](https://www.steinigke.de/download/51913503-Manual-96357-1.100-eurolite-led-ps-4-hcl-spot-en_de.pdf) | model + article match |
| LED TMH-9 | [manual](https://www.steinigke.de/download/51785964-Anleitung-96748-1.1000-eurolite-led-tmh-9-moving-head-wash-de_en.pdf) | model + article match |
| LED TMH-X25 | [manual](https://www.steinigke.de/download/51785991-Anleitung-94116-1.1000-eurolite-led-tmh-x25-moving-head-de_en.pdf) | model + article match |
| DMH-75.i | [manual](https://www.steinigke.de/download/51841840-Manual-87817-1.100-futurelight-dmh-75i-led-spot-de_en.pdf) | model + article match |
| PRO Slim PAR-7 HCL | [manual](https://www.steinigke.de/download/51842547-Manual-94623-1.10-futurelight-pro-slim-par-7-hcl-de_en.pdf) | model + article match |
| STB-648 LED Strobe SMD 5050 | [manual](https://www.steinigke.de/download/51841370-Manual-68855-1.00-futurelight-stb-648-led-strobe-smd-5050-de_en.pdf) | model + article match |
| LED PAR-56 TCL | [manual](https://www.steinigke.de/download/51913610-Manual-66247-1.00-eurolite-led-par-56-tcl-9x3w-short-sil-de_en.pdf) | model + article `51913611` included |
| LED SVF-1 | [manual](https://www.steinigke.de/download/51918662-Manual-73902-1.100-eurolite-led-svf-1-flower-effect-de_en.pdf) · [product](https://www.steinigke.com/mpn51918662-eurolite-led-svf-1-flower-effect.html) | model + article match |

Expanded as requested to cover the fixable Steinigke entries in #999. This is link-only fixture maintenance: 10 fixtures, 11 link-field edits, no DMX/physical data or `lastModifyDate` changes. The SVF-1 fixture already had its current manual misclassified as `productPage`; that is corrected here as part of the same link cleanup.

I left **LED SLS-6 UV Floor** unchanged: its current manufacturer manual identifies article `51915282`, but later contains an equipment-label illustration for `51915358`, so I could not prove that replacement cleanly enough to include it. The TMH-7, TMH-9, and TMH-X25 URLs are the current first-party links already identified by Flo in #6030.

Verification:
- all retained replacement links return HTTP 200 and the PDFs were checked for model/article identity;
- `npm run build:register` passed;
- all 10 changed fixtures pass `node tests/fixtures-valid.js <fixture>`;
- `git diff --check` passed.

Related: #999
