### PR TITLE
Fix grayed out capability switch to channel row

### DIFF
--- a/ui/components/fixture-page/FixturePageCapabilityTable.vue
+++ b/ui/components/fixture-page/FixturePageCapabilityTable.vue
@@ -39,7 +39,8 @@
         <tr
           v-for="switchChannel of cap.switchChannels"
           :key="`cap-${index}-switch-${switchChannel.key}`"
-          class="switch-to-channel">
+          class="switch-to-channel"
+          :data-capability-type="cap.model.type">
           <td colspan="4" />
           <td colspan="2">
             <span class="switching-channel-key">Channel&nbsp;{{ switchChannel.index + 1 }} →</span>&nbsp;{{ switchChannel.to }}
@@ -81,7 +82,7 @@ th {
 }
 
 .capability[data-capability-type="NoFunction"],
-.capability[data-capability-type="NoFunction"] + .switch-to-channel {
+.switch-to-channel[data-capability-type="NoFunction"] {
   opacity: 0.6;
 }
 


### PR DESCRIPTION
e.g. https://open-fixture-library.org/stairville/octagon-theater-20x6w-cw-ww-a:

<table>
<tr>
 <th>Before
 <th>After
<tr>
 <td><img width="455" height="251" alt="grafik" src="https://github.com/user-attachments/assets/2344f32d-0d0a-4d9a-8007-7965577f0d02" />
 <td><img width="455" height="251" alt="grafik" src="https://github.com/user-attachments/assets/f3d5d510-b3ad-4d41-beca-ce6c0a246bc3" />
</table>