### PR TITLE
Consolidate and fix invalid-field scroll logic in editor

### DIFF
--- a/ui/assets/scripts/editor-utilities.js
+++ b/ui/assets/scripts/editor-utilities.js
@@ -1,3 +1,4 @@
+import scrollIntoView from 'scroll-into-view';
 import { v4 as uuidv4 } from 'uuid';
 
 export const constants = {
@@ -12,6 +13,43 @@ export const constants = {
  */
 export function getEmptyFormState() {
   return {};
+}
+
+/**
+ * Opens all `<details>` ancestors of currently invalid fields in the given container (so they
+ * become visible), then scrolls to and focuses the first invalid field.
+ * @param {Document|Element} [container] - The DOM element to search within; defaults to the whole page.
+ */
+export function scrollToFirstInvalidField(container = document) {
+  const invalidFields = [...container.querySelectorAll('.vf-invalid')];
+
+  if (invalidFields.length === 0) {
+    return;
+  }
+
+  for (let index = 0; index < invalidFields.length; index++) {
+    const enclosingDetails = invalidFields[index].closest('details:not([open])');
+
+    if (enclosingDetails) {
+      enclosingDetails.open = true;
+
+      // current field could be enclosed another time, so repeat
+      index--;
+    }
+  }
+
+  const firstField = invalidFields[0];
+  const firstFieldInput = firstField.parentElement.querySelector('input, select, textarea') ?? firstField;
+  const scrollContainer = firstField.closest('.dialog') ?? window;
+  scrollIntoView(firstField, {
+    time: 300,
+    align: {
+      top: 0,
+      left: 0,
+      topOffset: 100,
+    },
+    isScrollable: (target) => target === scrollContainer,
+  }, () => firstFieldInput.focus());
 }
 
 /**

--- a/ui/components/editor/EditorChannelDialog.vue
+++ b/ui/components/editor/EditorChannelDialog.vue
@@ -319,6 +319,7 @@ import {
   getSanitizedChannel,
   isCapabilityChanged,
   isChannelChanged,
+  scrollToFirstInvalidField,
 } from '../../assets/scripts/editor-utilities.js';
 import A11yDialog from '../A11yDialog.vue';
 import LabeledInput from '../LabeledInput.vue';
@@ -682,30 +683,7 @@ export default {
       }
 
       if (this.formstate.$invalid) {
-        const invalidFields = document.querySelectorAll('#channel-dialog .vf-field-invalid');
-
-        for (let index = 0; index < invalidFields.length; index++) {
-          const enclosingDetails = invalidFields[index].closest('details:not([open])');
-
-          if (enclosingDetails) {
-            enclosingDetails.open = true;
-
-            // current field could be enclosed another time, so repeat
-            index--;
-          }
-        }
-
-        const scrollContainer = invalidFields[0].closest('.dialog');
-        scrollIntoView(invalidFields[0], {
-          time: 300,
-          align: {
-            top: 0,
-            left: 0,
-            topOffset: 100,
-          },
-          isScrollable: (target) => target === scrollContainer,
-        }, () => invalidFields[0].focus());
-
+        scrollToFirstInvalidField(this.$el);
         return;
       }
 

--- a/ui/pages/fixture-editor.vue
+++ b/ui/pages/fixture-editor.vue
@@ -126,7 +126,6 @@ noscript.card {
 </style>
 
 <script>
-import scrollIntoView from 'scroll-into-view';
 import { schemaDefinitions } from '../../lib/schema-properties.js';
 import {
   constants,
@@ -134,6 +133,7 @@ import {
   getEmptyFixture,
   getEmptyFormState,
   getEmptyMode,
+  scrollToFirstInvalidField,
 } from '../assets/scripts/editor-utilities.js';
 import EditorChannelDialog from '../components/editor/EditorChannelDialog.vue';
 import EditorChooseChannelEditModeDialog from '../components/editor/EditorChooseChannelEditModeDialog.vue';
@@ -387,18 +387,7 @@ export default {
 
     onSubmit() {
       if (this.formstate.$invalid) {
-        const field = document.querySelector('.vf-field-invalid');
-
-        scrollIntoView(field, {
-          time: 300,
-          align: {
-            top: 0,
-            left: 0,
-            topOffset: 100,
-          },
-          isScrollable: (target) => target === window,
-        }, () => field.focus());
-
+        scrollToFirstInvalidField();
         return;
       }
 

--- a/ui/pages/import-fixture-file.vue
+++ b/ui/pages/import-fixture-file.vue
@@ -105,8 +105,7 @@
 </template>
 
 <script>
-import scrollIntoView from 'scroll-into-view';
-import { getEmptyFormState } from '../assets/scripts/editor-utilities.js';
+import { getEmptyFormState, scrollToFirstInvalidField } from '../assets/scripts/editor-utilities.js';
 import EditorFileUpload from '../components/editor/EditorFileUpload.vue';
 import EditorSubmitDialog from '../components/editor/EditorSubmitDialog.vue';
 import LabeledInput from '../components/LabeledInput.vue';
@@ -157,18 +156,7 @@ export default {
   methods: {
     async onSubmit() {
       if (this.formstate.$invalid) {
-        const field = document.querySelector('.vf-field-invalid');
-
-        scrollIntoView(field, {
-          time: 300,
-          align: {
-            top: 0,
-            left: 0,
-            topOffset: 100,
-          },
-          isScrollable: (target) => target === window,
-        }, () => field.focus());
-
+        scrollToFirstInvalidField();
         return;
       }
 


### PR DESCRIPTION
`.vf-field-invalid` targetted the root element of composite input fields (e.g. `span.range`) instead of the first real focusable form field. → Replaced with more elaborate logic.

Also, the similar logic between the channel dialog and the editor/import pages has now been consolidated in one function.