### PR TITLE
Disallow adding fixtures with generic manufacturer via editor

### DIFF
--- a/ui/pages/fixture-editor.vue
+++ b/ui/pages/fixture-editor.vue
@@ -163,6 +163,7 @@ export default {
     let manufacturers;
     try {
       manufacturers = await $axios.$get('/api/v1/manufacturers');
+      delete manufacturers.generic;
     }
     catch (requestError) {
       return error(requestError);


### PR DESCRIPTION
Basically all `generic` fixture contributions are some kind of Chinese brand which are hard to find online and thus add little value to OFL. Making it a _little_ harder to add these is probably a good thing. In case there is actually a manufacturer website etc., that should be added properly.

In case someone _really_ wants to contribute a real `generic` fixture: It's still possible via a PR on GitHub, or just select a different manufacturer and write something in the comment, or add a new manufacturer that happens to be called "Generic" :wink: 

FYI @kengruven @luc122c