### PR TITLE
Add AGLight export test, remove AGLight color name → hex mapping

### DIFF
--- a/plugins/aglight/export.js
+++ b/plugins/aglight/export.js
@@ -11,9 +11,6 @@ import replaceNullSwitchChannels from '../../lib/plugin-downgrade-helpers/replac
 const units = new Set(['K', 'deg', '%', 'ms', 'Hz', 'm^3/min', 'rpm']);
 const excludeKeys = new Set(['comment', 'name', 'helpWanted', 'type', 'effectName', 'effectPreset', 'shutterEffect', 'wheel', 'isShaking', 'fogType', 'menuClick']);
 
-// see https://github.com/OpenLightingProject/open-fixture-library/issues/4415
-const colorNameListPromise = importJson('../../node_modules/color-name-list/dist/colornames.json', import.meta.url);
-
 export const version = '1.0.1';
 
 /**
@@ -27,16 +24,13 @@ export const version = '1.0.1';
 export async function exportFixtures(fixtures, options) {
   const displayedPluginVersion = options.displayedPluginVersion || version;
 
-  const [manufacturers, namedColors] = await Promise.all([
-    importJson('../../fixtures/manufacturers.json', import.meta.url),
-    colorNameListPromise,
-  ]);
+  const manufacturers = await importJson('../../fixtures/manufacturers.json', import.meta.url);
 
   const library = {
     version: displayedPluginVersion,
     fixtures: fixtures.map((fixture) => {
       try {
-        return exportFixture(fixture, manufacturers, namedColors);
+        return exportFixture(fixture, manufacturers);
       }
       catch (error) {
         throw new Error(`Exporting fixture ${fixture.manufacturer.key}/${fixture.key} failed: ${error}`, {
@@ -56,10 +50,9 @@ export async function exportFixtures(fixtures, options) {
 /**
  * @param {Fixture} fixture - The fixture to export.
  * @param {object} manufacturers - The manufacturers object.
- * @param {object[]} namedColors - The color names list.
  * @returns {object} The generated fixture JSON.
  */
-function exportFixture(fixture, manufacturers, namedColors) {
+function exportFixture(fixture, manufacturers) {
   const jsonData = structuredClone(fixture.jsonObject);
   jsonData.fixtureKey = fixture.key;
   jsonData.manufacturer = manufacturers[fixture.manufacturer.key];
@@ -71,7 +64,7 @@ function exportFixture(fixture, manufacturers, namedColors) {
   transformMatrixChannels(jsonData, fixture);
   replaceNullSwitchChannels(jsonData, fixture);
   transformSingleCapabilityToArray(jsonData);
-  transformNonNumericValues(jsonData, namedColors);
+  transformNonNumericValues(jsonData);
 
   for (const mode of jsonData.modes) {
     downgradePhysical(mode.physical);
@@ -141,41 +134,21 @@ function transformSingleCapabilityToArray(fixtureJson) {
 }
 
 /**
- * Replace capability properties' entity strings with unitless numbers,
- * Burst shutter effect with Strobe, and
- * ColorIntensity capabilities' color property with its hex value.
+ * Replace capability properties' entity strings with unitless numbers, and
+ * Burst shutter effect with Strobe.
  * @param {object} fixtureJson - The fixture whose capabilities should be processed
- * @param {object[]} namedColors - The color names list.
  */
-function transformNonNumericValues(fixtureJson, namedColors) {
+function transformNonNumericValues(fixtureJson) {
   for (const channel of Object.values(fixtureJson.availableChannels)) {
     for (const capability of channel.capabilities) {
       downgradeShutterEffect(capability);
 
       for (const [key, value] of Object.entries(capability)) {
-        if (key === 'color') {
-          processColor(capability, namedColors);
-        }
-        else if (typeof value === 'string' && !excludeKeys.has(key)) {
+        if (typeof value === 'string' && !excludeKeys.has(key)) {
           capability[key] = getEntityNumber(value);
         }
       }
     }
-  }
-}
-
-/**
- * @param {object} capability - The capability where the color name in the color attribute should be replaced with its hex value
- * @param {object[]} namedColors - The color names list.
- */
-function processColor(capability, namedColors) {
-  const namedColor = namedColors.find((color) => color.name === capability.color);
-  if (namedColor && namedColor.hex) {
-    capability.color = namedColor.hex;
-  }
-  else {
-    // If the color was not found, just ignore it
-    // console.log(`#### color not found`, capability.color);
   }
 }
 

--- a/plugins/aglight/export.js
+++ b/plugins/aglight/export.js
@@ -11,7 +11,7 @@ import replaceNullSwitchChannels from '../../lib/plugin-downgrade-helpers/replac
 const units = new Set(['K', 'deg', '%', 'ms', 'Hz', 'm^3/min', 'rpm']);
 const excludeKeys = new Set(['comment', 'name', 'helpWanted', 'type', 'effectName', 'effectPreset', 'shutterEffect', 'wheel', 'isShaking', 'fogType', 'menuClick']);
 
-export const version = '1.0.1';
+export const version = '1.0.2';
 
 /**
  * @param {Fixture[]} fixtures - An array of Fixture objects.

--- a/plugins/aglight/exportTests/json-schema-conformity.js
+++ b/plugins/aglight/exportTests/json-schema-conformity.js
@@ -71,7 +71,7 @@ async function getSchemas() {
   fixtureSchema.properties.oflURL = true;
 
   // AGLight resolves template channels and marks their source pixel
-  fixtureSchema.properties.templateChannels = undefined;
+  delete fixtureSchema.properties.templateChannels;
   fixtureSchema.dependencies = undefined;
   channelSchema.properties.pixelKey = true;
 

--- a/plugins/aglight/exportTests/json-schema-conformity.js
+++ b/plugins/aglight/exportTests/json-schema-conformity.js
@@ -1,0 +1,121 @@
+import https from 'https';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import getAjvErrorMessages from '../../../lib/get-ajv-error-messages.js';
+
+const BASE_OFL_SCHEMA_VERSION = '12.2.1';
+const REPO_BASE_URL = 'https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library';
+const SCHEMA_BASE_URL = `${REPO_BASE_URL}/schema-${BASE_OFL_SCHEMA_VERSION}/schemas/`;
+
+const SCHEMA_FILES = [
+  'capability.json',
+  'channel.json',
+  'definitions.json',
+  'fixture.json',
+  'gobo.json',
+  'matrix.json',
+  'wheel-slot.json',
+];
+
+const schemas = await getSchemas();
+
+/**
+ * @typedef {object} ExportFile
+ * @property {string} name File name, may include slashes to provide a folder structure.
+ * @property {string} content File content.
+ * @property {string} mimetype File mime type.
+ * @property {Fixture[] | null} fixtures Fixture objects that are described in given file; may be omitted if the file doesn't belong to any fixture (e.g. manufacturer information).
+ * @property {string | null} mode Mode's shortName if given file only describes a single mode.
+ */
+
+/**
+ * @param {ExportFile} exportFile - The file returned by the plugins' export module.
+ * @param {ExportFile[]} allExportFiles - An array of all export files.
+ * @returns {Promise<void, string[] | string>} Resolve when the test passes or reject with an array of errors or one error if the test fails.
+ */
+export default async function testJsonSchemaConformity(exportFile, allExportFiles) {
+  const ajv = new Ajv({
+    schemas,
+    strict: false,
+    verbose: true,
+  });
+  addFormats(ajv);
+  ajv.addFormat('color-hex', true);
+
+  const schemaValidate = ajv.getSchema(`${REPO_BASE_URL}/master/schemas/fixture.json`);
+
+  const fixtures = JSON.parse(exportFile.content).fixtures;
+  for (const fixture of fixtures) {
+    const schemaValid = schemaValidate(fixture);
+    if (!schemaValid) {
+      throw getAjvErrorMessages(schemaValidate.errors, 'fixture');
+    }
+  }
+}
+
+/**
+ * @returns {Promise<object[]>} The supported OFL schemas, adjusted for AGLight's export format.
+ */
+async function getSchemas() {
+  const schemasJson = await Promise.all(SCHEMA_FILES.map(
+    (filename) => downloadSchema(SCHEMA_BASE_URL + filename),
+  ));
+
+  const channelSchema = schemasJson[SCHEMA_FILES.indexOf('channel.json')];
+  const definitionsSchema = schemasJson[SCHEMA_FILES.indexOf('definitions.json')];
+  const fixtureSchema = schemasJson[SCHEMA_FILES.indexOf('fixture.json')];
+
+  // Allow AGLight's fixture-identifying fields and embedded manufacturer data
+  fixtureSchema.properties.fixtureKey = true;
+  fixtureSchema.properties.manufacturer = true;
+  fixtureSchema.properties.oflURL = true;
+
+  // AGLight resolves template channels and marks their source pixel
+  fixtureSchema.properties.templateChannels = undefined;
+  fixtureSchema.dependencies = undefined;
+  channelSchema.properties.pixelKey = true;
+
+  // AGLight represents single-capability channels as one-item capability arrays
+  channelSchema.properties.singleCapability = { const: true };
+  channelSchema.properties.capabilities.minItems = 1;
+  channelSchema.properties.capabilities.items.required = undefined;
+  channelSchema.oneOf = undefined;
+  channelSchema.required = ['capabilities'];
+
+  // AGLight embeds resolved gobo resource objects instead of resource strings
+  definitionsSchema.goboResourceString = { type: 'object' };
+
+  // AGLight turns supported entity strings into unitless numeric values.
+  for (const [entityName, entitySchema] of Object.entries(definitionsSchema.entities)) {
+    definitionsSchema.entities[entityName] = {
+      anyOf: [
+        entitySchema,
+        { type: 'number' },
+      ],
+    };
+  }
+
+  return schemasJson;
+}
+
+/**
+ * @param {string} url - The schema URL to download.
+ * @returns {Promise<object>} The downloaded and JSON parsed schema.
+ */
+function downloadSchema(url) {
+  return new Promise((resolve, reject) => {
+    const request = https.get(url, (response) => {
+      if (response.statusCode < 200 || response.statusCode > 299) {
+        reject(new Error(`Failed to load page, status code: ${response.statusCode}`));
+      }
+
+      let body = '';
+      response.on('data', (chunk) => {
+        body += chunk;
+      });
+      response.on('end', () => resolve(JSON.parse(body)));
+    });
+
+    request.on('error', (error) => reject(error));
+  });
+}

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -21,7 +21,9 @@
     "aglight": {
       "name": "AGLight",
       "exportPluginVersion": "1.0.1",
-      "exportTests": []
+      "exportTests": [
+        "json-schema-conformity"
+      ]
     },
     "color-chief": {
       "name": "Eurolite Color Chief 2.0",

--- a/plugins/plugins.json
+++ b/plugins/plugins.json
@@ -20,7 +20,7 @@
   "data": {
     "aglight": {
       "name": "AGLight",
-      "exportPluginVersion": "1.0.1",
+      "exportPluginVersion": "1.0.2",
       "exportTests": [
         "json-schema-conformity"
       ]


### PR DESCRIPTION
The [AGLight](https://github.com/hrueger/AGLight) format is based on the [v12.2.1 OFL schemas](https://github.com/OpenLightingProject/open-fixture-library/tree/schema-12.2.1/schemas), assuming it was using the newest version available (https://github.com/OpenLightingProject/open-fixture-library/releases/tag/schema-12.2.1, 2020-04-03) back when it was added (#1357, 2020-07-12). There are a few modifications in the plugin vs. the raw OFL schema:

1. `fixtureKey`, `manufacturerKey` and `oflUrl` properties are added
2. Template channels are resolved and marked wih `pixelKey`
3. Single-capability channels still get an `capabilities` array, but without `dmxRange` and instead `singleCapability: true`
4. Gobo resources are resolved
5. Entity strings are turned into unitless numbers
6. `ColorIntensity` capabilities' `color` property (`Red`, `Green`, `Blue`, etc.) is replaced with a hex color representation (`#ff0000`, `#00ff00`, `#0000ff`, etc.)

However, that last point doesn't seem to be needed based on the AGLight source code: https://github.com/hrueger/AGLight/blob/master/src/app/_entities/product.ts#L89

@hrueger can you please tell me whether I misread AGLight's source code?

If it should still be needed, I'll need to revert [`305b326`](https://github.com/OpenLightingProject/open-fixture-library/pull/6111/commits/305b326bb3212f0fe5509d92f3585016f65fb3d5) and [`167b2bf`](https://github.com/OpenLightingProject/open-fixture-library/pull/6111/commits/167b2bf9d8b9abeee2eec92205ba7e7b8c41b8c4) and add support for that in the export test schema. Otherwise, this is ready to go.