### PR TITLE
Add fixture `prova/beam-280`

### DIFF
--- a/fixtures/manufacturers.json
+++ b/fixtures/manufacturers.json
@@ -415,6 +415,10 @@
     "website": "https://prolights.it/",
     "rdmId": 5584
   },
+  "prova": {
+    "name": "prova",
+    "rdmId": 0
+  },
   "qtx": {
     "name": "QTX",
     "website": "https://www.avsl.com/brands/qtx"

--- a/fixtures/prova/beam-280.json
+++ b/fixtures/prova/beam-280.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenLightingProject/open-fixture-library/master/schemas/fixture.json",
+  "name": "beam 280",
+  "categories": ["Moving Head"],
+  "meta": {
+    "authors": ["sameer"],
+    "createDate": "2026-09-12",
+    "lastModifyDate": "2026-09-12"
+  },
+  "links": {
+    "video": [
+      "https://www.youtube.com/watch?v=z6Wr2fl6Xfc"
+    ]
+  },
+  "wheels": {
+    "Color Wheel": {
+      "slots": [
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        },
+        {
+          "type": "Color"
+        }
+      ]
+    }
+  },
+  "availableChannels": {
+    "Color Wheel": {
+      "capability": {
+        "type": "WheelSlot",
+        "slotNumber": 0.5
+      }
+    }
+  },
+  "modes": [
+    {
+      "name": "CH 1",
+      "channels": [
+        "Color Wheel"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
* Update manufacturers.json
* Add fixture `prova/beam-280`

### Fixture warnings / errors

* prova/beam-280
  - ❌ Category 'Moving Head' invalid since there are not both pan and tilt channels.
  - ⚠️ Unused wheel slot(s): Color Wheel (slot 2), Color Wheel (slot 3), Color Wheel (slot 4), Color Wheel (slot 5), Color Wheel (slot 6), Color Wheel (slot 7), Color Wheel (slot 8), Color Wheel (slot 9), Color Wheel (slot 10), Color Wheel (slot 11), Color Wheel (slot 12), Color Wheel (slot 13), Color Wheel (slot 14), Color Wheel (slot 15), Color Wheel (slot 16), Color Wheel (slot 17), Color Wheel (slot 18), Color Wheel (slot 19), Color Wheel (slot 20), Color Wheel (slot 21), Color Wheel (slot 22), Color Wheel (slot 23), Color Wheel (slot 24), Color Wheel (slot 25), Color Wheel (slot 26), Color Wheel (slot 27), Color Wheel (slot 28), Color Wheel (slot 29), Color Wheel (slot 30), Color Wheel (slot 31)
  - ⚠️ Category 'Color Changer' suggested since there are ColorPreset or ColorIntensity capabilities or Color wheel slots.


Thank you **sameer**!